### PR TITLE
Add GATT Peripheral example for Pico W

### DIFF
--- a/pico-w-ble-peripheral-sdk/BTStack/Error.swift
+++ b/pico-w-ble-peripheral-sdk/BTStack/Error.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// BTstack Error Code
+public struct BTStackError: Error, RawRepresentable, Equatable, Hashable, Sendable {
+    
+    public let rawValue: Int32
+    
+    public init(rawValue: Int32) {
+        self.rawValue = rawValue
+    }
+}
+
+public extension BTStackError {
+    
+    init(_ hci: HCIError) {
+        self.init(rawValue: Int32(hci.rawValue))
+    }
+}
+
+public extension HCIError {
+    
+    init?(_ error: BTStackError) {
+        guard error.rawValue <= UInt8.max else {
+            return nil
+        }
+        self.init(rawValue: UInt8(error.rawValue))
+    }
+}
+
+internal extension CInt {
+    
+    func throwsError() throws(BTStackError) {
+        guard self == 0 else {
+            throw BTStackError(rawValue: self)
+        }
+    }
+}
+
+internal extension UInt8 {
+    
+    func throwsError() throws(BTStackError) {
+        guard self == 0 else {
+            throw BTStackError(rawValue: numericCast(self))
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BTStack/GAP.swift
+++ b/pico-w-ble-peripheral-sdk/BTStack/GAP.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public extension HostController {
+    
+    func setAdvertisementParameters(
+        advIntMin: UInt16 = 0x0030,
+        advIntMax: UInt16 = 0x0030,
+        advType: UInt8 = 0,
+        directAddressType: UInt8 = 0,
+        directAddress: BluetoothAddress = .zero,
+        channelMap: UInt8 = 0x07,
+        filterPolicy: UInt8 = 0x00
+    ) {
+        var directAddress = directAddress
+        withUnsafeMutablePointer(to: &directAddress.bytes) {
+            gap_advertisements_set_params(advIntMin, advIntMax, advType, directAddressType, $0, channelMap, filterPolicy)
+        }
+    }
+    
+    var address: BluetoothAddress {
+        var address: BluetoothAddress = .zero
+        gap_local_bd_addr(&address.bytes)
+        return address.bigEndian
+    }
+}
+
+internal extension HostController {
+    
+    func setAdvertisementData() {
+        let length = advertisement.length
+        advertisementBuffer = [UInt8](advertisement)
+        // data is not copied, pointer has to stay valid
+        gap_advertisements_set_data(length, &advertisementBuffer)
+    }
+    
+    func setScanResponse() {
+        let length = scanResponse.length
+        scanResponseBuffer = [UInt8](scanResponse)
+        // data is not copied, pointer has to stay valid
+        gap_scan_response_set_data(length, &scanResponseBuffer)
+    }
+    
+    func setAdvertisementState() {
+        gap_advertisements_enable(isAdvertising ? 1 : 0)
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BTStack/GATTPeripheral.swift
+++ b/pico-w-ble-peripheral-sdk/BTStack/GATTPeripheral.swift
@@ -1,0 +1,489 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// GATT Peripheral Manager
+public final class BTStackPeripheral: PeripheralManager, @unchecked Sendable {
+    
+    /// Peripheral Options
+    public typealias Options = BTStackPeripheralOptions
+    
+    /// Peripheral Advertising Options
+    public typealias AdvertisingOptions = BTStackPeripheralAdvertisingOptions
+    
+    public typealias Data = [UInt8]
+    
+    internal typealias Socket = BTStackPeripheral.L2CAP.Server
+    
+    // MARK: - Properties
+    
+    public let hostController: HostController
+    
+    public let options: Options
+    
+    /// Logging
+    public var log: (@Sendable (String) -> ())? {
+        get {
+            storage.log
+        }
+        set {
+            storage.log = newValue
+        }
+    }
+    
+    public var willRead: ((GATTReadRequest<Central, Data>) -> ATTError?)? {
+        get {
+            storage.willRead
+        }
+        set {
+            storage.willRead = newValue
+        }
+    }
+    
+    public var willWrite: ((GATTWriteRequest<Central, Data>) -> ATTError?)? {
+        get {
+            storage.willWrite
+        }
+        set {
+            storage.willWrite = newValue
+        }
+    }
+    
+    public var didWrite: ((GATTWriteConfirmation<Central, Data>) -> ())? {
+        get {
+            storage.didWrite
+        }
+        set {
+            storage.didWrite = newValue
+        }
+    }
+    
+    public var connections: Set<Central> {
+        Set(storage.connections.values.lazy.map { $0.central })
+    }
+    
+    public var isAdvertising: Bool {
+        storage.isAdvertising
+    }
+        
+    private var _storage = Storage()
+    
+    private var storage: Storage {
+        get {
+            #if canImport(Foundation)
+            lock.lock()
+            defer { lock.unlock() }
+            #endif
+            return _storage
+        }
+        set {
+            #if canImport(Foundation)
+            lock.lock()
+            defer { lock.unlock() }
+            #endif
+            _storage = newValue
+        }
+    }
+    
+    #if canImport(Foundation)
+    private let lock = NSLock()
+    #endif
+    
+    // MARK: - Initialization
+    
+    public init(
+        hostController: HostController = .default,
+        options: Options = Options()
+    ) {
+        self.hostController = hostController
+        self.options = options
+    }
+    
+    deinit {
+        if storage.isAdvertising {
+            storage.stop()
+        }
+    }
+    
+    // MARK: - Methods
+    
+    public func start() throws(Error) {
+        try start(options: AdvertisingOptions())
+    }
+    
+    internal func start(
+        address: BluetoothAddress,
+        isRandom: Bool
+    ) throws(Error) {
+        // create server socket
+        let socket: Socket
+        do {
+            socket = try Socket.lowEnergyServer(
+                address: address,
+                isRandom: isRandom,
+                backlog: self.options.socketBacklog
+            )
+        }
+        catch {
+            throw .connection(.socket(error))
+        }
+        
+        // start listening for connections
+        self.storage.socket = socket
+        self.log?("Started GATT Server")
+        // listen for
+        while self.storage.isAdvertising, let socket = self.storage.socket {
+            self.accept(socket)
+        }
+    }
+    
+    public func start(options: BTStackPeripheralAdvertisingOptions) throws(Error) {
+        assert(isAdvertising == false)
+        
+        // use public or random address
+        let address: BluetoothAddress
+        if let randomAddress = options.randomAddress {
+            address = randomAddress
+            //try await hostController.lowEnergySetRandomAddress(randomAddress)
+        } else {
+            address = hostController.address
+        }
+        
+        // set advertising data and scan response
+        if options.advertisingData != nil || options.scanResponse != nil {
+            hostController.isAdvertising = false
+        }
+        if let advertisingData = options.advertisingData {
+            hostController.advertisement = advertisingData
+        }
+        if let scanResponse = options.scanResponse {
+            hostController.scanResponse = scanResponse
+        }
+        
+        // enable advertising
+        hostController.isAdvertising = true
+        
+        // start listening thread
+        try start(
+            address: address,
+            isRandom: options.randomAddress != nil
+        )
+    }
+    
+    public func stop() {
+        storage.stop()
+        log?("Stopped GATT Server")
+    }
+    
+    public func add(service: GATTAttribute<Data>.Service) -> (UInt16, [UInt16]) {
+        return storage.add(service: service)
+    }
+    
+    public func remove(service handle: UInt16) {
+        storage.remove(service: handle)
+    }
+    
+    public func removeAllServices() {
+        storage.removeAllServices()
+    }
+    
+    /// Modify the value of a characteristic, optionally emiting notifications if configured on active connections.
+    public func write(_ newValue: Data, forCharacteristic handle: UInt16) {
+        write(newValue, forCharacteristic: handle, ignore: .none)
+    }
+    
+    public func write(_ newValue: Data, forCharacteristic handle: UInt16, for central: Central) throws(Error) {
+        guard let connection = storage.connections[central] else {
+            throw .disconnected(central)
+        }
+        connection.write(newValue, forCharacteristic: handle)
+    }
+    
+    /// Read the value of the characteristic with specified handle.
+    public subscript(characteristic handle: UInt16) -> Data {
+        storage.database[handle: handle].value
+    }
+    
+    public func value(for characteristicHandle: UInt16, central: Central) throws(Error) -> Data {
+        guard let connection = storage.connections[central] else {
+            throw .disconnected(central)
+        }
+        return connection[characteristicHandle]
+    }
+    
+    /// Return the handles of the characteristics matching the specified UUID.
+    public func characteristics(for uuid: BluetoothUUID) -> [UInt16] {
+        return storage.database
+            .lazy
+            .filter { $0.uuid == uuid }
+            .map { $0.handle }
+    }
+}
+
+internal extension BTStackPeripheral {
+    
+    func log(_ central: Central, _ message: String) {
+        log?("[\(central)]: " + message)
+    }
+    
+    /// Modify the value of a characteristic, optionally emiting notifications if configured on active connections.
+    func write(_ newValue: Data, forCharacteristic handle: UInt16, ignore central: Central? = nil) {
+        // write to master DB
+        storage.write(newValue, forAttribute: handle)
+        // propagate changes to active connections
+        let connections = storage.connections
+            .values
+            .lazy
+            .filter { $0.central != central }
+        // update the DB of each connection, and send notifications concurrently
+        for connection in connections {
+            connection.write(newValue, forCharacteristic: handle)
+        }
+    }
+    
+    func callback(for central: Central) -> GATTServer<Socket.Connection>.Callback {
+        var callback = GATTServer<Socket.Connection>.Callback()
+        callback.willRead = {
+            self.willRead(central: central, uuid: $0, handle: $1, value: $2, offset: $3)
+        }
+        callback.willWrite = {
+            self.willWrite(central: central, uuid: $0, handle: $1, value: $2, newValue: $3)
+        }
+        callback.didWrite = { (uuid, handle, value) in
+            self.didWrite(central: central, uuid: uuid, handle: handle, value: value)
+        }
+        return callback
+    }
+    
+    func maximumUpdateValueLength(for central: Central) -> Int {
+        guard let maximumUpdateValueLength = self.storage.connections[central]?.maximumUpdateValueLength else {
+            assertionFailure()
+            return Int(ATTMaximumTransmissionUnit.min.rawValue - 3)
+        }
+        return maximumUpdateValueLength
+    }
+    
+    func willRead(central: Central, uuid: BluetoothUUID, handle: UInt16, value: Data, offset: Int) -> ATTError? {
+        let maximumUpdateValueLength = maximumUpdateValueLength(for: central)
+        let request = GATTReadRequest(
+            central: central,
+            maximumUpdateValueLength: maximumUpdateValueLength,
+            uuid: uuid,
+            handle: handle,
+            value: value,
+            offset: offset
+        )
+        return willRead?(request)
+    }
+    
+    func willWrite(central: Central, uuid: BluetoothUUID, handle: UInt16, value: Data, newValue: Data) -> ATTError? {
+        let maximumUpdateValueLength = maximumUpdateValueLength(for: central)
+        let request = GATTWriteRequest(
+            central: central,
+            maximumUpdateValueLength: maximumUpdateValueLength,
+            uuid: uuid,
+            handle: handle,
+            value: value,
+            newValue: newValue
+        )
+        return willWrite?(request)
+    }
+    
+    func didWrite(central: Central, uuid: BluetoothUUID, handle: UInt16, value: Data) {
+        let maximumUpdateValueLength = maximumUpdateValueLength(for: central)
+        let confirmation = GATTWriteConfirmation(
+            central: central,
+            maximumUpdateValueLength: maximumUpdateValueLength,
+            uuid: uuid,
+            handle: handle,
+            value: value
+        )
+        // update DB and inform other connections
+        write(confirmation.value, forCharacteristic: confirmation.handle, ignore: confirmation.central)
+        // notify delegate
+        didWrite?(confirmation)
+    }
+    
+    func accept(
+        _ socket: Socket
+    ) {
+        let log = self.log
+        do {
+            // wait for pending socket
+            while socket.status.accept == false, socket.status.error == nil {
+                sleep_ms(500)
+            }
+            let newSocket = try socket.accept()
+            let central = Central(id: newSocket.address)
+            log?("[\(central)]: New connection")
+            let connection = GATTServerConnection<Socket.Connection>(
+                central: central,
+                socket: newSocket,
+                maximumTransmissionUnit: options.maximumTransmissionUnit,
+                maximumPreparedWrites: options.maximumPreparedWrites,
+                database: storage.database,
+                callback: callback(for: central),
+                log: {
+                    log?("[\(central)]: " + $0)
+                }
+            )
+            storage.newConnection(connection)
+            do {
+                    sleep_ms(100)
+                        // read and write
+                        try connection.run()
+                }
+                catch {
+                    //log?("[\(central)]: " + error.rawValue.description)
+                }
+                self.didDisconnect(central, log: log)
+        }
+        catch {
+            log?("Error waiting for new connection: \(error)")
+            sleep_ms(1000)
+        }
+    }
+    
+    func didDisconnect(
+        _ central: Central,
+        log: (@Sendable (String) -> ())?
+    ) {
+        // try advertising again
+        hostController.isAdvertising = true
+        // remove connection cache
+        storage.removeConnection(central)
+        // log
+        log?("[\(central)]: " + "Did disconnect.")
+    }
+}
+
+// MARK: - Supporting Types
+
+public struct BTStackPeripheralOptions: Equatable, Hashable, Sendable {
+    
+    public var maximumTransmissionUnit: ATTMaximumTransmissionUnit
+    
+    public var maximumPreparedWrites: Int
+    
+    public var socketBacklog: Int
+    
+    public init(
+        maximumTransmissionUnit: ATTMaximumTransmissionUnit = .max,
+        maximumPreparedWrites: Int = 100,
+        socketBacklog: Int = 20
+    ) {
+        assert(maximumPreparedWrites > 0)
+        assert(socketBacklog > 0)
+        self.maximumTransmissionUnit = maximumTransmissionUnit
+        self.maximumPreparedWrites = maximumPreparedWrites
+        self.socketBacklog = socketBacklog
+    }
+}
+
+public struct BTStackPeripheralAdvertisingOptions: Equatable, Hashable, Sendable {
+    
+    public var advertisingData: LowEnergyAdvertisingData?
+    
+    public var scanResponse: LowEnergyAdvertisingData?
+    
+    public var randomAddress: BluetoothAddress?
+    
+    public init(
+        advertisingData: LowEnergyAdvertisingData? = nil,
+        scanResponse: LowEnergyAdvertisingData? = nil,
+        randomAddress: BluetoothAddress? = nil
+    ) {
+        self.advertisingData = advertisingData
+        self.scanResponse = scanResponse
+        self.randomAddress = randomAddress
+    }
+}
+
+public extension BTStackPeripheral {
+    
+    enum Error: Swift.Error {
+        
+        case library(BTStackError)
+        case disconnected(Central)
+        case connection(ATTConnectionError<BTStackError, [UInt8]>)
+    }
+}
+
+internal extension BTStackPeripheral {
+    
+    struct Storage {
+        
+        var database = GATTDatabase<Data>()
+        
+        var willRead: ((GATTReadRequest<Central, Data>) -> ATTError?)?
+        
+        var willWrite: ((GATTWriteRequest<Central, Data>) -> ATTError?)?
+        
+        var didWrite: ((GATTWriteConfirmation<Central, Data>) -> ())?
+        
+        var log: (@Sendable (String) -> ())?
+        
+        var socket: Socket?
+        
+        var connections = [Central: GATTServerConnection<Socket.Connection>](minimumCapacity: 2)
+                
+        fileprivate init() { }
+        
+        var isAdvertising: Bool {
+            socket != nil
+        }
+        
+        mutating func stop() {
+            assert(socket != nil)
+            socket = nil
+        }
+        
+        mutating func add(service: GATTAttribute<Data>.Service) -> (UInt16, [UInt16]) {
+            var includedServicesHandles = [UInt16]()
+            var characteristicDeclarationHandles = [UInt16]()
+            var characteristicValueHandles = [UInt16]()
+            var descriptorHandles = [[UInt16]]()
+            let serviceHandle = database.add(
+                service: service,
+                includedServicesHandles: &includedServicesHandles,
+                characteristicDeclarationHandles: &characteristicDeclarationHandles,
+                characteristicValueHandles: &characteristicValueHandles,
+                descriptorHandles: &descriptorHandles
+            )
+            return (serviceHandle, characteristicValueHandles)
+        }
+        
+        mutating func remove(service handle: UInt16) {
+            database.remove(service: handle)
+        }
+        
+        mutating func removeAllServices() {
+            database.removeAll()
+        }
+        
+        mutating func write(_ value: Data, forAttribute handle: UInt16) {
+            database.write(value, forAttribute: handle)
+        }
+        
+        mutating func newConnection(
+            _ connection: GATTServerConnection<Socket.Connection>
+        ) {
+            connections[connection.central] = connection
+        }
+        
+        mutating func removeConnection(_ central: Central) {
+            connections[central] = nil
+        }
+        
+        mutating func maximumUpdateValueLength(for central: Central) -> Int? {
+            connections[central]?.maximumUpdateValueLength
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BTStack/GATTPeripheral.swift
+++ b/pico-w-ble-peripheral-sdk/BTStack/GATTPeripheral.swift
@@ -75,7 +75,7 @@ public final class BTStackPeripheral: PeripheralManager, @unchecked Sendable {
         
     private var _storage = Storage()
     
-    private var storage: Storage {
+    internal var storage: Storage {
         get {
             #if canImport(Foundation)
             lock.lock()
@@ -336,9 +336,11 @@ internal extension BTStackPeripheral {
             )
             storage.newConnection(connection)
             do {
-                    sleep_ms(100)
+                    while true {
+                        sleep_ms(10)
                         // read and write
                         try connection.run()
+                    }
                 }
                 catch {
                     //log?("[\(central)]: " + error.rawValue.description)

--- a/pico-w-ble-peripheral-sdk/BTStack/GATTServerConnection.swift
+++ b/pico-w-ble-peripheral-sdk/BTStack/GATTServerConnection.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+internal final class GATTServerConnection <Socket: L2CAPConnection>: @unchecked Sendable {
+    
+    typealias Data = Socket.Data
+    
+    typealias Error = Socket.Error
+    
+    // MARK: - Properties
+    
+    public let central: Central
+        
+    private let server: GATTServer<Socket>
+    
+    public var maximumUpdateValueLength: Int {
+        // ATT_MTU-3
+        Int(server.maximumTransmissionUnit.rawValue) - 3
+    }
+    
+    #if canImport(Foundation)
+    private let lock = NSLock()
+    #endif
+    
+    // MARK: - Initialization
+    
+    internal init(
+        central: Central,
+        socket: Socket,
+        maximumTransmissionUnit: ATTMaximumTransmissionUnit,
+        maximumPreparedWrites: Int,
+        database: GATTDatabase<Socket.Data>,
+        callback: GATTServer<Socket>.Callback,
+        log: (@Sendable (String) -> ())?
+    ) {
+        self.central = central
+        self.server = GATTServer(
+            socket: socket,
+            maximumTransmissionUnit: maximumTransmissionUnit,
+            maximumPreparedWrites: maximumPreparedWrites,
+            database: database,
+            log: log
+        )
+        self.server.callback = callback
+    }
+    
+    // MARK: - Methods
+    
+    /// Modify the value of a characteristic, optionally emiting notifications if configured on active connections.
+    public func write(_ value: Data, forCharacteristic handle: UInt16) {
+        #if canImport(Foundation)
+        lock.lock()
+        defer { lock.unlock() }
+        #endif
+        server.writeValue(value, forCharacteristic: handle)
+    }
+    
+    public func run() throws(ATTConnectionError<Socket.Error, Socket.Data>) {
+        #if canImport(Foundation)
+        lock.lock()
+        defer { lock.unlock() }
+        #endif
+        try self.server.run()
+    }
+    
+    public subscript(handle: UInt16) -> Data {
+        #if canImport(Foundation)
+        lock.lock()
+        defer { lock.unlock() }
+        #endif
+        return server.database[handle: handle].value
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BTStack/HostController.swift
+++ b/pico-w-ble-peripheral-sdk/BTStack/HostController.swift
@@ -1,0 +1,154 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public final class HostController {
+    
+    public nonisolated(unsafe) static let `default` = HostController(transport: .default)
+    
+    // MARK: - Properties
+    
+    private var callbackRegistration = btstack_packet_callback_registration_t()
+    
+    public var log: (@Sendable (String) -> ())?
+
+    public internal(set) var state: State = .off {
+        didSet {
+            log?("HCI State: \(oldValue) -> \(state)")
+        }
+    }
+    
+    public var isAdvertising = false {
+        didSet {
+            setAdvertisementState()
+        }
+    }
+    
+    public var advertisement = LowEnergyAdvertisingData() {
+        didSet {
+            setAdvertisementData()
+        }
+    }
+    
+    internal var advertisementBuffer = [UInt8]()
+    
+    public var scanResponse = LowEnergyAdvertisingData() {
+        didSet {
+            setScanResponse()
+        }
+    }
+    
+    internal var scanResponseBuffer = [UInt8]()
+    
+    // MARK: - Initialization
+    
+    internal init(transport: borrowing Transport) {
+        // init BTStack
+        hci_init(transport.pointer, nil)
+        // register for callbacks
+        callbackRegistration.callback = _bluetooth_packet_handler
+        hci_add_event_handler(&callbackRegistration)
+    }
+
+    deinit {
+        hci_remove_event_handler(&callbackRegistration)
+        hci_deinit()
+    }
+    
+    // MARK: - Methods
+    
+    /// Requests the change of BTstack power mode.
+    public func setPower(_ state: PowerState) throws(BTStackError) {
+        try hci_power_control(.init(rawValue: numericCast(state.rawValue))).throwsError()
+    }
+}
+
+// MARK: - Supporting Types
+
+public extension HostController {
+
+    enum PowerState: UInt8, Sendable {
+
+        case off    = 0
+        case on     = 1
+        case sleep  = 2
+    }
+
+    enum State: UInt8, Sendable {
+
+        case off            = 0
+        case initializing   = 1
+        case on             = 2
+        case halting        = 3
+        case sleeping       = 4
+        case fallingAsleep  = 5
+    }
+}
+
+// packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size)
+internal func _bluetooth_packet_handler(packetType: UInt8, channel: UInt16, packetPointer: UnsafeMutablePointer<UInt8>?, packetSize: UInt16) {
+    
+    let hostController = HostController.default
+    switch Int32(packetType) {
+        case HCI_EVENT_PACKET:
+            switch UInt32(hci_event_packet_get_type(packetPointer)) {
+                case BTSTACK_EVENT_STATE:
+                    hostController.handle_BTSTACK_EVENT_STATE(packetType, channel, packetPointer, packetSize)
+                case HCI_EVENT_TRANSPORT_USB_INFO:
+                    hostController.handle_HCI_EVENT_TRANSPORT_USB_INFO(packetType, channel, packetPointer, packetSize)
+                case HCI_EVENT_DISCONNECTION_COMPLETE:
+                    hostController.handle_HCI_EVENT_DISCONNECTION_COMPLETE(packetType, channel, packetPointer, packetSize)
+                case HCI_EVENT_VENDOR_SPECIFIC:
+                    break
+            case HCI_EVENT_META_GAP:
+                switch UInt32(hci_event_gap_meta_get_subevent_code(packetPointer)) {
+                case GAP_SUBEVENT_LE_CONNECTION_COMPLETE:
+                    hostController.handle_GAP_SUBEVENT_LE_CONNECTION_COMPLETE(packetType, channel, packetPointer, packetSize)
+                default:
+                    break
+                }
+                default:
+                    break
+            }
+        default:
+            break
+    }
+}
+
+internal extension HostController {
+    
+    func handle_BTSTACK_EVENT_STATE(_ packetType: UInt8, _ channel: UInt16, _ packetPointer: UnsafeMutablePointer<UInt8>?, _ packetSize: UInt16) {
+        let rawState = btstack_event_state_get_state(packetPointer)
+        let newValue = HostController.State(rawValue: rawState) ?? .off
+        self.state = newValue
+    }
+    
+    func handle_HCI_EVENT_TRANSPORT_USB_INFO(_ packetType: UInt8, _ channel: UInt16, _ packetPointer: UnsafeMutablePointer<UInt8>?, _ packetSize: UInt16) {
+        let vendor = hci_event_transport_usb_info_get_vendor_id(packetPointer)
+        let product = hci_event_transport_usb_info_get_product_id(packetPointer)
+        log?("USB Vendor \(vendor) Product \(product) ")
+    }
+    
+    func handle_GAP_SUBEVENT_LE_CONNECTION_COMPLETE(_ packetType: UInt8, _ channel: UInt16, _ packetPointer: UnsafeMutablePointer<UInt8>?, _ packetSize: UInt16) {
+        let connectionHandle = gap_subevent_le_connection_complete_get_connection_handle(packetPointer)
+        log?("LE Connection - Handle: \(connectionHandle)")
+    }
+    
+    func handle_HCI_EVENT_DISCONNECTION_COMPLETE(_ packetType: UInt8, _ channel: UInt16, _ packetPointer: UnsafeMutablePointer<UInt8>?, _ packetSize: UInt16) {
+        let connectionHandle = hci_event_disconnection_complete_get_connection_handle(packetPointer)
+        log?("LE Disconnection - Handle: \(connectionHandle)")
+        // re-enable advertising
+        if isAdvertising {
+            //gap_discoverable_control(1)
+            //gap_connectable_control(1)
+            gap_advertisements_enable(1)
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BTStack/L2CAPServer.swift
+++ b/pico-w-ble-peripheral-sdk/BTStack/L2CAPServer.swift
@@ -1,0 +1,289 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+internal extension BTStackPeripheral {
+    
+    final class L2CAP {
+        
+        public nonisolated(unsafe) static var shared = BTStackPeripheral.L2CAP()
+        
+        internal var l2capCallbackRegistration = btstack_packet_callback_registration_t()
+        
+        private var hciCallbackRegistration = btstack_packet_callback_registration_t()
+            
+        public var log: (@Sendable (String) -> ())?
+        
+        internal fileprivate(set) var recievedData = [UInt16: [BTStackPeripheral.L2CAP.Connection.Data]]()
+        
+        internal fileprivate(set) var pendingConnections = [BTStackPeripheral.L2CAP.Connection]()
+        
+        private init() {
+            // Set up L2CAP and register L2CAP with HCI layer.
+            l2cap_init()
+            // register for callbacks
+            l2capCallbackRegistration.callback = _l2cap_gattserver_packet_handler
+            l2cap_add_event_handler(&l2capCallbackRegistration)
+            hciCallbackRegistration.callback = _l2cap_gattserver_packet_handler
+            hci_add_event_handler(&hciCallbackRegistration)
+        }
+        
+        deinit {
+            l2cap_remove_event_handler(&l2capCallbackRegistration)
+            hci_remove_event_handler(&hciCallbackRegistration)
+        }
+        
+        public func register(channel: ChannelIdentifier) {
+            l2cap_register_fixed_channel(_l2cap_gattserver_packet_handler, channel.rawValue)
+        }
+        
+        public func disconnect(connection: UInt16) throws(BTStackError) {
+            try l2cap_disconnect(connection).throwsError()
+        }
+        
+        public func canRead(_ handle: UInt16) -> Bool {
+            self.recievedData[handle, default: []].isEmpty == false
+        }
+        
+        public func read(length: Int = 23, connection handle: UInt16) -> [UInt8]? {
+            guard canRead(handle) else {
+                return nil
+            }
+            return Array(self.recievedData[handle, default: []].removeFirst().prefix(length))
+        }
+        
+        internal func recieved(_ connection: UInt16, _ buffer: UnsafeBufferPointer<UInt8>) {
+            let data = Array(buffer)
+            self.recievedData[connection, default: []].append(data)
+        }
+        
+        public func canWrite(_ handle: UInt16) -> Bool {
+            /*
+            guard let channel = l2cap_fixed_channel_for_channel_id(handle) else {
+                assertionFailure()
+                return false
+            }
+            return channel.pointee.waiting_for_can_send_now != 0
+             */
+            return true
+        }
+        
+        public func write(_ data: [UInt8], connection handle: UInt16) throws(BTStackError) {
+            //try l2cap_send(handle, buffer.baseAddress, UInt16(buffer.count)).throwsError()
+            try data.withUnsafeBytes {
+                l2cap_send_connectionless(
+                    handle,
+                    UInt16(L2CAP_CID_ATTRIBUTE_PROTOCOL),
+                    .init(mutating: $0.baseAddress?.assumingMemoryBound(to: UInt8.self)),
+                    UInt16($0.count)
+                )
+            }.throwsError()
+        }
+        
+        public func canAccept() -> Bool {
+            pendingConnections.isEmpty == false
+        }
+        
+        public func accept() -> Connection? {
+            guard canAccept() else {
+                return nil
+            }
+            return self.pendingConnections.removeFirst()
+        }
+    }
+}
+
+internal extension BTStackPeripheral.L2CAP {
+    
+    struct Server: L2CAPServer {
+                
+        public typealias Error = BTStackError
+        
+        public let address: BluetoothAddress
+        
+        /// Creates a new server,
+        public static func lowEnergyServer(
+            address: BluetoothAddress,
+            isRandom: Bool,
+            backlog: Int
+        ) throws(BTStackError) -> Self {
+            self.init(address: address, channel: .att)
+        }
+        
+        internal init(address: BluetoothAddress, channel: ChannelIdentifier) {
+            BTStackPeripheral.L2CAP.shared.register(channel: channel)
+            self.address = address
+        }
+        
+        public func close() {
+            
+        }
+        
+        public func accept() throws(BTStackError) -> Connection {
+            guard let connection = BTStackPeripheral.L2CAP.shared.accept() else {
+                throw BTStackError(.noConnection)
+            }
+            return connection
+        }
+        
+        public var status: L2CAPSocketStatus<BTStackError> {
+            return .init(
+                send: false,
+                recieve: false,
+                accept: BTStackPeripheral.L2CAP.shared.canAccept(),
+                error: nil
+            )
+        }
+    }
+}
+
+internal extension BTStackPeripheral.L2CAP {
+    
+    struct Connection: L2CAPConnection {
+        
+        public typealias Error = BTStackError
+        
+        public typealias Data = [UInt8]
+        
+        public let handle: UInt16
+                
+        public let address: BluetoothAddress
+        
+        public let destination: BluetoothAddress
+        
+        internal var l2cap: BTStackPeripheral.L2CAP { BTStackPeripheral.L2CAP.shared }
+        
+        /// Creates a new socket connected to the remote address specified.
+        public static func lowEnergyClient(
+            address: BluetoothAddress,
+            destination: BluetoothAddress,
+            isRandom: Bool
+        ) throws(BTStackError) -> Self {
+            // TODO: Outgoing connection
+            throw .init(.unspecifiedError)
+        }
+        
+        public func close() {
+            try? l2cap.disconnect(connection: handle)
+        }
+        
+        /// Write to the socket.
+        public func send(_ data: Data) throws(BTStackError) {
+            try l2cap.write(data, connection: handle)
+        }
+        
+        /// Reads from the socket.
+        public func receive(_ bufferSize: Int) throws(Self.Error) -> Self.Data {
+            guard let data = l2cap.read(length: bufferSize, connection: handle) else {
+                throw BTStackError(.unspecifiedError)
+            }
+            return data
+        }
+            
+        /// Attempts to change the socket's security level.
+        public func setSecurityLevel(_ securityLevel: SecurityLevel) throws(Self.Error) {
+            throw BTStackError(.unspecifiedError)
+        }
+        
+        /// Get security level
+        //var securityLevel: SecurityLevel { get throws(Self.Error) }
+        public func securityLevel() throws(Self.Error) -> SecurityLevel {
+            .sdp
+        }
+        
+        public var status: L2CAPSocketStatus<BTStackError> {
+            return .init(
+                send: l2cap.canWrite(handle),
+                recieve: l2cap.canRead(handle),
+                accept: false,
+                error: nil
+            )
+        }
+    }
+}
+
+
+internal func _l2cap_gattserver_packet_handler(
+    packetType: UInt8,
+    connection: UInt16,
+    packetPointer: UnsafeMutablePointer<UInt8>?,
+    packetSize: UInt16
+) {
+    let l2cap = BTStackPeripheral.L2CAP.shared
+    let buffer = UnsafeBufferPointer(start: packetPointer, count: Int(packetSize))
+    switch Int32(packetType) {
+        case HCI_EVENT_PACKET:
+            switch UInt32(hci_event_packet_get_type(packetPointer)) {
+                case L2CAP_EVENT_INCOMING_CONNECTION:
+                    let local_cid = l2cap_event_incoming_connection_get_local_cid(packetPointer)
+                    l2cap_accept_connection(local_cid)
+                case L2CAP_EVENT_CHANNEL_OPENED:
+                    break
+                case L2CAP_EVENT_CHANNEL_CLOSED:
+                    break
+                case L2CAP_EVENT_CAN_SEND_NOW:
+                    break
+                case HCI_EVENT_DISCONNECTION_COMPLETE:
+                    l2cap.handle_HCI_EVENT_DISCONNECTION_COMPLETE(connection, buffer)
+                case HCI_EVENT_META_GAP:
+                    switch UInt32(hci_event_gap_meta_get_subevent_code(packetPointer)) {
+                        case GAP_SUBEVENT_LE_CONNECTION_COMPLETE:
+                        l2cap.handle_GAP_SUBEVENT_LE_CONNECTION_COMPLETE(connection, buffer)
+                        default:
+                            break
+                }
+                default:
+                    break
+            }
+        case Int32(L2CAP_DATA_PACKET):
+            l2cap.handle_L2CAP_DATA_PACKET(connection, buffer)
+        case Int32(ATT_DATA_PACKET):
+            l2cap.handle_ATT_DATA_PACKET(connection, buffer)
+        default:
+            break
+    }
+}
+
+internal extension BTStackPeripheral.L2CAP {
+    
+    func handle_L2CAP_DATA_PACKET(_ connection: UInt16, _ data: UnsafeBufferPointer<UInt8>) {
+        log?("L2CAP Packet - Handle \(connection)")
+        recieved(connection, data)
+    }
+    
+    func handle_ATT_DATA_PACKET(_ connection: UInt16, _ data: UnsafeBufferPointer<UInt8>) {
+        log?("ATT Packet - Handle \(connection)")
+        guard data.isEmpty == false, let opcode = ATTOpcode(rawValue: data[0]) else {
+            return
+        }
+        log?("ATT Opcode \(opcode)")
+        recieved(connection, data)
+    }
+    
+    func handle_HCI_EVENT_DISCONNECTION_COMPLETE(_ connection: UInt16, _ data: UnsafeBufferPointer<UInt8>) {
+        let handle = hci_event_disconnection_complete_get_connection_handle(data.baseAddress)
+        log?("Disconnected - Handle \(handle)")
+        self.recievedData[handle] = nil
+        self.pendingConnections.removeAll(where: { $0.handle == handle })
+    }
+    
+    func handle_GAP_SUBEVENT_LE_CONNECTION_COMPLETE(_ connection: UInt16, _ data: UnsafeBufferPointer<UInt8>) {
+        let connectionHandle = gap_subevent_le_connection_complete_get_connection_handle(data.baseAddress)
+        var peerAddress: BluetoothAddress = .zero
+        gap_subevent_le_connection_complete_get_peer_address(data.baseAddress, &peerAddress)
+        let connection = BTStackPeripheral.L2CAP.Connection(
+            handle: connectionHandle,
+            address: peerAddress,
+            destination: HostController.default.address
+        )
+        self.pendingConnections.append(connection)
+        log?("Connected - Handle \(connectionHandle) - Address \(peerAddress)")
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BTStack/L2CAPServer.swift
+++ b/pico-w-ble-peripheral-sdk/BTStack/L2CAPServer.swift
@@ -45,9 +45,11 @@ internal extension BTStackPeripheral {
         }
         
         public func disconnect(connection: UInt16) throws(BTStackError) {
+            #if L2CAP_USES_CHANNELS
             try l2cap_disconnect(connection).throwsError()
+            #endif
         }
-        
+
         public func canRead(_ handle: UInt16) -> Bool {
             self.recievedData[handle, default: []].isEmpty == false
         }
@@ -222,8 +224,7 @@ internal func _l2cap_gattserver_packet_handler(
         case HCI_EVENT_PACKET:
             switch UInt32(hci_event_packet_get_type(packetPointer)) {
                 case L2CAP_EVENT_INCOMING_CONNECTION:
-                    let local_cid = l2cap_event_incoming_connection_get_local_cid(packetPointer)
-                    l2cap_accept_connection(local_cid)
+                    break
                 case L2CAP_EVENT_CHANNEL_OPENED:
                     break
                 case L2CAP_EVENT_CHANNEL_CLOSED:
@@ -263,7 +264,6 @@ internal extension BTStackPeripheral.L2CAP {
         guard data.isEmpty == false, let opcode = ATTOpcode(rawValue: data[0]) else {
             return
         }
-        log?("ATT Opcode \(opcode)")
         recieved(connection, data)
     }
     

--- a/pico-w-ble-peripheral-sdk/BTStack/Transport.swift
+++ b/pico-w-ble-peripheral-sdk/BTStack/Transport.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public extension HostController {
+    
+    enum Transport {
+        
+        case usb(USB = USB())
+    }
+}
+
+public extension HostController.Transport {
+    
+    static var `default`: HostController.Transport {
+        #if os(macOS) || os(Linux)
+        return .usb(USB())
+        #else
+        return .usb(USB())
+        #endif
+    }
+}
+
+internal extension HostController.Transport {
+    
+    var pointer: UnsafePointer<hci_transport_t> {
+        switch self {
+        case let .usb(transport):
+            return transport.pointer
+        }
+    }
+}
+
+public extension HostController.Transport {
+    
+    /// USB Transport
+    struct USB {
+        
+        internal let pointer: UnsafePointer<hci_transport_t>
+        
+        internal init(_ pointer: UnsafePointer<hci_transport_t>) {
+            self.pointer = pointer
+        }
+        
+        public init() {
+            self.init(hci_transport_usb_instance()) // singleton
+        }
+        
+        public func setPath(_ path: [UInt8]) {
+            var path = path
+            hci_transport_usb_set_path(Int32(path.count), &path)
+        }
+        
+        public func addDevice(vendor: UInt16, product: UInt16) {
+            hci_transport_usb_add_device(vendor, product)
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/Bluetooth/Address.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/Address.swift
@@ -1,0 +1,145 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Bluetooth address.
+@frozen
+public struct BluetoothAddress: Comparable, Sendable {
+    
+    // MARK: - Properties
+    
+    /// Underlying address bytes (host endianess).
+    public var bytes: ByteValue
+    
+    // MARK: - Initialization
+    
+    /// Initialize with the specifed bytes (in host endianess).
+    public init(bytes: ByteValue = (0, 0, 0, 0, 0, 0)) {
+        self.bytes = bytes
+    }
+}
+
+public extension BluetoothAddress {
+    
+    /// The minimum representable value in this type.
+    static var min: BluetoothAddress { BluetoothAddress(bytes: (.min, .min, .min, .min, .min, .min)) }
+    
+    /// The maximum representable value in this type.
+    static var max: BluetoothAddress { BluetoothAddress(bytes: (.max, .max, .max, .max, .max, .max)) }
+    
+    /// A zero address.
+    static var zero: BluetoothAddress { BluetoothAddress(bytes: (.zero, .zero, .zero, .zero, .zero, .zero)) }
+}
+
+// MARK: - Hashable
+
+extension BluetoothAddress: Hashable {
+    
+    public func hash(into hasher: inout Hasher) {
+        Swift.withUnsafeBytes(of: bytes) { hasher.combine(bytes: $0) }
+    }
+}
+
+// MARK: - ByteValue
+
+extension BluetoothAddress: ByteValue {
+    
+    /// Raw Bluetooth Address 6 byte (48 bit) value.
+    public typealias ByteValue = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+    
+    public static var bitWidth: Int { 48 }
+}
+
+// MARK: - Byte Swap
+
+extension BluetoothAddress: ByteSwap {
+    
+    /// A representation of this address with the byte order swapped.
+    public var byteSwapped: BluetoothAddress {
+        return BluetoothAddress(bytes: (bytes.5, bytes.4, bytes.3, bytes.2, bytes.1, bytes.0))
+    }
+}
+
+// MARK: - RawRepresentable
+
+extension BluetoothAddress: RawRepresentable {
+    
+    /// Initialize a Bluetooth Address from its big endian string representation (e.g. `00:1A:7D:DA:71:13`).
+    public init?(rawValue: String) {
+        self.init(rawValue)
+    }
+    
+    /// Initialize a Bluetooth Address from its big endian string representation (e.g. `00:1A:7D:DA:71:13`).
+    internal init?<S: StringProtocol>(_ rawValue: S) {
+        
+        // verify string length
+        let characters = rawValue.utf8
+        guard characters.count == 17,
+            let separator = ":".utf8.first
+            else { return nil }
+        
+        var bytes: ByteValue = (0, 0, 0, 0, 0, 0)
+        
+        let components = characters.split(whereSeparator: { $0 == separator })
+        
+        guard components.count == 6
+            else { return nil }
+        
+        for (index, subsequence) in components.enumerated() {
+            
+            guard subsequence.count == 2,
+                  let byte = UInt8(hexadecimal: subsequence)
+                else { return nil }
+            
+            withUnsafeMutablePointer(to: &bytes) {
+                $0.withMemoryRebound(to: UInt8.self, capacity: 6) {
+                    $0.advanced(by: index).pointee = byte
+                }
+            }
+        }
+        
+        self.init(bigEndian: BluetoothAddress(bytes: bytes))
+    }
+    
+    /// Convert a Bluetooth Address to its big endian string representation (e.g. `00:1A:7D:DA:71:13`).
+    public var rawValue: String {
+        let bytes = self.bigEndian.bytes
+        return bytes.0.toHexadecimal()
+            + ":" + bytes.1.toHexadecimal()
+            + ":" + bytes.2.toHexadecimal()
+            + ":" + bytes.3.toHexadecimal()
+            + ":" + bytes.4.toHexadecimal()
+            + ":" + bytes.5.toHexadecimal()
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension BluetoothAddress: CustomStringConvertible {
+    
+    public var description: String { rawValue }
+}
+
+// MARK: - Data
+
+extension BluetoothAddress: DataConvertible {
+        
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == Self.length
+            else { return nil }
+        self.bytes = (data[0], data[1], data[2], data[3], data[4], data[5])
+    }
+}
+
+// MARK: - Codable
+
+#if !hasFeature(Embedded)
+extension BluetoothAddress: Codable { }
+#endif

--- a/pico-w-ble-peripheral-sdk/Bluetooth/BluetoothUUID.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/BluetoothUUID.swift
@@ -1,0 +1,333 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+/// Bluetooth UUID
+@frozen
+public enum BluetoothUUID: Equatable, Hashable, Sendable {
+    
+    case bit16(UInt16)
+    case bit32(UInt32)
+    case bit128(UInt128)
+}
+
+public extension BluetoothUUID {
+    
+    /// Creates a random 128-bit Bluetooth UUID.
+    init() {
+        self.init(uuid: UUID())
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension BluetoothUUID: CustomStringConvertible {
+    
+    public var description: String {
+        #if !os(WASI) && !hasFeature(Embedded)
+        if let name = self.name {
+            return "\(rawValue) (\(name))"
+        } else {
+            return rawValue
+        }
+        #else
+        return rawValue
+        #endif
+    }
+}
+
+// MARK: - RawRepresentable
+
+extension BluetoothUUID: RawRepresentable {
+    
+    /// Initialize from a UUID string (in big endian representation).
+    ///
+    /// - Example: "60F14FE2-F972-11E5-B84F-23E070D5A8C7", "000000A8", "00A8"
+    public init?(rawValue: String) {
+        
+        switch rawValue.utf8.count {
+            
+        case 4:
+            
+            guard let value = UInt16(hexadecimal: rawValue)
+                else { return nil }
+            self = .bit16(value)
+            
+        case 8:
+            
+            guard let value = UInt32(hexadecimal: rawValue)
+                else { return nil }
+            self = .bit32(value)
+            
+        case 36:
+            
+            guard let uuid = UInt128(uuidString: rawValue)
+                else { return nil }
+            self = .bit128(uuid)
+            
+        default:
+            return nil
+        }
+    }
+    
+    public var rawValue: String {
+        switch self {
+        case let .bit16(value):
+            return value.toHexadecimal()
+        case let .bit32(value):
+            return value.toHexadecimal()
+        case let .bit128(value):
+            return value.uuidString
+        }
+    }
+}
+
+// MARK: - Data
+
+extension BluetoothUUID: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+    
+        guard let length = Length(rawValue: data.count)
+            else { return nil }
+        
+        switch length {
+            
+        // 16 bit
+        case .bit16:
+            
+            let value = UInt16(bytes: (data[0], data[1]))
+            self = .bit16(value)
+            
+        // 32 bit
+        case .bit32:
+            
+            let value = UInt32(bytes: (data[0], data[1], data[2], data[3]))
+            self = .bit32(value)
+            
+        // 128 bit
+        case .bit128:
+            
+            let value = UInt128(bytes: (data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15]))
+            self = .bit128(value)
+        }
+    }
+    
+    public var dataLength: Int {
+        length.rawValue
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        switch self {
+        case let .bit16(value):
+            data += value
+        case let .bit32(value):
+            data += value
+        case let .bit128(value):
+            data += value
+        }
+    }
+}
+
+internal extension BluetoothUUID {
+    
+    /// Number of bytes to represent Bluetooth UUID.
+    enum Length: Int {
+        
+        case bit16 = 2
+        case bit32 = 4
+        case bit128 = 16
+    }
+    
+    private var length: Length {
+        
+        switch self {
+        case .bit16: return .bit16
+        case .bit32: return .bit32
+        case .bit128: return .bit128
+        }
+    }
+}
+
+// MARK: - Codable
+
+#if !hasFeature(Embedded)
+extension BluetoothUUID: Codable { }
+#endif
+
+// MARK: - Byte Swap
+
+extension BluetoothUUID: ByteSwap {
+    
+    /// A representation of this Bluetooth UUID with the byte order swapped.
+    public var byteSwapped: BluetoothUUID {
+        
+        switch self {
+        case let .bit16(value): return .bit16(value.byteSwapped)
+        case let .bit32(value): return .bit32(value.byteSwapped)
+        case let .bit128(value): return .bit128(value.byteSwapped)
+        }
+    }
+}
+
+// MARK: - UInt128 Conversion
+
+public extension BluetoothUUID {
+    
+    /// Bluetooth Base UUID (big endian)
+    internal static var baseUUID: UInt128 { return UInt128(bytes: (0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00,
+                                                                   0x80, 0x00, 0x00, 0x80, 0x5F, 0x9B, 0x34, 0xFB)) }
+    
+}
+
+public extension UInt128 {
+    
+    /// Forceably convert `BluetoothUUID` to `UInt128` value.
+    init(_ bluetoothUUID: BluetoothUUID) {
+        
+        switch bluetoothUUID {
+            
+        case let .bit16(value):
+            
+            let bytes = value.bigEndian.bytes
+            var bigEndianValue = BluetoothUUID.baseUUID
+            
+            bigEndianValue.bytes.2 = bytes.0
+            bigEndianValue.bytes.3 = bytes.1
+            
+            self = UInt128(bigEndian: bigEndianValue)
+            
+        case let .bit32(value):
+            
+            let bytes = value.bigEndian.bytes
+            var bigEndianValue = BluetoothUUID.baseUUID
+            
+            bigEndianValue.bytes.0 = bytes.0
+            bigEndianValue.bytes.1 = bytes.1
+            bigEndianValue.bytes.2 = bytes.2
+            bigEndianValue.bytes.3 = bytes.3
+            
+            self = UInt128(bigEndian: bigEndianValue)
+            
+        case let .bit128(value):
+            
+            self = value
+        }
+    }
+}
+
+public extension BluetoothUUID {
+    
+    /// Forceably convert `BluetoothUUID` to `UInt128` value.
+    var bit128: BluetoothUUID {
+        let value = UInt128(self)
+        return .bit128(value)
+    }
+}
+
+internal extension UUID {
+    
+    @inline(__always)
+    func bluetoothPrefix() -> (UInt8, UInt8, UInt8, UInt8)? {
+        
+        // big endian
+        let baseUUID = BluetoothUUID.baseUUID.bytes
+        
+        guard bytes.4 == baseUUID.4,
+            bytes.5 == baseUUID.5,
+            bytes.6 == baseUUID.6,
+            bytes.7 == baseUUID.7,
+            bytes.8 == baseUUID.8,
+            bytes.9 == baseUUID.9,
+            bytes.10 == baseUUID.10,
+            bytes.11 == baseUUID.11,
+            bytes.12 == baseUUID.12,
+            bytes.13 == baseUUID.13,
+            bytes.14 == baseUUID.14,
+            bytes.15 == baseUUID.15
+            else { return nil }
+        
+        return (bytes.0, bytes.1, bytes.2, bytes.3)
+    }
+}
+
+public extension UInt16 {
+    
+    /// Attempt to extract Bluetooth 16-bit UUID from standard 128-bit UUID.
+    init?(bluetooth uuid: UUID) {
+        
+        guard let prefixBytes = uuid.bluetoothPrefix(),
+            prefixBytes.0 == 0,
+            prefixBytes.1 == 0
+            else { return nil }
+        
+        self.init(bigEndian: UInt16(bytes: (prefixBytes.2, prefixBytes.3)))
+    }
+}
+
+public extension UInt32 {
+    
+    /// Attempt to extract Bluetooth 32-bit UUID from standard 128-bit UUID.
+    init?(bluetooth uuid: UUID) {
+        
+        guard let prefixBytes = uuid.bluetoothPrefix()
+            else { return nil }
+        
+        self.init(bigEndian: UInt32(bytes: (prefixBytes.0, prefixBytes.1, prefixBytes.2, prefixBytes.3)))
+    }
+}
+
+// MARK: - NSUUID Conversion
+
+public extension BluetoothUUID {
+    
+    /// Initialize from a `Foundation.UUID`.
+    init(uuid: UUID) {
+        self = .bit128(UInt128(uuid: uuid))
+    }
+}
+
+public extension UUID {
+    
+    /// Initialize and convert from a Bluetooth UUID.
+    init(bluetooth uuid: BluetoothUUID) {
+        self.init(UInt128(uuid))
+    }
+}
+
+// MARK: - CoreBluetooth
+
+#if canImport(CoreBluetooth)
+import CoreBluetooth
+
+public extension BluetoothUUID {
+    
+    init(_ coreBluetooth: CBUUID) {
+        
+        guard let uuid = BluetoothUUID(data: coreBluetooth.data)
+            else { fatalError("Could not create Bluetooth UUID from \(coreBluetooth)") }
+        
+        // CBUUID is always big endian
+        self.init(bigEndian: uuid)
+    }
+}
+
+public extension CBUUID {
+    
+    convenience init(_ bluetoothUUID: BluetoothUUID) {
+        self.init(data: Data(bluetoothUUID.bigEndian))
+    }
+}
+
+#endif

--- a/pico-w-ble-peripheral-sdk/Bluetooth/BluetoothUUID.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/BluetoothUUID.swift
@@ -15,7 +15,7 @@ import Foundation
 
 /// Bluetooth UUID
 @frozen
-public enum BluetoothUUID: Equatable, Hashable, Sendable {
+public enum BluetoothUUID: Hashable, Sendable {
     
     case bit16(UInt16)
     case bit32(UInt32)
@@ -44,6 +44,24 @@ extension BluetoothUUID: CustomStringConvertible {
         #else
         return rawValue
         #endif
+    }
+}
+
+// MARK: - Equatable
+
+extension BluetoothUUID: Equatable {
+    
+    public static func == (lhs: BluetoothUUID, rhs: BluetoothUUID) -> Bool {
+        switch (lhs, rhs) {
+        case let (.bit16(lhsValue), .bit16(rhsValue)):
+            return lhsValue == rhsValue
+        case let (.bit32(lhsValue), .bit32(rhsValue)):
+            return lhsValue == rhsValue
+        case let (.bit128(lhsValue), .bit128(rhsValue)):
+            return lhsValue == rhsValue
+        default:
+            return false
+        }
     }
 }
 

--- a/pico-w-ble-peripheral-sdk/Bluetooth/ByteSwap.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/ByteSwap.swift
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A Bluetooth value that is stored in the CPU native endianess format.
+public protocol ByteSwap {
+    
+    /// A representation of this integer with the byte order swapped.
+    var byteSwapped: Self { get }
+}
+
+public extension ByteSwap {
+    
+    /// Creates an instance from its little-endian representation, changing the
+    /// byte order if necessary.
+    ///
+    /// - Parameter value: A value to use as the little-endian representation of
+    ///   the new instance.
+    init(littleEndian value: Self) {
+        #if _endian(little)
+        self = value
+        #else
+        self = value.byteSwapped
+        #endif
+    }
+    
+    /// Creates an instance from its big-endian representation, changing the byte
+    /// order if necessary.
+    ///
+    /// - Parameter value: A value to use as the big-endian representation of the
+    ///   new instance.
+    init(bigEndian value: Self) {
+        #if _endian(big)
+        self = value
+        #else
+        self = value.byteSwapped
+        #endif
+    }
+    
+    /// The little-endian representation of this value.
+    ///
+    /// If necessary, the byte order of this value is reversed from the typical
+    /// byte order of this address. On a little-endian platform, for any
+    /// address `x`, `x == x.littleEndian`.
+    var littleEndian: Self {
+        #if _endian(little)
+        return self
+        #else
+        return byteSwapped
+        #endif
+    }
+    
+    /// The big-endian representation of this value.
+    ///
+    /// If necessary, the byte order of this value is reversed from the typical
+    /// byte order of this address. On a big-endian platform, for any
+    /// address `x`, `x == x.bigEndian`.
+    var bigEndian: Self {
+        #if _endian(big)
+        return self
+        #else
+        return byteSwapped
+        #endif
+    }
+}

--- a/pico-w-ble-peripheral-sdk/Bluetooth/ByteValue.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/ByteValue.swift
@@ -1,0 +1,113 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Stores a primitive value. 
+///
+/// Useful for Swift wrappers for primitive byte types. 
+public protocol ByteValue: Equatable {
+    
+    associatedtype ByteValue
+    
+    /// Returns the the primitive byte type.
+    var bytes: ByteValue { get }
+    
+    /// Initializes with the primitive the primitive byte type.
+    init(bytes: ByteValue)
+    
+    /// The number of bits used for the underlying binary representation of values of this type.
+    static var bitWidth: Int { get }
+}
+
+// MARK: - Data Convertible
+
+public extension ByteValue {
+    
+    /// Size of value in bytes.
+    static var length: Int { bitWidth / 8 }
+    
+    @inline(__always)
+    func withUnsafeBytes<R>(_ body: (UnsafeBufferPointer<UInt8>) throws -> R) rethrows -> R {
+        return try Swift.withExtendedLifetime(self) {
+            try Swift.withUnsafeBytes(of: bytes) { rawBuffer in
+                return try rawBuffer.withMemoryRebound(to: UInt8.self) { buffer in
+                    return try body(buffer)
+                }
+            }
+        }
+    }
+}
+
+public extension ByteValue where Self: DataConvertible {
+    
+    /// Append data representation into buffer.
+    func append<Data: DataContainer>(to data: inout Data) {
+        withUnsafeBytes { buffer in
+            data += buffer
+        }
+    }
+    
+    var dataLength: Int {
+        Self.length
+    }
+}
+
+// MARK: - Equatable
+
+extension ByteValue where Self: Equatable {
+    
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.withUnsafeBytes { (b1) in
+            rhs.withUnsafeBytes { (b2) in
+                b1.elementsEqual(b2)
+            }
+        }
+    }
+}
+
+// MARK: - Comparable
+
+extension ByteValue where Self: Comparable {
+    
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.withUnsafeBytes { (b1) in
+            rhs.withUnsafeBytes { (b2) in
+                _memcmp(
+                    b1.baseAddress.flatMap { UnsafeRawPointer($0) }!,
+                    b2.baseAddress.flatMap { UnsafeRawPointer($0) }!,
+                    Self.length
+                ) < 0
+            }
+        }
+    }
+    
+    public static func > (lhs: Self, rhs: Self) -> Bool {
+        lhs.withUnsafeBytes { (b1) in
+            rhs.withUnsafeBytes { (b2) in
+                _memcmp(
+                    b1.baseAddress.flatMap { UnsafeRawPointer($0) }!,
+                    b2.baseAddress.flatMap { UnsafeRawPointer($0) }!,
+                    Self.length
+                ) > 0
+            }
+        }
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension ByteValue where Self: CustomStringConvertible, Self: ByteSwap {
+    
+    public var description: String {
+        bigEndian.withUnsafeBytes {
+            "0x" + $0.toHexadecimal()
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/Bluetooth/CompanyIdentifier.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/CompanyIdentifier.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Company identifiers are unique numbers assigned by the Bluetooth SIG to member companies requesting one.
+///
+/// Each Bluetooth SIG member assigned a Company Identifier may use the assigned value for any/all of the following:
+///
+/// * LMP_CompID (refer to the Bluetooth® Core Specification)
+/// * Company Identifier Code used in Manufacturer Specific Data type used for EIR and Advertising Data Types (refer to CSSv1 or later)
+/// * Company ID for vendor specific codecs (refer to Vol. 2, Part E, of the Bluetooth Core Specification, v4.1 or later)
+/// * As the lower 16 bits of the Vendor ID for designating Vendor Specific A2DP Codecs (refer to the A2DP v1.3 or later
+/// * VendorID Attribute in Device ID service record (when VendorIDSourceAttribute equals 0x0001, refer toDevice ID Profile)
+/// * 802.11_PAL_Company_Identifier (refer to Bluetooth Core Specification v3.0 + HS or later)
+/// * TCS Company ID (refer to Telephony Control Protocol [[WITHDRAWN](https://www.bluetooth.com/specifications)])
+///
+/// Each of the adopted specifications listed above can be found on the [Adopted Specifications Page](https://www.bluetooth.com/specifications)
+/// unless it is otherwise indicated as withdrawn.
+///
+/// - SeeAlso: [Company Identifiers](https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers)
+@frozen
+public struct CompanyIdentifier: RawRepresentable, Equatable, Hashable, Sendable {
+    
+    public var rawValue: UInt16
+    
+    public init(rawValue: UInt16) {
+        self.rawValue = rawValue
+    }
+}
+
+#if !hasFeature(Embedded)
+extension CompanyIdentifier: Codable { }
+#endif
+
+#if !os(WASI) && !hasFeature(Embedded)
+public extension CompanyIdentifier {
+    
+    /// Bluetooth Company name.
+    ///
+    /// - SeeAlso: [Company Identifiers](https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers)
+    var name: String? {
+        return Self.companyIdentifiers[rawValue]
+    }
+}
+#endif
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension CompanyIdentifier: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral value: UInt16) {
+        self.init(rawValue: value)
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension CompanyIdentifier: CustomStringConvertible {
+    
+    public var description: String {
+        #if !os(WASI) && !hasFeature(Embedded)
+        return name ?? rawValue.description
+        #else
+        return rawValue.description
+        #endif
+    }
+}

--- a/pico-w-ble-peripheral-sdk/Bluetooth/Data.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/Data.swift
@@ -1,0 +1,231 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+/// Data container type.
+public protocol DataContainer: RandomAccessCollection where Self.Index == Int, Self.Element == UInt8, Self: Hashable, Self: Sendable {
+    
+    init()
+    
+    init<C: Collection> (_ collection: C) where C.Element == UInt8
+    
+    mutating func reserveCapacity(_ capacity: Int)
+    
+    subscript(index: Int) -> UInt8 { get }
+        
+    mutating func append(_ newElement: UInt8)
+    
+    mutating func append(_ pointer: UnsafePointer<UInt8>, count: Int)
+    
+    mutating func append <C: Collection> (contentsOf bytes: C) where C.Element == UInt8
+    
+    static func += (lhs: inout Self, rhs: UInt8)
+    
+    static func += <C: Collection> (lhs: inout Self, rhs: C) where C.Element == UInt8
+    
+    /// Return a new copy of the data in a specified range.
+    ///
+    /// - parameter range: The range to copy.
+    func subdata(in range: Range<Index>) -> Self
+}
+
+#if canImport(Foundation)
+extension Data: DataContainer {
+    
+    public static func += (lhs: inout Data, rhs: UInt8) {
+        lhs.append(rhs)
+    }
+}
+#endif
+
+extension LowEnergyAdvertisingData: DataContainer {
+    
+    public mutating func reserveCapacity(_ capacity: Int) {
+        // does nothing
+    }
+    
+    public func subdata(in range: Range<Int>) -> LowEnergyAdvertisingData {
+        var data = LowEnergyAdvertisingData()
+        data.length = UInt8(range.count)
+        for (newIndex, oldIndex) in range.enumerated() {
+            data[newIndex] = self[oldIndex]
+        }
+        return data
+    }
+}
+
+extension Array: DataContainer where Self.Element == UInt8 {
+    
+    public static func += (lhs: inout Array<Element>, rhs: UInt8) {
+        lhs.append(rhs)
+    }
+    
+    public mutating func append(_ pointer: UnsafePointer<UInt8>, count: Int) {
+        let newCapacity = self.count + count
+        self.reserveCapacity(newCapacity)
+        for index in 0 ..< count {
+            self.append(pointer[index])
+        }
+    }
+    
+    public func subdata(in range: Range<Int>) -> [UInt8] {
+        .init(self[range])
+    }
+}
+
+// MARK: - DataConvertible
+
+/// Can be converted into data.
+public protocol DataConvertible {
+    
+    /// Initialize from data.
+    init?<Data: DataContainer>(data: Data)
+    
+    /// Append data representation into buffer.
+    func append<Data: DataContainer>(to data: inout Data)
+        
+    /// Length of value when encoded into data.
+    var dataLength: Int { get }
+}
+
+public extension DataConvertible {
+    
+    /// Append data representation into buffer.
+    static func += <Data: DataContainer> (data: inout Data, value: Self) {
+        value.append(to: &data)
+    }
+}
+
+public extension Array where Element: DataConvertible {
+    
+    /// Append data representation into buffer.
+    static func += <T: DataContainer> (data: inout T, value: Self) {
+        value.forEach { data += $0 }
+    }
+}
+
+public extension DataContainer {
+    
+    /// Initialize data with contents of value.
+    init <T: DataConvertible> (_ value: T) {
+        let length = value.dataLength
+        self.init()
+        self.reserveCapacity(length)
+        self += value
+        assert(self.count == length)
+    }
+    
+    mutating func append <T: DataConvertible> (_ value: T) {
+        self += value
+    }
+}
+
+// MARK: - UnsafeDataConvertible
+
+/// Internal Data casting protocol
+internal protocol UnsafeDataConvertible { }
+
+extension UnsafeDataConvertible {
+    
+    var unsafeDataLength: Int {
+        MemoryLayout<Self>.size
+    }
+    
+    func unsafeAppend <T: DataContainer> (to data: inout T) {
+        let length = unsafeDataLength
+        withUnsafePointer(to: self) {
+            $0.withMemoryRebound(to: UInt8.self, capacity: length) {
+                data.append($0, count: length)
+            }
+        }
+    }
+}
+
+extension UInt16: UnsafeDataConvertible { }
+extension UInt32: UnsafeDataConvertible { }
+extension UInt64: UnsafeDataConvertible { }
+extension UInt128: UnsafeDataConvertible { }
+extension BluetoothAddress: UnsafeDataConvertible { }
+
+extension UInt16: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == MemoryLayout<Self>.size else {
+            return nil
+        }
+        self.init(bytes: (data[0], data[1]))
+    }
+    
+    public func append<Data: DataContainer>(to data: inout Data) {
+        unsafeAppend(to: &data)
+    }
+    
+    /// Length of value when encoded into data.
+    public var dataLength: Int { unsafeDataLength }
+}
+
+extension UInt32: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == MemoryLayout<Self>.size else {
+            return nil
+        }
+        self.init(bytes: (data[0], data[1], data[2], data[3]))
+    }
+    
+    public func append<Data: DataContainer>(to data: inout Data) {
+        unsafeAppend(to: &data)
+    }
+    
+    /// Length of value when encoded into data.
+    public var dataLength: Int { unsafeDataLength }
+}
+
+extension UInt64: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == MemoryLayout<Self>.size else {
+            return nil
+        }
+        self.init(bytes: (data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]))
+    }
+    
+    public func append<Data: DataContainer>(to data: inout Data) {
+        unsafeAppend(to: &data)
+    }
+    
+    /// Length of value when encoded into data.
+    public var dataLength: Int { unsafeDataLength }
+}
+
+internal extension DataContainer {
+    
+    @usableFromInline
+    func suffixCheckingBounds<Data: DataContainer>(from start: Int) -> Data {
+        if count > start {
+            return Data(suffix(from: start))
+        } else {
+            return Data()
+        }
+    }
+    
+    static func += (data: inout Self, bytes: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) {
+        let length = MemoryLayout<(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)>.size
+        withUnsafePointer(to: bytes) {
+            $0.withMemoryRebound(to: UInt8.self, capacity: length) {
+                data.append($0, count: length)
+            }
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/Bluetooth/DefinedUUIDExtension.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/DefinedUUIDExtension.swift
@@ -1,0 +1,3099 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public extension BluetoothUUID {
+
+    /// SDP (`0x0001`)
+    static var sdp: BluetoothUUID {
+        return .bit16(0x0001)
+    }
+
+    /// RFCOMM (`0x0003`)
+    static var rfcomm: BluetoothUUID {
+        return .bit16(0x0003)
+    }
+
+    /// TCS-BIN (`0x0005`)
+    static var tcsBin: BluetoothUUID {
+        return .bit16(0x0005)
+    }
+
+    /// ATT (`0x0007`)
+    static var att: BluetoothUUID {
+        return .bit16(0x0007)
+    }
+
+    /// OBEX (`0x0008`)
+    static var obex: BluetoothUUID {
+        return .bit16(0x0008)
+    }
+
+    /// BNEP (`0x000F`)
+    static var bnep: BluetoothUUID {
+        return .bit16(0x000F)
+    }
+
+    /// UPNP (`0x0010`)
+    static var upnp: BluetoothUUID {
+        return .bit16(0x0010)
+    }
+
+    /// HIDP (`0x0011`)
+    static var hidp: BluetoothUUID {
+        return .bit16(0x0011)
+    }
+
+    /// Hardcopy Control Channel (`0x0012`)
+    static var hardcopyControlChannel: BluetoothUUID {
+        return .bit16(0x0012)
+    }
+
+    /// Hardcopy Data Channel (`0x0014`)
+    static var hardcopyDataChannel: BluetoothUUID {
+        return .bit16(0x0014)
+    }
+
+    /// Hardcopy Notification (`0x0016`)
+    static var hardcopyNotification: BluetoothUUID {
+        return .bit16(0x0016)
+    }
+
+    /// AVCTP (`0x0017`)
+    static var avctp: BluetoothUUID {
+        return .bit16(0x0017)
+    }
+
+    /// AVDTP (`0x0019`)
+    static var avdtp: BluetoothUUID {
+        return .bit16(0x0019)
+    }
+
+    /// CMTP (`0x001B`)
+    static var cmtp: BluetoothUUID {
+        return .bit16(0x001B)
+    }
+
+    /// MCAP Control Channel (`0x001E`)
+    static var mcapControlChannel: BluetoothUUID {
+        return .bit16(0x001E)
+    }
+
+    /// MCAP Data Channel (`0x001F`)
+    static var mcapDataChannel: BluetoothUUID {
+        return .bit16(0x001F)
+    }
+
+    /// L2CAP (`0x0100`)
+    static var l2Cap: BluetoothUUID {
+        return .bit16(0x0100)
+    }
+
+    /// Service Discovery Server Service Class (`0x1000`)
+    static var serviceDiscoveryServerServiceClass: BluetoothUUID {
+        return .bit16(0x1000)
+    }
+
+    /// Browse Group Descriptor Service Class (`0x1001`)
+    static var browseGroupDescriptorServiceClass: BluetoothUUID {
+        return .bit16(0x1001)
+    }
+
+    /// Public Browse Root (`0x1002`)
+    static var publicBrowseRoot: BluetoothUUID {
+        return .bit16(0x1002)
+    }
+
+    /// Serial Port (`0x1101`)
+    static var serialPort: BluetoothUUID {
+        return .bit16(0x1101)
+    }
+
+    /// LAN Access Using PPP (`0x1102`)
+    static var lanAccessUsingPpp: BluetoothUUID {
+        return .bit16(0x1102)
+    }
+
+    /// Dialup Networking (`0x1103`)
+    static var dialupNetworking: BluetoothUUID {
+        return .bit16(0x1103)
+    }
+
+    /// IrMC Sync (`0x1104`)
+    static var irmcSync: BluetoothUUID {
+        return .bit16(0x1104)
+    }
+
+    /// OBEX Object Push (`0x1105`)
+    static var obexObjectPush: BluetoothUUID {
+        return .bit16(0x1105)
+    }
+
+    /// OBEX File Transfer (`0x1106`)
+    static var obexFileTransfer: BluetoothUUID {
+        return .bit16(0x1106)
+    }
+
+    /// IrMC Sync Command (`0x1107`)
+    static var irmcSyncCommand: BluetoothUUID {
+        return .bit16(0x1107)
+    }
+
+    /// Headset (`0x1108`)
+    static var headset: BluetoothUUID {
+        return .bit16(0x1108)
+    }
+
+    /// Cordless Telephony (`0x1109`)
+    static var cordlessTelephony: BluetoothUUID {
+        return .bit16(0x1109)
+    }
+
+    /// Audio Source (`0x110A`)
+    static var audioSource: BluetoothUUID {
+        return .bit16(0x110A)
+    }
+
+    /// Audio Sink (`0x110B`)
+    static var audioSink: BluetoothUUID {
+        return .bit16(0x110B)
+    }
+
+    /// A/V Remote Control Target (`0x110C`)
+    static var avRemoteControlTarget: BluetoothUUID {
+        return .bit16(0x110C)
+    }
+
+    /// Advanced Audio Distribution (`0x110D`)
+    static var advancedAudioDistribution: BluetoothUUID {
+        return .bit16(0x110D)
+    }
+
+    /// A/V Remote Control (`0x110E`)
+    static var avRemoteControl: BluetoothUUID {
+        return .bit16(0x110E)
+    }
+
+    /// A/V Remote Control Controller (`0x110F`)
+    static var avRemoteControlController: BluetoothUUID {
+        return .bit16(0x110F)
+    }
+
+    /// Intercom (`0x1110`)
+    static var intercom: BluetoothUUID {
+        return .bit16(0x1110)
+    }
+
+    /// Fax (`0x1111`)
+    static var fax: BluetoothUUID {
+        return .bit16(0x1111)
+    }
+
+    /// Headset AG (`0x1112`)
+    static var headset2: BluetoothUUID {
+        return .bit16(0x1112)
+    }
+
+    /// WAP (`0x1113`)
+    static var wap: BluetoothUUID {
+        return .bit16(0x1113)
+    }
+
+    /// WAP Client (`0x1114`)
+    static var wapClient: BluetoothUUID {
+        return .bit16(0x1114)
+    }
+
+    /// PANU (`0x1115`)
+    static var panu: BluetoothUUID {
+        return .bit16(0x1115)
+    }
+
+    /// NAP (`0x1116`)
+    static var nap: BluetoothUUID {
+        return .bit16(0x1116)
+    }
+
+    /// GN (`0x1117`)
+    static var gn: BluetoothUUID {
+        return .bit16(0x1117)
+    }
+
+    /// Direct Printing (`0x1118`)
+    static var directPrinting: BluetoothUUID {
+        return .bit16(0x1118)
+    }
+
+    /// Reference Printing (`0x1119`)
+    static var referencePrinting: BluetoothUUID {
+        return .bit16(0x1119)
+    }
+
+    /// Basic Imaging Profile (`0x111A`)
+    static var basicImagingProfile: BluetoothUUID {
+        return .bit16(0x111A)
+    }
+
+    /// Imaging Responder (`0x111B`)
+    static var imagingResponder: BluetoothUUID {
+        return .bit16(0x111B)
+    }
+
+    /// Imaging Automatic Archive (`0x111C`)
+    static var imagingAutomaticArchive: BluetoothUUID {
+        return .bit16(0x111C)
+    }
+
+    /// Imaging Referenced Objects (`0x111D`)
+    static var imagingReferencedObjects: BluetoothUUID {
+        return .bit16(0x111D)
+    }
+
+    /// Handsfree (`0x111E`)
+    static var handsfree: BluetoothUUID {
+        return .bit16(0x111E)
+    }
+
+    /// Handsfree Audio Gateway (`0x111F`)
+    static var handsfreeAudioGateway: BluetoothUUID {
+        return .bit16(0x111F)
+    }
+
+    /// Direct Printing Refrence Objects Service (`0x1120`)
+    static var directPrintingRefrenceObjectsService: BluetoothUUID {
+        return .bit16(0x1120)
+    }
+
+    /// Reflected UI (`0x1121`)
+    static var reflectedUi: BluetoothUUID {
+        return .bit16(0x1121)
+    }
+
+    /// Basic Printing (`0x1122`)
+    static var basicPrinting: BluetoothUUID {
+        return .bit16(0x1122)
+    }
+
+    /// Printing Status (`0x1123`)
+    static var printingStatus: BluetoothUUID {
+        return .bit16(0x1123)
+    }
+
+    /// Human Interface Device Service (`0x1124`)
+    static var humanInterfaceDeviceService: BluetoothUUID {
+        return .bit16(0x1124)
+    }
+
+    /// Hardcopy Cable Replacement (`0x1125`)
+    static var hardcopyCableReplacement: BluetoothUUID {
+        return .bit16(0x1125)
+    }
+
+    /// HCR Print (`0x1126`)
+    static var hcrPrint: BluetoothUUID {
+        return .bit16(0x1126)
+    }
+
+    /// HCR Scan (`0x1127`)
+    static var hcrScan: BluetoothUUID {
+        return .bit16(0x1127)
+    }
+
+    /// Common ISDN Access (`0x1128`)
+    static var commonIsdnAccess: BluetoothUUID {
+        return .bit16(0x1128)
+    }
+
+    /// SIM Access (`0x112D`)
+    static var simAccess: BluetoothUUID {
+        return .bit16(0x112D)
+    }
+
+    /// Phonebook Access Client (`0x112E`)
+    static var phonebookAccessClient: BluetoothUUID {
+        return .bit16(0x112E)
+    }
+
+    /// Phonebook Access Server (`0x112F`)
+    static var phonebookAccessServer: BluetoothUUID {
+        return .bit16(0x112F)
+    }
+
+    /// Phonebook Access (`0x1130`)
+    static var phonebookAccess: BluetoothUUID {
+        return .bit16(0x1130)
+    }
+
+    /// Headset HS (`0x1131`)
+    static var headsetHs: BluetoothUUID {
+        return .bit16(0x1131)
+    }
+
+    /// Message Access Server (`0x1132`)
+    static var messageAccessServer: BluetoothUUID {
+        return .bit16(0x1132)
+    }
+
+    /// Message Notification Server (`0x1133`)
+    static var messageNotificationServer: BluetoothUUID {
+        return .bit16(0x1133)
+    }
+
+    /// Message Access Profile (`0x1134`)
+    static var messageAccessProfile: BluetoothUUID {
+        return .bit16(0x1134)
+    }
+
+    /// GNSS (`0x1135`)
+    static var gnss: BluetoothUUID {
+        return .bit16(0x1135)
+    }
+
+    /// GNSS Server (`0x1136`)
+    static var gnssServer: BluetoothUUID {
+        return .bit16(0x1136)
+    }
+
+    /// 3D Display (`0x1137`)
+    static var uuid3Ddisplay: BluetoothUUID {
+        return .bit16(0x1137)
+    }
+
+    /// 3D Glasses (`0x1138`)
+    static var uuid3Dglasses: BluetoothUUID {
+        return .bit16(0x1138)
+    }
+
+    /// 3D Synchronization (`0x1139`)
+    static var uuid3Dsynchronization: BluetoothUUID {
+        return .bit16(0x1139)
+    }
+
+    /// MPS Profile (`0x113A`)
+    static var mpsProfile: BluetoothUUID {
+        return .bit16(0x113A)
+    }
+
+    /// MPS Service (`0x113B`)
+    static var mpsService: BluetoothUUID {
+        return .bit16(0x113B)
+    }
+
+    /// PnP Information (`0x1200`)
+    static var pnpInformation: BluetoothUUID {
+        return .bit16(0x1200)
+    }
+
+    /// Generic Networking (`0x1201`)
+    static var genericNetworking: BluetoothUUID {
+        return .bit16(0x1201)
+    }
+
+    /// Generic File Transfer (`0x1202`)
+    static var genericFileTransfer: BluetoothUUID {
+        return .bit16(0x1202)
+    }
+
+    /// Generic Audio (`0x1203`)
+    static var genericAudio: BluetoothUUID {
+        return .bit16(0x1203)
+    }
+
+    /// Generic Telephony (`0x1204`)
+    static var genericTelephony: BluetoothUUID {
+        return .bit16(0x1204)
+    }
+
+    /// UPNP Service (`0x1205`)
+    static var upnpService: BluetoothUUID {
+        return .bit16(0x1205)
+    }
+
+    /// UPNP IP Service (`0x1206`)
+    static var upnpIpService: BluetoothUUID {
+        return .bit16(0x1206)
+    }
+
+    /// UPNP IP PAN (`0x1300`)
+    static var upnpIpPan: BluetoothUUID {
+        return .bit16(0x1300)
+    }
+
+    /// UPNP IP LAP (`0x1301`)
+    static var upnpIpLap: BluetoothUUID {
+        return .bit16(0x1301)
+    }
+
+    /// UPNP IP L2CAP (`0x1302`)
+    static var upnpIpL2Cap: BluetoothUUID {
+        return .bit16(0x1302)
+    }
+
+    /// Video Source (`0x1303`)
+    static var videoSource: BluetoothUUID {
+        return .bit16(0x1303)
+    }
+
+    /// Video Sink (`0x1304`)
+    static var videoSink: BluetoothUUID {
+        return .bit16(0x1304)
+    }
+
+    /// Video Distribution (`0x1305`)
+    static var videoDistribution: BluetoothUUID {
+        return .bit16(0x1305)
+    }
+
+    /// HDP (`0x1400`)
+    static var hdp: BluetoothUUID {
+        return .bit16(0x1400)
+    }
+
+    /// HDP Source (`0x1401`)
+    static var hdpSource: BluetoothUUID {
+        return .bit16(0x1401)
+    }
+
+    /// HDP Sink (`0x1402`)
+    static var hdpSink: BluetoothUUID {
+        return .bit16(0x1402)
+    }
+
+    /// Generic Access Profile (`0x1800`)
+    static var genericAccessProfile: BluetoothUUID {
+        return .bit16(0x1800)
+    }
+
+    /// Generic Attribute Profile (`0x1801`)
+    static var genericAttributeProfile: BluetoothUUID {
+        return .bit16(0x1801)
+    }
+
+    /// Immediate Alert (`0x1802`)
+    static var immediateAlert: BluetoothUUID {
+        return .bit16(0x1802)
+    }
+
+    /// Link Loss (`0x1803`)
+    static var linkLoss: BluetoothUUID {
+        return .bit16(0x1803)
+    }
+
+    /// Tx Power (`0x1804`)
+    static var txPower: BluetoothUUID {
+        return .bit16(0x1804)
+    }
+
+    /// Current Time Service (`0x1805`)
+    static var currentTimeService: BluetoothUUID {
+        return .bit16(0x1805)
+    }
+
+    /// Reference Time Update Service (`0x1806`)
+    static var referenceTimeUpdateService: BluetoothUUID {
+        return .bit16(0x1806)
+    }
+
+    /// Next DST Change Service (`0x1807`)
+    static var nextDstChangeService: BluetoothUUID {
+        return .bit16(0x1807)
+    }
+
+    /// Glucose (`0x1808`)
+    static var glucose: BluetoothUUID {
+        return .bit16(0x1808)
+    }
+
+    /// Health Thermometer (`0x1809`)
+    static var healthThermometer: BluetoothUUID {
+        return .bit16(0x1809)
+    }
+
+    /// Device Information (`0x180A`)
+    static var deviceInformation: BluetoothUUID {
+        return .bit16(0x180A)
+    }
+
+    /// Heart Rate (`0x180D`)
+    static var heartRate: BluetoothUUID {
+        return .bit16(0x180D)
+    }
+
+    /// Phone Alert Status Service (`0x180E`)
+    static var phoneAlertStatusService: BluetoothUUID {
+        return .bit16(0x180E)
+    }
+
+    /// Battery Service (`0x180F`)
+    static var batteryService: BluetoothUUID {
+        return .bit16(0x180F)
+    }
+
+    /// Blood Pressure (`0x1810`)
+    static var bloodPressure: BluetoothUUID {
+        return .bit16(0x1810)
+    }
+
+    /// Alert Notification Service (`0x1811`)
+    static var alertNotificationService: BluetoothUUID {
+        return .bit16(0x1811)
+    }
+
+    /// Human Interface Device (`0x1812`)
+    static var humanInterfaceDevice: BluetoothUUID {
+        return .bit16(0x1812)
+    }
+
+    /// Scan Parameters (`0x1813`)
+    static var scanParameters: BluetoothUUID {
+        return .bit16(0x1813)
+    }
+
+    /// Running Speed and Cadence (`0x1814`)
+    static var runningSpeedAndCadence: BluetoothUUID {
+        return .bit16(0x1814)
+    }
+
+    /// Automation IO (`0x1815`)
+    static var automationIo: BluetoothUUID {
+        return .bit16(0x1815)
+    }
+
+    /// Cycling Speed and Cadence (`0x1816`)
+    static var cyclingSpeedAndCadence: BluetoothUUID {
+        return .bit16(0x1816)
+    }
+
+    /// Cycling Power (`0x1818`)
+    static var cyclingPower: BluetoothUUID {
+        return .bit16(0x1818)
+    }
+
+    /// Location and Navigation (`0x1819`)
+    static var locationAndNavigation: BluetoothUUID {
+        return .bit16(0x1819)
+    }
+
+    /// Environmental Sensing (`0x181A`)
+    static var environmentalSensing: BluetoothUUID {
+        return .bit16(0x181A)
+    }
+
+    /// Body Composition (`0x181B`)
+    static var bodyComposition: BluetoothUUID {
+        return .bit16(0x181B)
+    }
+
+    /// User Data (`0x181C`)
+    static var userData: BluetoothUUID {
+        return .bit16(0x181C)
+    }
+
+    /// Weight Scale (`0x181D`)
+    static var weightScale: BluetoothUUID {
+        return .bit16(0x181D)
+    }
+
+    /// Bond Management (`0x181E`)
+    static var bondManagement: BluetoothUUID {
+        return .bit16(0x181E)
+    }
+
+    /// Continuous Glucose Monitoring (`0x181F`)
+    static var continuousGlucoseMonitoring: BluetoothUUID {
+        return .bit16(0x181F)
+    }
+
+    /// Internet Protocol Support (`0x1820`)
+    static var internetProtocolSupport: BluetoothUUID {
+        return .bit16(0x1820)
+    }
+
+    /// Indoor Positioning (`0x1821`)
+    static var indoorPositioning: BluetoothUUID {
+        return .bit16(0x1821)
+    }
+
+    /// Pulse Oximeter (`0x1822`)
+    static var pulseOximeter: BluetoothUUID {
+        return .bit16(0x1822)
+    }
+
+    /// HTTP Proxy (`0x1823`)
+    static var httpProxy: BluetoothUUID {
+        return .bit16(0x1823)
+    }
+
+    /// Transport Discovery (`0x1824`)
+    static var transportDiscovery: BluetoothUUID {
+        return .bit16(0x1824)
+    }
+
+    /// Object Transfer (`0x1825`)
+    static var objectTransfer: BluetoothUUID {
+        return .bit16(0x1825)
+    }
+
+    /// Primary Service (`0x2800`)
+    static var primaryService: BluetoothUUID {
+        return .bit16(0x2800)
+    }
+
+    /// Secondary Service (`0x2801`)
+    static var secondaryService: BluetoothUUID {
+        return .bit16(0x2801)
+    }
+
+    /// Include (`0x2802`)
+    static var include: BluetoothUUID {
+        return .bit16(0x2802)
+    }
+
+    /// Characteristic (`0x2803`)
+    static var characteristic: BluetoothUUID {
+        return .bit16(0x2803)
+    }
+
+    /// Characteristic Extended Properties (`0x2900`)
+    static var characteristicExtendedProperties: BluetoothUUID {
+        return .bit16(0x2900)
+    }
+
+    /// Characteristic User Description (`0x2901`)
+    static var characteristicUserDescription: BluetoothUUID {
+        return .bit16(0x2901)
+    }
+
+    /// Client Characteristic Configuration (`0x2902`)
+    static var clientCharacteristicConfiguration: BluetoothUUID {
+        return .bit16(0x2902)
+    }
+
+    /// Server Characteristic Configuration (`0x2903`)
+    static var serverCharacteristicConfiguration: BluetoothUUID {
+        return .bit16(0x2903)
+    }
+
+    /// Characteristic Format (`0x2904`)
+    static var characteristicFormat: BluetoothUUID {
+        return .bit16(0x2904)
+    }
+
+    /// Characteristic Aggregate Format (`0x2905`)
+    static var characteristicAggregateFormat: BluetoothUUID {
+        return .bit16(0x2905)
+    }
+
+    /// Valid Range (`0x2906`)
+    static var validRange: BluetoothUUID {
+        return .bit16(0x2906)
+    }
+
+    /// External Report Reference (`0x2907`)
+    static var externalReportReference: BluetoothUUID {
+        return .bit16(0x2907)
+    }
+
+    /// Report Reference (`0x2908`)
+    static var reportReference: BluetoothUUID {
+        return .bit16(0x2908)
+    }
+
+    /// Number of Digitals (`0x2909`)
+    static var numberOfDigitals: BluetoothUUID {
+        return .bit16(0x2909)
+    }
+
+    /// Value Trigger Setting (`0x290A`)
+    static var valueTriggerSetting: BluetoothUUID {
+        return .bit16(0x290A)
+    }
+
+    /// Environmental Sensing Configuration (`0x290B`)
+    static var environmentalSensingConfiguration: BluetoothUUID {
+        return .bit16(0x290B)
+    }
+
+    /// Environmental Sensing Measurement (`0x290C`)
+    static var environmentalSensingMeasurement: BluetoothUUID {
+        return .bit16(0x290C)
+    }
+
+    /// Environmental Sensing Trigger Setting (`0x290D`)
+    static var environmentalSensingTriggerSetting: BluetoothUUID {
+        return .bit16(0x290D)
+    }
+
+    /// Time Trigger Setting (`0x290E`)
+    static var timeTriggerSetting: BluetoothUUID {
+        return .bit16(0x290E)
+    }
+
+    /// Device Name (`0x2A00`)
+    static var deviceName: BluetoothUUID {
+        return .bit16(0x2A00)
+    }
+
+    /// Appearance (`0x2A01`)
+    static var appearance: BluetoothUUID {
+        return .bit16(0x2A01)
+    }
+
+    /// Peripheral Privacy Flag (`0x2A02`)
+    static var peripheralPrivacyFlag: BluetoothUUID {
+        return .bit16(0x2A02)
+    }
+
+    /// Reconnection Address (`0x2A03`)
+    static var reconnectionAddress: BluetoothUUID {
+        return .bit16(0x2A03)
+    }
+
+    /// Peripheral Preferred Connection Parameters (`0x2A04`)
+    static var peripheralPreferredConnectionParameters: BluetoothUUID {
+        return .bit16(0x2A04)
+    }
+
+    /// Service Changed (`0x2A05`)
+    static var serviceChanged: BluetoothUUID {
+        return .bit16(0x2A05)
+    }
+
+    /// Alert Level (`0x2A06`)
+    static var alertLevel: BluetoothUUID {
+        return .bit16(0x2A06)
+    }
+
+    /// Tx Power Level (`0x2A07`)
+    static var txPowerLevel: BluetoothUUID {
+        return .bit16(0x2A07)
+    }
+
+    /// Date Time (`0x2A08`)
+    static var dateTime: BluetoothUUID {
+        return .bit16(0x2A08)
+    }
+
+    /// Day of Week (`0x2A09`)
+    static var dayOfWeek: BluetoothUUID {
+        return .bit16(0x2A09)
+    }
+
+    /// Day Date Time (`0x2A0A`)
+    static var dayDateTime: BluetoothUUID {
+        return .bit16(0x2A0A)
+    }
+
+    /// Exact Time 100 (`0x2A0B`)
+    static var exactTime100: BluetoothUUID {
+        return .bit16(0x2A0B)
+    }
+
+    /// Exact Time 256 (`0x2A0C`)
+    static var exactTime256: BluetoothUUID {
+        return .bit16(0x2A0C)
+    }
+
+    /// DST Offset (`0x2A0D`)
+    static var dstOffset: BluetoothUUID {
+        return .bit16(0x2A0D)
+    }
+
+    /// Time Zone (`0x2A0E`)
+    static var timeZone: BluetoothUUID {
+        return .bit16(0x2A0E)
+    }
+
+    /// Local Time Information (`0x2A0F`)
+    static var localTimeInformation: BluetoothUUID {
+        return .bit16(0x2A0F)
+    }
+
+    /// Secondary Time Zone (`0x2A10`)
+    static var secondaryTimeZone: BluetoothUUID {
+        return .bit16(0x2A10)
+    }
+
+    /// Time with DST (`0x2A11`)
+    static var timeWithDst: BluetoothUUID {
+        return .bit16(0x2A11)
+    }
+
+    /// Time Accuracy (`0x2A12`)
+    static var timeAccuracy: BluetoothUUID {
+        return .bit16(0x2A12)
+    }
+
+    /// Time Source (`0x2A13`)
+    static var timeSource: BluetoothUUID {
+        return .bit16(0x2A13)
+    }
+
+    /// Reference Time Information (`0x2A14`)
+    static var referenceTimeInformation: BluetoothUUID {
+        return .bit16(0x2A14)
+    }
+
+    /// Time Broadcast (`0x2A15`)
+    static var timeBroadcast: BluetoothUUID {
+        return .bit16(0x2A15)
+    }
+
+    /// Time Update Control Point (`0x2A16`)
+    static var timeUpdateControlPoint: BluetoothUUID {
+        return .bit16(0x2A16)
+    }
+
+    /// Time Update State (`0x2A17`)
+    static var timeUpdateState: BluetoothUUID {
+        return .bit16(0x2A17)
+    }
+
+    /// Glucose Measurement (`0x2A18`)
+    static var glucoseMeasurement: BluetoothUUID {
+        return .bit16(0x2A18)
+    }
+
+    /// Battery Level (`0x2A19`)
+    static var batteryLevel: BluetoothUUID {
+        return .bit16(0x2A19)
+    }
+
+    /// Battery Power State (`0x2A1A`)
+    static var batteryPowerState: BluetoothUUID {
+        return .bit16(0x2A1A)
+    }
+
+    /// Battery Level State (`0x2A1B`)
+    static var batteryLevelState: BluetoothUUID {
+        return .bit16(0x2A1B)
+    }
+
+    /// Temperature Measurement (`0x2A1C`)
+    static var temperatureMeasurement: BluetoothUUID {
+        return .bit16(0x2A1C)
+    }
+
+    /// Temperature Type (`0x2A1D`)
+    static var temperatureType: BluetoothUUID {
+        return .bit16(0x2A1D)
+    }
+
+    /// Intermediate Temperature (`0x2A1E`)
+    static var intermediateTemperature: BluetoothUUID {
+        return .bit16(0x2A1E)
+    }
+
+    /// Measurement Interval (`0x2A21`)
+    static var measurementInterval: BluetoothUUID {
+        return .bit16(0x2A21)
+    }
+
+    /// Boot Keyboard Input Report (`0x2A22`)
+    static var bootKeyboardInputReport: BluetoothUUID {
+        return .bit16(0x2A22)
+    }
+
+    /// System ID (`0x2A23`)
+    static var systemId: BluetoothUUID {
+        return .bit16(0x2A23)
+    }
+
+    /// Model Number String (`0x2A24`)
+    static var modelNumberString: BluetoothUUID {
+        return .bit16(0x2A24)
+    }
+
+    /// Serial Number String (`0x2A25`)
+    static var serialNumberString: BluetoothUUID {
+        return .bit16(0x2A25)
+    }
+
+    /// Firmware Revision String (`0x2A26`)
+    static var firmwareRevisionString: BluetoothUUID {
+        return .bit16(0x2A26)
+    }
+
+    /// Hardware Revision String (`0x2A27`)
+    static var hardwareRevisionString: BluetoothUUID {
+        return .bit16(0x2A27)
+    }
+
+    /// Software Revision String (`0x2A28`)
+    static var softwareRevisionString: BluetoothUUID {
+        return .bit16(0x2A28)
+    }
+
+    /// Manufacturer Name String (`0x2A29`)
+    static var manufacturerNameString: BluetoothUUID {
+        return .bit16(0x2A29)
+    }
+
+    /// IEEE 11073-20601 Regulatory Cert. Data List (`0x2A2A`)
+    static var ieee1107320601RegulatoryCertDataList: BluetoothUUID {
+        return .bit16(0x2A2A)
+    }
+
+    /// Current Time (`0x2A2B`)
+    static var currentTime: BluetoothUUID {
+        return .bit16(0x2A2B)
+    }
+
+    /// Magnetic Declination (`0x2A2C`)
+    static var magneticDeclination: BluetoothUUID {
+        return .bit16(0x2A2C)
+    }
+
+    /// Scan Refresh (`0x2A31`)
+    static var scanRefresh: BluetoothUUID {
+        return .bit16(0x2A31)
+    }
+
+    /// Boot Keyboard Output Report (`0x2A32`)
+    static var bootKeyboardOutputReport: BluetoothUUID {
+        return .bit16(0x2A32)
+    }
+
+    /// Boot Mouse Input Report (`0x2A33`)
+    static var bootMouseInputReport: BluetoothUUID {
+        return .bit16(0x2A33)
+    }
+
+    /// Glucose Measurement Context (`0x2A34`)
+    static var glucoseMeasurementContext: BluetoothUUID {
+        return .bit16(0x2A34)
+    }
+
+    /// Blood Pressure Measurement (`0x2A35`)
+    static var bloodPressureMeasurement: BluetoothUUID {
+        return .bit16(0x2A35)
+    }
+
+    /// Intermediate Cuff Pressure (`0x2A36`)
+    static var intermediateCuffPressure: BluetoothUUID {
+        return .bit16(0x2A36)
+    }
+
+    /// Heart Rate Measurement (`0x2A37`)
+    static var heartRateMeasurement: BluetoothUUID {
+        return .bit16(0x2A37)
+    }
+
+    /// Body Sensor Location (`0x2A38`)
+    static var bodySensorLocation: BluetoothUUID {
+        return .bit16(0x2A38)
+    }
+
+    /// Heart Rate Control Point (`0x2A39`)
+    static var heartRateControlPoint: BluetoothUUID {
+        return .bit16(0x2A39)
+    }
+
+    /// Alert Status (`0x2A3F`)
+    static var alertStatus: BluetoothUUID {
+        return .bit16(0x2A3F)
+    }
+
+    /// Ringer Control Point (`0x2A40`)
+    static var ringerControlPoint: BluetoothUUID {
+        return .bit16(0x2A40)
+    }
+
+    /// Ringer Setting (`0x2A41`)
+    static var ringerSetting: BluetoothUUID {
+        return .bit16(0x2A41)
+    }
+
+    /// Alert Category ID Bit Mask (`0x2A42`)
+    static var alertCategoryIdBitMask: BluetoothUUID {
+        return .bit16(0x2A42)
+    }
+
+    /// Alert Category ID (`0x2A43`)
+    static var alertCategoryId: BluetoothUUID {
+        return .bit16(0x2A43)
+    }
+
+    /// Alert Notification Control Point (`0x2A44`)
+    static var alertNotificationControlPoint: BluetoothUUID {
+        return .bit16(0x2A44)
+    }
+
+    /// Unread Alert Status (`0x2A45`)
+    static var unreadAlertStatus: BluetoothUUID {
+        return .bit16(0x2A45)
+    }
+
+    /// New Alert (`0x2A46`)
+    static var newAlert: BluetoothUUID {
+        return .bit16(0x2A46)
+    }
+
+    /// Supported New Alert Category (`0x2A47`)
+    static var supportedNewAlertCategory: BluetoothUUID {
+        return .bit16(0x2A47)
+    }
+
+    /// Supported Unread Alert Category (`0x2A48`)
+    static var supportedUnreadAlertCategory: BluetoothUUID {
+        return .bit16(0x2A48)
+    }
+
+    /// Blood Pressure Feature (`0x2A49`)
+    static var bloodPressureFeature: BluetoothUUID {
+        return .bit16(0x2A49)
+    }
+
+    /// HID Information (`0x2A4A`)
+    static var hidInformation: BluetoothUUID {
+        return .bit16(0x2A4A)
+    }
+
+    /// Report Map (`0x2A4B`)
+    static var reportMap: BluetoothUUID {
+        return .bit16(0x2A4B)
+    }
+
+    /// HID Control Point (`0x2A4C`)
+    static var hidControlPoint: BluetoothUUID {
+        return .bit16(0x2A4C)
+    }
+
+    /// Report (`0x2A4D`)
+    static var report: BluetoothUUID {
+        return .bit16(0x2A4D)
+    }
+
+    /// Protocol Mode (`0x2A4E`)
+    static var protocolMode: BluetoothUUID {
+        return .bit16(0x2A4E)
+    }
+
+    /// Scan Interval Window (`0x2A4F`)
+    static var scanIntervalWindow: BluetoothUUID {
+        return .bit16(0x2A4F)
+    }
+
+    /// PnP ID (`0x2A50`)
+    static var pnpId: BluetoothUUID {
+        return .bit16(0x2A50)
+    }
+
+    /// Glucose Feature (`0x2A51`)
+    static var glucoseFeature: BluetoothUUID {
+        return .bit16(0x2A51)
+    }
+
+    /// Record Access Control Point (`0x2A52`)
+    static var recordAccessControlPoint: BluetoothUUID {
+        return .bit16(0x2A52)
+    }
+
+    /// RSC Measurement (`0x2A53`)
+    static var rscMeasurement: BluetoothUUID {
+        return .bit16(0x2A53)
+    }
+
+    /// RSC Feature (`0x2A54`)
+    static var rscFeature: BluetoothUUID {
+        return .bit16(0x2A54)
+    }
+
+    /// SC Control Point (`0x2A55`)
+    static var scControlPoint: BluetoothUUID {
+        return .bit16(0x2A55)
+    }
+
+    /// Digital (`0x2A56`)
+    static var digital: BluetoothUUID {
+        return .bit16(0x2A56)
+    }
+
+    /// Analog (`0x2A58`)
+    static var analog: BluetoothUUID {
+        return .bit16(0x2A58)
+    }
+
+    /// Analog Output (`0x2A59`)
+    static var analogOutput: BluetoothUUID {
+        return .bit16(0x2A59)
+    }
+
+    /// Aggregate (`0x2A5A`)
+    static var aggregate: BluetoothUUID {
+        return .bit16(0x2A5A)
+    }
+
+    /// CSC Measurement (`0x2A5B`)
+    static var cscMeasurement: BluetoothUUID {
+        return .bit16(0x2A5B)
+    }
+
+    /// CSC Feature (`0x2A5C`)
+    static var cscFeature: BluetoothUUID {
+        return .bit16(0x2A5C)
+    }
+
+    /// Sensor Location (`0x2A5D`)
+    static var sensorLocation: BluetoothUUID {
+        return .bit16(0x2A5D)
+    }
+
+    /// Cycling Power Measurement (`0x2A63`)
+    static var cyclingPowerMeasurement: BluetoothUUID {
+        return .bit16(0x2A63)
+    }
+
+    /// Cycling Power Vector (`0x2A64`)
+    static var cyclingPowerVector: BluetoothUUID {
+        return .bit16(0x2A64)
+    }
+
+    /// Cycling Power Feature (`0x2A65`)
+    static var cyclingPowerFeature: BluetoothUUID {
+        return .bit16(0x2A65)
+    }
+
+    /// Cycling Power Control Point (`0x2A66`)
+    static var cyclingPowerControlPoint: BluetoothUUID {
+        return .bit16(0x2A66)
+    }
+
+    /// Location and Speed (`0x2A67`)
+    static var locationAndSpeed: BluetoothUUID {
+        return .bit16(0x2A67)
+    }
+
+    /// Navigation (`0x2A68`)
+    static var navigation: BluetoothUUID {
+        return .bit16(0x2A68)
+    }
+
+    /// Position Quality (`0x2A69`)
+    static var positionQuality: BluetoothUUID {
+        return .bit16(0x2A69)
+    }
+
+    /// LN Feature (`0x2A6A`)
+    static var lnFeature: BluetoothUUID {
+        return .bit16(0x2A6A)
+    }
+
+    /// LN Control Point (`0x2A6B`)
+    static var lnControlPoint: BluetoothUUID {
+        return .bit16(0x2A6B)
+    }
+
+    /// Elevation (`0x2A6C`)
+    static var elevation: BluetoothUUID {
+        return .bit16(0x2A6C)
+    }
+
+    /// Pressure (`0x2A6D`)
+    static var pressure: BluetoothUUID {
+        return .bit16(0x2A6D)
+    }
+
+    /// Temperature (`0x2A6E`)
+    static var temperature: BluetoothUUID {
+        return .bit16(0x2A6E)
+    }
+
+    /// Humidity (`0x2A6F`)
+    static var humidity: BluetoothUUID {
+        return .bit16(0x2A6F)
+    }
+
+    /// True Wind Speed (`0x2A70`)
+    static var trueWindSpeed: BluetoothUUID {
+        return .bit16(0x2A70)
+    }
+
+    /// True Wind Direction (`0x2A71`)
+    static var trueWindDirection: BluetoothUUID {
+        return .bit16(0x2A71)
+    }
+
+    /// Apparent Wind Speed (`0x2A72`)
+    static var apparentWindSpeed: BluetoothUUID {
+        return .bit16(0x2A72)
+    }
+
+    /// Apparent Wind Direction (`0x2A73`)
+    static var apparentWindDirection: BluetoothUUID {
+        return .bit16(0x2A73)
+    }
+
+    /// Gust Factor (`0x2A74`)
+    static var gustFactor: BluetoothUUID {
+        return .bit16(0x2A74)
+    }
+
+    /// Pollen Concentration (`0x2A75`)
+    static var pollenConcentration: BluetoothUUID {
+        return .bit16(0x2A75)
+    }
+
+    /// UV Index (`0x2A76`)
+    static var uvIndex: BluetoothUUID {
+        return .bit16(0x2A76)
+    }
+
+    /// Irradiance (`0x2A77`)
+    static var irradiance: BluetoothUUID {
+        return .bit16(0x2A77)
+    }
+
+    /// Rainfall (`0x2A78`)
+    static var rainfall: BluetoothUUID {
+        return .bit16(0x2A78)
+    }
+
+    /// Wind Chill (`0x2A79`)
+    static var windChill: BluetoothUUID {
+        return .bit16(0x2A79)
+    }
+
+    /// Heat Index (`0x2A7A`)
+    static var heatIndex: BluetoothUUID {
+        return .bit16(0x2A7A)
+    }
+
+    /// Dew Point (`0x2A7B`)
+    static var dewPoint: BluetoothUUID {
+        return .bit16(0x2A7B)
+    }
+
+    /// Trend (`0x2A7C`)
+    static var trend: BluetoothUUID {
+        return .bit16(0x2A7C)
+    }
+
+    /// Descriptor Value Changed (`0x2A7D`)
+    static var descriptorValueChanged: BluetoothUUID {
+        return .bit16(0x2A7D)
+    }
+
+    /// Aerobic Heart Rate Lower Limit (`0x2A7E`)
+    static var aerobicHeartRateLowerLimit: BluetoothUUID {
+        return .bit16(0x2A7E)
+    }
+
+    /// Aerobic Threshold (`0x2A7F`)
+    static var aerobicThreshold: BluetoothUUID {
+        return .bit16(0x2A7F)
+    }
+
+    /// Age (`0x2A80`)
+    static var age: BluetoothUUID {
+        return .bit16(0x2A80)
+    }
+
+    /// Anaerobic Heart Rate Lower Limit (`0x2A81`)
+    static var anaerobicHeartRateLowerLimit: BluetoothUUID {
+        return .bit16(0x2A81)
+    }
+
+    /// Anaerobic Heart Rate Upper Limit (`0x2A82`)
+    static var anaerobicHeartRateUpperLimit: BluetoothUUID {
+        return .bit16(0x2A82)
+    }
+
+    /// Anaerobic Threshold (`0x2A83`)
+    static var anaerobicThreshold: BluetoothUUID {
+        return .bit16(0x2A83)
+    }
+
+    /// Aerobic Heart Rate Upper Limit (`0x2A84`)
+    static var aerobicHeartRateUpperLimit: BluetoothUUID {
+        return .bit16(0x2A84)
+    }
+
+    /// Date of Birth (`0x2A85`)
+    static var dateOfBirth: BluetoothUUID {
+        return .bit16(0x2A85)
+    }
+
+    /// Date of Threshold Assessment (`0x2A86`)
+    static var dateOfThresholdAssessment: BluetoothUUID {
+        return .bit16(0x2A86)
+    }
+
+    /// Email Address (`0x2A87`)
+    static var emailAddress: BluetoothUUID {
+        return .bit16(0x2A87)
+    }
+
+    /// Fat Burn Heart Rate Lower Limit (`0x2A88`)
+    static var fatBurnHeartRateLowerLimit: BluetoothUUID {
+        return .bit16(0x2A88)
+    }
+
+    /// Fat Burn Heart Rate Upper Limit (`0x2A89`)
+    static var fatBurnHeartRateUpperLimit: BluetoothUUID {
+        return .bit16(0x2A89)
+    }
+
+    /// First Name (`0x2A8A`)
+    static var firstName: BluetoothUUID {
+        return .bit16(0x2A8A)
+    }
+
+    /// Five Zone Heart Rate Limits (`0x2A8B`)
+    static var fiveZoneHeartRateLimits: BluetoothUUID {
+        return .bit16(0x2A8B)
+    }
+
+    /// Gender (`0x2A8C`)
+    static var gender: BluetoothUUID {
+        return .bit16(0x2A8C)
+    }
+
+    /// Heart Rate Max (`0x2A8D`)
+    static var heartRateMax: BluetoothUUID {
+        return .bit16(0x2A8D)
+    }
+
+    /// Height (`0x2A8E`)
+    static var height: BluetoothUUID {
+        return .bit16(0x2A8E)
+    }
+
+    /// Hip Circumference (`0x2A8F`)
+    static var hipCircumference: BluetoothUUID {
+        return .bit16(0x2A8F)
+    }
+
+    /// Last Name (`0x2A90`)
+    static var lastName: BluetoothUUID {
+        return .bit16(0x2A90)
+    }
+
+    /// Maximum Recommended Heart Rate (`0x2A91`)
+    static var maximumRecommendedHeartRate: BluetoothUUID {
+        return .bit16(0x2A91)
+    }
+
+    /// Resting Heart Rate (`0x2A92`)
+    static var restingHeartRate: BluetoothUUID {
+        return .bit16(0x2A92)
+    }
+
+    /// Sport Type for Aerobic/Anaerobic Thresholds (`0x2A93`)
+    static var sportTypeForAerobicAnaerobicThresholds: BluetoothUUID {
+        return .bit16(0x2A93)
+    }
+
+    /// Three Zone Heart Rate Limits (`0x2A94`)
+    static var threeZoneHeartRateLimits: BluetoothUUID {
+        return .bit16(0x2A94)
+    }
+
+    /// Two Zone Heart Rate Limit (`0x2A95`)
+    static var twoZoneHeartRateLimit: BluetoothUUID {
+        return .bit16(0x2A95)
+    }
+
+    /// VO2 Max (`0x2A96`)
+    static var vo2Max: BluetoothUUID {
+        return .bit16(0x2A96)
+    }
+
+    /// Waist Circumference (`0x2A97`)
+    static var waistCircumference: BluetoothUUID {
+        return .bit16(0x2A97)
+    }
+
+    /// Weight (`0x2A98`)
+    static var weight: BluetoothUUID {
+        return .bit16(0x2A98)
+    }
+
+    /// Database Change Increment (`0x2A99`)
+    static var databaseChangerement: BluetoothUUID {
+        return .bit16(0x2A99)
+    }
+
+    /// User Index (`0x2A9A`)
+    static var userIndex: BluetoothUUID {
+        return .bit16(0x2A9A)
+    }
+
+    /// Body Composition Feature (`0x2A9B`)
+    static var bodyCompositionFeature: BluetoothUUID {
+        return .bit16(0x2A9B)
+    }
+
+    /// Body Composition Measurement (`0x2A9C`)
+    static var bodyCompositionMeasurement: BluetoothUUID {
+        return .bit16(0x2A9C)
+    }
+
+    /// Weight Measurement (`0x2A9D`)
+    static var weightMeasurement: BluetoothUUID {
+        return .bit16(0x2A9D)
+    }
+
+    /// Weight Scale Feature (`0x2A9E`)
+    static var weightScaleFeature: BluetoothUUID {
+        return .bit16(0x2A9E)
+    }
+
+    /// User Control Point (`0x2A9F`)
+    static var userControlPoint: BluetoothUUID {
+        return .bit16(0x2A9F)
+    }
+
+    /// Magnetic Flux Density - 2D (`0x2AA0`)
+    static var magneticFluxDensity2D: BluetoothUUID {
+        return .bit16(0x2AA0)
+    }
+
+    /// Magnetic Flux Density - 3D (`0x2AA1`)
+    static var magneticFluxDensity3D: BluetoothUUID {
+        return .bit16(0x2AA1)
+    }
+
+    /// Language (`0x2AA2`)
+    static var language: BluetoothUUID {
+        return .bit16(0x2AA2)
+    }
+
+    /// Barometric Pressure Trend (`0x2AA3`)
+    static var barometricPressureTrend: BluetoothUUID {
+        return .bit16(0x2AA3)
+    }
+
+    /// Bond Management Control Point (`0x2AA4`)
+    static var bondManagementControlPoint: BluetoothUUID {
+        return .bit16(0x2AA4)
+    }
+
+    /// Bond Management Feature (`0x2AA5`)
+    static var bondManagementFeature: BluetoothUUID {
+        return .bit16(0x2AA5)
+    }
+
+    /// Central Address Resolution (`0x2AA6`)
+    static var centralAddressResolution: BluetoothUUID {
+        return .bit16(0x2AA6)
+    }
+
+    /// CGM Measurement (`0x2AA7`)
+    static var cgmMeasurement: BluetoothUUID {
+        return .bit16(0x2AA7)
+    }
+
+    /// CGM Feature (`0x2AA8`)
+    static var cgmFeature: BluetoothUUID {
+        return .bit16(0x2AA8)
+    }
+
+    /// CGM Status (`0x2AA9`)
+    static var cgmStatus: BluetoothUUID {
+        return .bit16(0x2AA9)
+    }
+
+    /// CGM Session Start Time (`0x2AAA`)
+    static var cgmSessionStartTime: BluetoothUUID {
+        return .bit16(0x2AAA)
+    }
+
+    /// CGM Session Run Time (`0x2AAB`)
+    static var cgmSessionRunTime: BluetoothUUID {
+        return .bit16(0x2AAB)
+    }
+
+    /// CGM Specific Ops Control Point (`0x2AAC`)
+    static var cgmSpecificOpsControlPoint: BluetoothUUID {
+        return .bit16(0x2AAC)
+    }
+
+    /// Indoor Positioning Configuration (`0x2AAD`)
+    static var indoorPositioningConfiguration: BluetoothUUID {
+        return .bit16(0x2AAD)
+    }
+
+    /// Latitude (`0x2AAE`)
+    static var latitude: BluetoothUUID {
+        return .bit16(0x2AAE)
+    }
+
+    /// Longitude (`0x2AAF`)
+    static var longitude: BluetoothUUID {
+        return .bit16(0x2AAF)
+    }
+
+    /// Local North Coordinate (`0x2AB0`)
+    static var localNorthCoordinate: BluetoothUUID {
+        return .bit16(0x2AB0)
+    }
+
+    /// Local East Coordinate (`0x2AB1`)
+    static var localEastCoordinate: BluetoothUUID {
+        return .bit16(0x2AB1)
+    }
+
+    /// Floor Number (`0x2AB2`)
+    static var floorNumber: BluetoothUUID {
+        return .bit16(0x2AB2)
+    }
+
+    /// Altitude (`0x2AB3`)
+    static var altitude: BluetoothUUID {
+        return .bit16(0x2AB3)
+    }
+
+    /// Uncertainty (`0x2AB4`)
+    static var uncertainty: BluetoothUUID {
+        return .bit16(0x2AB4)
+    }
+
+    /// Location Name (`0x2AB5`)
+    static var locationName: BluetoothUUID {
+        return .bit16(0x2AB5)
+    }
+
+    /// URI (`0x2AB6`)
+    static var uri: BluetoothUUID {
+        return .bit16(0x2AB6)
+    }
+
+    /// HTTP Headers (`0x2AB7`)
+    static var httpHeaders: BluetoothUUID {
+        return .bit16(0x2AB7)
+    }
+
+    /// HTTP Status Code (`0x2AB8`)
+    static var httpStatusCode: BluetoothUUID {
+        return .bit16(0x2AB8)
+    }
+
+    /// HTTP Entity Body (`0x2AB9`)
+    static var httpEntityBody: BluetoothUUID {
+        return .bit16(0x2AB9)
+    }
+
+    /// HTTP Control Point (`0x2ABA`)
+    static var httpControlPoint: BluetoothUUID {
+        return .bit16(0x2ABA)
+    }
+
+    /// HTTPS Security (`0x2ABB`)
+    static var httpsSecurity: BluetoothUUID {
+        return .bit16(0x2ABB)
+    }
+
+    /// TDS Control Point (`0x2ABC`)
+    static var tdsControlPoint: BluetoothUUID {
+        return .bit16(0x2ABC)
+    }
+
+    /// OTS Feature (`0x2ABD`)
+    static var otsFeature: BluetoothUUID {
+        return .bit16(0x2ABD)
+    }
+
+    /// Object Name (`0x2ABE`)
+    static var objectName: BluetoothUUID {
+        return .bit16(0x2ABE)
+    }
+
+    /// Object Type (`0x2ABF`)
+    static var objectType: BluetoothUUID {
+        return .bit16(0x2ABF)
+    }
+
+    /// Object Size (`0x2AC0`)
+    static var objectSize: BluetoothUUID {
+        return .bit16(0x2AC0)
+    }
+
+    /// Object First-Created (`0x2AC1`)
+    static var objectFirstCreated: BluetoothUUID {
+        return .bit16(0x2AC1)
+    }
+
+    /// Object Last-Modified (`0x2AC2`)
+    static var objectLastModified: BluetoothUUID {
+        return .bit16(0x2AC2)
+    }
+
+    /// Object ID (`0x2AC3`)
+    static var objectId: BluetoothUUID {
+        return .bit16(0x2AC3)
+    }
+
+    /// Object Properties (`0x2AC4`)
+    static var objectProperties: BluetoothUUID {
+        return .bit16(0x2AC4)
+    }
+
+    /// Object Action Control Point (`0x2AC5`)
+    static var objectActionControlPoint: BluetoothUUID {
+        return .bit16(0x2AC5)
+    }
+
+    /// Object List Control Point (`0x2AC6`)
+    static var objectListControlPoint: BluetoothUUID {
+        return .bit16(0x2AC6)
+    }
+
+    /// Object List Filter (`0x2AC7`)
+    static var objectListFilter: BluetoothUUID {
+        return .bit16(0x2AC7)
+    }
+
+    /// Object Changed (`0x2AC8`)
+    static var objectChanged: BluetoothUUID {
+        return .bit16(0x2AC8)
+    }
+
+    /// Cross Trainer Data (`0x2ACE`)
+    static var crossTrainerData: BluetoothUUID {
+        return .bit16(0x2ACE)
+    }
+
+    /// Date UTC (`0x2AED`)
+    static var dateUtc: BluetoothUUID {
+        return .bit16(0x2AED)
+    }
+
+    /// Abbott Diabetes Care (`0xFDE3`)
+    static var abbottDiabetesCare: BluetoothUUID {
+        return .bit16(0xFDE3)
+    }
+
+    /// JUUL Labs, Inc. (`0xFDE4`)
+    static var juulLabs: BluetoothUUID {
+        return .bit16(0xFDE4)
+    }
+
+    /// SMK Corporation (`0xFDE5`)
+    static var smk: BluetoothUUID {
+        return .bit16(0xFDE5)
+    }
+
+    /// Intelletto Technologies Inc (`0xFDE6`)
+    static var intellettoTechnologies: BluetoothUUID {
+        return .bit16(0xFDE6)
+    }
+
+    /// SECOM Co., LTD (`0xFDE7`)
+    static var secom: BluetoothUUID {
+        return .bit16(0xFDE7)
+    }
+
+    /// Robert Bosch GmbH (`0xFDE8`)
+    static var robertBosch: BluetoothUUID {
+        return .bit16(0xFDE8)
+    }
+
+    /// Spacesaver Corporation (`0xFDE9`)
+    static var spacesaver: BluetoothUUID {
+        return .bit16(0xFDE9)
+    }
+
+    /// SeeScan, Inc (`0xFDEA`)
+    static var seescan: BluetoothUUID {
+        return .bit16(0xFDEA)
+    }
+
+    /// Syntronix Corporation (`0xFDEB`)
+    static var syntronix: BluetoothUUID {
+        return .bit16(0xFDEB)
+    }
+
+    /// Mannkind Corporation (`0xFDEC`)
+    static var mannkind: BluetoothUUID {
+        return .bit16(0xFDEC)
+    }
+
+    /// Pole Star (`0xFDED`)
+    static var poleStar: BluetoothUUID {
+        return .bit16(0xFDED)
+    }
+
+    /// Huawei Technologies Co., Ltd. (`0xFDEE`)
+    static var huaweiTechnologies: BluetoothUUID {
+        return .bit16(0xFDEE)
+    }
+
+    /// ART AND PROGRAM, INC. (`0xFDEF`)
+    static var artAndProgram: BluetoothUUID {
+        return .bit16(0xFDEF)
+    }
+
+    /// Google Inc. (`0xFDF0`)
+    static var google: BluetoothUUID {
+        return .bit16(0xFDF0)
+    }
+
+    /// LAMPLIGHT Co.,Ltd (`0xFDF1`)
+    static var lamplight: BluetoothUUID {
+        return .bit16(0xFDF1)
+    }
+
+    /// AMICCOM Electronics Corporation (`0xFDF2`)
+    static var amiccomElectronics: BluetoothUUID {
+        return .bit16(0xFDF2)
+    }
+
+    /// Amersports (`0xFDF3`)
+    static var amersports: BluetoothUUID {
+        return .bit16(0xFDF3)
+    }
+
+    /// O. E. M. Controls, Inc. (`0xFDF4`)
+    static var oEMControls: BluetoothUUID {
+        return .bit16(0xFDF4)
+    }
+
+    /// Milwaukee Electric Tools (`0xFDF5`)
+    static var milwaukeeElectricTools: BluetoothUUID {
+        return .bit16(0xFDF5)
+    }
+
+    /// AIAIAI ApS (`0xFDF6`)
+    static var aiaiai: BluetoothUUID {
+        return .bit16(0xFDF6)
+    }
+
+    /// HP Inc. (`0xFDF7`)
+    static var hp: BluetoothUUID {
+        return .bit16(0xFDF7)
+    }
+
+    /// Onvocal (`0xFDF8`)
+    static var onvocal: BluetoothUUID {
+        return .bit16(0xFDF8)
+    }
+
+    /// INIA (`0xFDF9`)
+    static var inia: BluetoothUUID {
+        return .bit16(0xFDF9)
+    }
+
+    /// Tandem Diabetes Care (`0xFDFA`)
+    static var tandemDiabetesCare: BluetoothUUID {
+        return .bit16(0xFDFA)
+    }
+
+    /// Tandem Diabetes Care (`0xFDFB`)
+    static var tandemDiabetesCare2: BluetoothUUID {
+        return .bit16(0xFDFB)
+    }
+
+    /// Optrel AG (`0xFDFC`)
+    static var optrel: BluetoothUUID {
+        return .bit16(0xFDFC)
+    }
+
+    /// RecursiveSoft Inc. (`0xFDFD`)
+    static var recursivesoft: BluetoothUUID {
+        return .bit16(0xFDFD)
+    }
+
+    /// ADHERIUM(NZ) LIMITED (`0xFDFE`)
+    static var adheriumNzLimited: BluetoothUUID {
+        return .bit16(0xFDFE)
+    }
+
+    /// OSRAM GmbH (`0xFDFF`)
+    static var osram: BluetoothUUID {
+        return .bit16(0xFDFF)
+    }
+
+    /// Amazon.com Services, Inc. (`0xFE00`)
+    static var amazon: BluetoothUUID {
+        return .bit16(0xFE00)
+    }
+
+    /// Duracell U.S. Operations Inc. (`0xFE01`)
+    static var duracellUSOperations: BluetoothUUID {
+        return .bit16(0xFE01)
+    }
+
+    /// Robert Bosch GmbH (`0xFE02`)
+    static var robertBosch2: BluetoothUUID {
+        return .bit16(0xFE02)
+    }
+
+    /// Amazon.com Services, Inc. (`0xFE03`)
+    static var amazon2: BluetoothUUID {
+        return .bit16(0xFE03)
+    }
+
+    /// OpenPath Security Inc (`0xFE04`)
+    static var openpathSecurity: BluetoothUUID {
+        return .bit16(0xFE04)
+    }
+
+    /// CORE Transport Technologies NZ Limited (`0xFE05`)
+    static var coreTransportTechnologiesNz: BluetoothUUID {
+        return .bit16(0xFE05)
+    }
+
+    /// Qualcomm Technologies, Inc. (`0xFE06`)
+    static var qualcommTechnologies: BluetoothUUID {
+        return .bit16(0xFE06)
+    }
+
+    /// Microsoft (`0xFE08`)
+    static var microsoft: BluetoothUUID {
+        return .bit16(0xFE08)
+    }
+
+    /// Pillsy, Inc. (`0xFE09`)
+    static var pillsy: BluetoothUUID {
+        return .bit16(0xFE09)
+    }
+
+    /// ruwido austria gmbh (`0xFE0A`)
+    static var ruwidoAustria: BluetoothUUID {
+        return .bit16(0xFE0A)
+    }
+
+    /// ruwido austria gmbh (`0xFE0B`)
+    static var ruwidoAustria2: BluetoothUUID {
+        return .bit16(0xFE0B)
+    }
+
+    /// Procter & Gamble (`0xFE0C`)
+    static var procterGamble: BluetoothUUID {
+        return .bit16(0xFE0C)
+    }
+
+    /// Procter & Gamble (`0xFE0D`)
+    static var procterGamble2: BluetoothUUID {
+        return .bit16(0xFE0D)
+    }
+
+    /// Setec Pty Ltd (`0xFE0E`)
+    static var setecPty: BluetoothUUID {
+        return .bit16(0xFE0E)
+    }
+
+    /// Philips Lighting B.V. (`0xFE0F`)
+    static var philipsLighting: BluetoothUUID {
+        return .bit16(0xFE0F)
+    }
+
+    /// Lapis Semiconductor Co., Ltd. (`0xFE10`)
+    static var lapisSemiconductor: BluetoothUUID {
+        return .bit16(0xFE10)
+    }
+
+    /// GMC-I Messtechnik GmbH (`0xFE11`)
+    static var gmcIMesstechnik: BluetoothUUID {
+        return .bit16(0xFE11)
+    }
+
+    /// M-Way Solutions GmbH (`0xFE12`)
+    static var mWaySolutions: BluetoothUUID {
+        return .bit16(0xFE12)
+    }
+
+    /// Apple Inc. (`0xFE13`)
+    static var apple: BluetoothUUID {
+        return .bit16(0xFE13)
+    }
+
+    /// Flextronics International USA Inc. (`0xFE14`)
+    static var flextronicsInternationalUsa: BluetoothUUID {
+        return .bit16(0xFE14)
+    }
+
+    /// Amazon.com Services, Inc. (`0xFE15`)
+    static var amazon3: BluetoothUUID {
+        return .bit16(0xFE15)
+    }
+
+    /// Footmarks, Inc. (`0xFE16`)
+    static var footmarks: BluetoothUUID {
+        return .bit16(0xFE16)
+    }
+
+    /// Telit Wireless Solutions GmbH (`0xFE17`)
+    static var telitWirelessSolutions: BluetoothUUID {
+        return .bit16(0xFE17)
+    }
+
+    /// Runtime, Inc. (`0xFE18`)
+    static var runtime: BluetoothUUID {
+        return .bit16(0xFE18)
+    }
+
+    /// Google Inc. (`0xFE19`)
+    static var google2: BluetoothUUID {
+        return .bit16(0xFE19)
+    }
+
+    /// Tyto Life LLC (`0xFE1A`)
+    static var tytoLife: BluetoothUUID {
+        return .bit16(0xFE1A)
+    }
+
+    /// Tyto Life LLC (`0xFE1B`)
+    static var tytoLife2: BluetoothUUID {
+        return .bit16(0xFE1B)
+    }
+
+    /// NetMedia, Inc. (`0xFE1C`)
+    static var netmedia: BluetoothUUID {
+        return .bit16(0xFE1C)
+    }
+
+    /// Illuminati Instrument Corporation (`0xFE1D`)
+    static var illuminatiInstrument: BluetoothUUID {
+        return .bit16(0xFE1D)
+    }
+
+    /// Smart Innovations Co., Ltd (`0xFE1E`)
+    static var smartInnovations: BluetoothUUID {
+        return .bit16(0xFE1E)
+    }
+
+    /// Garmin International, Inc. (`0xFE1F`)
+    static var garminInternational: BluetoothUUID {
+        return .bit16(0xFE1F)
+    }
+
+    /// Emerson (`0xFE20`)
+    static var emerson: BluetoothUUID {
+        return .bit16(0xFE20)
+    }
+
+    /// Bose Corporation (`0xFE21`)
+    static var bose: BluetoothUUID {
+        return .bit16(0xFE21)
+    }
+
+    /// Zoll Medical Corporation (`0xFE22`)
+    static var zollMedical: BluetoothUUID {
+        return .bit16(0xFE22)
+    }
+
+    /// Zoll Medical Corporation (`0xFE23`)
+    static var zollMedical2: BluetoothUUID {
+        return .bit16(0xFE23)
+    }
+
+    /// August Home Inc (`0xFE24`)
+    static var augustHome: BluetoothUUID {
+        return .bit16(0xFE24)
+    }
+
+    /// Apple, Inc. (`0xFE25`)
+    static var apple2: BluetoothUUID {
+        return .bit16(0xFE25)
+    }
+
+    /// Google Inc. (`0xFE26`)
+    static var google3: BluetoothUUID {
+        return .bit16(0xFE26)
+    }
+
+    /// Google Inc. (`0xFE27`)
+    static var google4: BluetoothUUID {
+        return .bit16(0xFE27)
+    }
+
+    /// Ayla Networks (`0xFE28`)
+    static var aylaNetworks: BluetoothUUID {
+        return .bit16(0xFE28)
+    }
+
+    /// Gibson Innovations (`0xFE29`)
+    static var gibsonInnovations: BluetoothUUID {
+        return .bit16(0xFE29)
+    }
+
+    /// DaisyWorks, Inc. (`0xFE2A`)
+    static var daisyworks: BluetoothUUID {
+        return .bit16(0xFE2A)
+    }
+
+    /// ITT Industries (`0xFE2B`)
+    static var ittIndustries: BluetoothUUID {
+        return .bit16(0xFE2B)
+    }
+
+    /// Google Inc. (`0xFE2C`)
+    static var google5: BluetoothUUID {
+        return .bit16(0xFE2C)
+    }
+
+    /// SMART INNOVATION Co.,Ltd (`0xFE2D`)
+    static var smartInnovation: BluetoothUUID {
+        return .bit16(0xFE2D)
+    }
+
+    /// ERi,Inc. (`0xFE2E`)
+    static var eri: BluetoothUUID {
+        return .bit16(0xFE2E)
+    }
+
+    /// CRESCO Wireless, Inc (`0xFE2F`)
+    static var crescoWireless: BluetoothUUID {
+        return .bit16(0xFE2F)
+    }
+
+    /// Volkswagen AG (`0xFE30`)
+    static var volkswagen: BluetoothUUID {
+        return .bit16(0xFE30)
+    }
+
+    /// Volkswagen AG (`0xFE31`)
+    static var volkswagen2: BluetoothUUID {
+        return .bit16(0xFE31)
+    }
+
+    /// Pro-Mark, Inc. (`0xFE32`)
+    static var proMark: BluetoothUUID {
+        return .bit16(0xFE32)
+    }
+
+    /// CHIPOLO d.o.o. (`0xFE33`)
+    static var chipolo: BluetoothUUID {
+        return .bit16(0xFE33)
+    }
+
+    /// SmallLoop LLC (`0xFE34`)
+    static var smallloop: BluetoothUUID {
+        return .bit16(0xFE34)
+    }
+
+    /// HUAWEI Technologies Co., Ltd (`0xFE35`)
+    static var huaweiTechnologies2: BluetoothUUID {
+        return .bit16(0xFE35)
+    }
+
+    /// HUAWEI Technologies Co., Ltd (`0xFE36`)
+    static var huaweiTechnologies3: BluetoothUUID {
+        return .bit16(0xFE36)
+    }
+
+    /// Spaceek LTD (`0xFE37`)
+    static var spaceek: BluetoothUUID {
+        return .bit16(0xFE37)
+    }
+
+    /// Spaceek LTD (`0xFE38`)
+    static var spaceek2: BluetoothUUID {
+        return .bit16(0xFE38)
+    }
+
+    /// TTS Tooltechnic Systems AG & Co. (`0xFE39`)
+    static var ttsTooltechnicSystems: BluetoothUUID {
+        return .bit16(0xFE39)
+    }
+
+    /// TTS Tooltechnic Systems AG & Co. (`0xFE3A`)
+    static var ttsTooltechnicSystems2: BluetoothUUID {
+        return .bit16(0xFE3A)
+    }
+
+    /// Dolby Laboratories (`0xFE3B`)
+    static var dolbyLaboratories: BluetoothUUID {
+        return .bit16(0xFE3B)
+    }
+
+    /// Alibaba (`0xFE3C`)
+    static var alibaba: BluetoothUUID {
+        return .bit16(0xFE3C)
+    }
+
+    /// BD Medical (`0xFE3D`)
+    static var bdMedical: BluetoothUUID {
+        return .bit16(0xFE3D)
+    }
+
+    /// BD Medical (`0xFE3E`)
+    static var bdMedical2: BluetoothUUID {
+        return .bit16(0xFE3E)
+    }
+
+    /// Friday Labs Limited (`0xFE3F`)
+    static var fridayLabs: BluetoothUUID {
+        return .bit16(0xFE3F)
+    }
+
+    /// Inugo Systems Limited (`0xFE40`)
+    static var inugoSystems: BluetoothUUID {
+        return .bit16(0xFE40)
+    }
+
+    /// Inugo Systems Limited (`0xFE41`)
+    static var inugoSystems2: BluetoothUUID {
+        return .bit16(0xFE41)
+    }
+
+    /// Nets A/S (`0xFE42`)
+    static var nets: BluetoothUUID {
+        return .bit16(0xFE42)
+    }
+
+    /// Andreas Stihl AG & Co. KG (`0xFE43`)
+    static var andreasStihl: BluetoothUUID {
+        return .bit16(0xFE43)
+    }
+
+    /// SK Telecom (`0xFE44`)
+    static var skTelecom: BluetoothUUID {
+        return .bit16(0xFE44)
+    }
+
+    /// Snapchat Inc (`0xFE45`)
+    static var snapchat: BluetoothUUID {
+        return .bit16(0xFE45)
+    }
+
+    /// B&O Play A/S (`0xFE46`)
+    static var bOPlay: BluetoothUUID {
+        return .bit16(0xFE46)
+    }
+
+    /// General Motors (`0xFE47`)
+    static var generalMotors: BluetoothUUID {
+        return .bit16(0xFE47)
+    }
+
+    /// General Motors (`0xFE48`)
+    static var generalMotors2: BluetoothUUID {
+        return .bit16(0xFE48)
+    }
+
+    /// SenionLab AB (`0xFE49`)
+    static var senionlab: BluetoothUUID {
+        return .bit16(0xFE49)
+    }
+
+    /// OMRON HEALTHCARE Co., Ltd. (`0xFE4A`)
+    static var omronHealthcare: BluetoothUUID {
+        return .bit16(0xFE4A)
+    }
+
+    /// Philips Lighting B.V. (`0xFE4B`)
+    static var philipsLighting2: BluetoothUUID {
+        return .bit16(0xFE4B)
+    }
+
+    /// Volkswagen AG (`0xFE4C`)
+    static var volkswagen3: BluetoothUUID {
+        return .bit16(0xFE4C)
+    }
+
+    /// Casambi Technologies Oy (`0xFE4D`)
+    static var casambiTechnologies: BluetoothUUID {
+        return .bit16(0xFE4D)
+    }
+
+    /// NTT docomo (`0xFE4E`)
+    static var nttDocomo: BluetoothUUID {
+        return .bit16(0xFE4E)
+    }
+
+    /// Molekule, Inc. (`0xFE4F`)
+    static var molekule: BluetoothUUID {
+        return .bit16(0xFE4F)
+    }
+
+    /// Google Inc. (`0xFE50`)
+    static var google6: BluetoothUUID {
+        return .bit16(0xFE50)
+    }
+
+    /// SRAM (`0xFE51`)
+    static var sram: BluetoothUUID {
+        return .bit16(0xFE51)
+    }
+
+    /// SetPoint Medical (`0xFE52`)
+    static var setpointMedical: BluetoothUUID {
+        return .bit16(0xFE52)
+    }
+
+    /// 3M (`0xFE53`)
+    static var uuid3M: BluetoothUUID {
+        return .bit16(0xFE53)
+    }
+
+    /// Motiv, Inc. (`0xFE54`)
+    static var motiv: BluetoothUUID {
+        return .bit16(0xFE54)
+    }
+
+    /// Google Inc. (`0xFE55`)
+    static var google7: BluetoothUUID {
+        return .bit16(0xFE55)
+    }
+
+    /// Google Inc. (`0xFE56`)
+    static var google8: BluetoothUUID {
+        return .bit16(0xFE56)
+    }
+
+    /// Dotted Labs (`0xFE57`)
+    static var dottedLabs: BluetoothUUID {
+        return .bit16(0xFE57)
+    }
+
+    /// Nordic Semiconductor ASA (`0xFE58`)
+    static var nordicSemiconductor: BluetoothUUID {
+        return .bit16(0xFE58)
+    }
+
+    /// Nordic Semiconductor ASA (`0xFE59`)
+    static var nordicSemiconductor2: BluetoothUUID {
+        return .bit16(0xFE59)
+    }
+
+    /// Chronologics Corporation (`0xFE5A`)
+    static var chronologics: BluetoothUUID {
+        return .bit16(0xFE5A)
+    }
+
+    /// GT-tronics HK Ltd (`0xFE5B`)
+    static var gtTronicsHk: BluetoothUUID {
+        return .bit16(0xFE5B)
+    }
+
+    /// million hunters GmbH (`0xFE5C`)
+    static var millionHunters: BluetoothUUID {
+        return .bit16(0xFE5C)
+    }
+
+    /// Grundfos A/S (`0xFE5D`)
+    static var grundfos: BluetoothUUID {
+        return .bit16(0xFE5D)
+    }
+
+    /// Plastc Corporation (`0xFE5E`)
+    static var plastc: BluetoothUUID {
+        return .bit16(0xFE5E)
+    }
+
+    /// Eyefi, Inc. (`0xFE5F`)
+    static var eyefi: BluetoothUUID {
+        return .bit16(0xFE5F)
+    }
+
+    /// Lierda Science & Technology Group Co., Ltd. (`0xFE60`)
+    static var lierdaScienceTechnologyGroup: BluetoothUUID {
+        return .bit16(0xFE60)
+    }
+
+    /// Logitech International SA (`0xFE61`)
+    static var logitechInternational: BluetoothUUID {
+        return .bit16(0xFE61)
+    }
+
+    /// Indagem Tech LLC (`0xFE62`)
+    static var indagemTech: BluetoothUUID {
+        return .bit16(0xFE62)
+    }
+
+    /// Connected Yard, Inc. (`0xFE63`)
+    static var connectedYard: BluetoothUUID {
+        return .bit16(0xFE63)
+    }
+
+    /// Siemens AG (`0xFE64`)
+    static var siemens: BluetoothUUID {
+        return .bit16(0xFE64)
+    }
+
+    /// CHIPOLO d.o.o. (`0xFE65`)
+    static var chipolo2: BluetoothUUID {
+        return .bit16(0xFE65)
+    }
+
+    /// Intel Corporation (`0xFE66`)
+    static var intel: BluetoothUUID {
+        return .bit16(0xFE66)
+    }
+
+    /// Lab Sensor Solutions (`0xFE67`)
+    static var labSensorSolutions: BluetoothUUID {
+        return .bit16(0xFE67)
+    }
+
+    /// Qualcomm Life Inc (`0xFE68`)
+    static var qualcommLife: BluetoothUUID {
+        return .bit16(0xFE68)
+    }
+
+    /// Qualcomm Life Inc (`0xFE69`)
+    static var qualcommLife2: BluetoothUUID {
+        return .bit16(0xFE69)
+    }
+
+    /// Kontakt Micro-Location Sp. z o.o. (`0xFE6A`)
+    static var kontaktMicroLocation: BluetoothUUID {
+        return .bit16(0xFE6A)
+    }
+
+    /// TASER International, Inc. (`0xFE6B`)
+    static var taserInternational: BluetoothUUID {
+        return .bit16(0xFE6B)
+    }
+
+    /// TASER International, Inc. (`0xFE6C`)
+    static var taserInternational2: BluetoothUUID {
+        return .bit16(0xFE6C)
+    }
+
+    /// The University of Tokyo (`0xFE6D`)
+    static var universityOfTokyo: BluetoothUUID {
+        return .bit16(0xFE6D)
+    }
+
+    /// The University of Tokyo (`0xFE6E`)
+    static var universityOfTokyo2: BluetoothUUID {
+        return .bit16(0xFE6E)
+    }
+
+    /// LINE Corporation (`0xFE6F`)
+    static var line: BluetoothUUID {
+        return .bit16(0xFE6F)
+    }
+
+    /// Beijing Jingdong Century Trading Co., Ltd. (`0xFE70`)
+    static var beijingJingdongCenturyTrading: BluetoothUUID {
+        return .bit16(0xFE70)
+    }
+
+    /// Plume Design Inc (`0xFE71`)
+    static var plumeDesign: BluetoothUUID {
+        return .bit16(0xFE71)
+    }
+
+    /// St. Jude Medical, Inc. (`0xFE72`)
+    static var stJudeMedical: BluetoothUUID {
+        return .bit16(0xFE72)
+    }
+
+    /// St. Jude Medical, Inc. (`0xFE73`)
+    static var stJudeMedical2: BluetoothUUID {
+        return .bit16(0xFE73)
+    }
+
+    /// unwire (`0xFE74`)
+    static var unwire: BluetoothUUID {
+        return .bit16(0xFE74)
+    }
+
+    /// TangoMe (`0xFE75`)
+    static var tangome: BluetoothUUID {
+        return .bit16(0xFE75)
+    }
+
+    /// TangoMe (`0xFE76`)
+    static var tangome2: BluetoothUUID {
+        return .bit16(0xFE76)
+    }
+
+    /// Hewlett-Packard Company (`0xFE77`)
+    static var hewlettPackardCompany: BluetoothUUID {
+        return .bit16(0xFE77)
+    }
+
+    /// Hewlett-Packard Company (`0xFE78`)
+    static var hewlettPackardCompany2: BluetoothUUID {
+        return .bit16(0xFE78)
+    }
+
+    /// Zebra Technologies (`0xFE79`)
+    static var zebraTechnologies: BluetoothUUID {
+        return .bit16(0xFE79)
+    }
+
+    /// Bragi GmbH (`0xFE7A`)
+    static var bragi: BluetoothUUID {
+        return .bit16(0xFE7A)
+    }
+
+    /// Orion Labs, Inc. (`0xFE7B`)
+    static var orionLabs: BluetoothUUID {
+        return .bit16(0xFE7B)
+    }
+
+    /// Stollmann E+V GmbH (`0xFE7C`)
+    static var stollmannEV: BluetoothUUID {
+        return .bit16(0xFE7C)
+    }
+
+    /// Aterica Health Inc. (`0xFE7D`)
+    static var atericaHealth: BluetoothUUID {
+        return .bit16(0xFE7D)
+    }
+
+    /// Awear Solutions Ltd (`0xFE7E`)
+    static var awearSolutions: BluetoothUUID {
+        return .bit16(0xFE7E)
+    }
+
+    /// Doppler Lab (`0xFE7F`)
+    static var dopplerLab: BluetoothUUID {
+        return .bit16(0xFE7F)
+    }
+
+    /// Doppler Lab (`0xFE80`)
+    static var dopplerLab2: BluetoothUUID {
+        return .bit16(0xFE80)
+    }
+
+    /// Medtronic Inc. (`0xFE81`)
+    static var medtronic: BluetoothUUID {
+        return .bit16(0xFE81)
+    }
+
+    /// Medtronic Inc. (`0xFE82`)
+    static var medtronic2: BluetoothUUID {
+        return .bit16(0xFE82)
+    }
+
+    /// Blue Bite (`0xFE83`)
+    static var blueBite: BluetoothUUID {
+        return .bit16(0xFE83)
+    }
+
+    /// RF Digital Corp (`0xFE84`)
+    static var rfDigital: BluetoothUUID {
+        return .bit16(0xFE84)
+    }
+
+    /// RF Digital Corp (`0xFE85`)
+    static var rfDigital2: BluetoothUUID {
+        return .bit16(0xFE85)
+    }
+
+    /// HUAWEI Technologies Co., Ltd. ( 华为技术有限公司 ) (`0xFE86`)
+    static var huaweiTechnologies华为技术有限公司: BluetoothUUID {
+        return .bit16(0xFE86)
+    }
+
+    /// Qingdao Yeelink Information Technology Co., Ltd. ( 青岛亿联客信息技术有限公司 ) (`0xFE87`)
+    static var qingdaoYeelinkInformationTechnology青岛亿联客信息技术有限公司: BluetoothUUID {
+        return .bit16(0xFE87)
+    }
+
+    /// SALTO SYSTEMS S.L. (`0xFE88`)
+    static var saltoSystems: BluetoothUUID {
+        return .bit16(0xFE88)
+    }
+
+    /// B&O Play A/S (`0xFE89`)
+    static var bOPlay2: BluetoothUUID {
+        return .bit16(0xFE89)
+    }
+
+    /// Apple, Inc. (`0xFE8A`)
+    static var apple3: BluetoothUUID {
+        return .bit16(0xFE8A)
+    }
+
+    /// Apple, Inc. (`0xFE8B`)
+    static var apple4: BluetoothUUID {
+        return .bit16(0xFE8B)
+    }
+
+    /// TRON Forum (`0xFE8C`)
+    static var tronForum: BluetoothUUID {
+        return .bit16(0xFE8C)
+    }
+
+    /// Interaxon Inc. (`0xFE8D`)
+    static var interaxon: BluetoothUUID {
+        return .bit16(0xFE8D)
+    }
+
+    /// ARM Ltd (`0xFE8E`)
+    static var arm: BluetoothUUID {
+        return .bit16(0xFE8E)
+    }
+
+    /// CSR (`0xFE8F`)
+    static var csr: BluetoothUUID {
+        return .bit16(0xFE8F)
+    }
+
+    /// JUMA (`0xFE90`)
+    static var juma: BluetoothUUID {
+        return .bit16(0xFE90)
+    }
+
+    /// Shanghai Imilab Technology Co.,Ltd (`0xFE91`)
+    static var shanghaiImilabTechnology: BluetoothUUID {
+        return .bit16(0xFE91)
+    }
+
+    /// Jarden Safety & Security (`0xFE92`)
+    static var jardenSafetySecurity: BluetoothUUID {
+        return .bit16(0xFE92)
+    }
+
+    /// OttoQ Inc. (`0xFE93`)
+    static var ottoq: BluetoothUUID {
+        return .bit16(0xFE93)
+    }
+
+    /// OttoQ Inc. (`0xFE94`)
+    static var ottoq2: BluetoothUUID {
+        return .bit16(0xFE94)
+    }
+
+    /// Xiaomi Inc. (`0xFE95`)
+    static var xiaomi: BluetoothUUID {
+        return .bit16(0xFE95)
+    }
+
+    /// Tesla Motor Inc. (`0xFE96`)
+    static var teslaMotor: BluetoothUUID {
+        return .bit16(0xFE96)
+    }
+
+    /// Tesla Motor Inc. (`0xFE97`)
+    static var teslaMotor2: BluetoothUUID {
+        return .bit16(0xFE97)
+    }
+
+    /// Currant, Inc. (`0xFE98`)
+    static var currant: BluetoothUUID {
+        return .bit16(0xFE98)
+    }
+
+    /// Currant, Inc. (`0xFE99`)
+    static var currant2: BluetoothUUID {
+        return .bit16(0xFE99)
+    }
+
+    /// Estimote (`0xFE9A`)
+    static var estimote: BluetoothUUID {
+        return .bit16(0xFE9A)
+    }
+
+    /// Samsara Networks, Inc (`0xFE9B`)
+    static var samsaraNetworks: BluetoothUUID {
+        return .bit16(0xFE9B)
+    }
+
+    /// GSI Laboratories, Inc. (`0xFE9C`)
+    static var gsiLaboratories: BluetoothUUID {
+        return .bit16(0xFE9C)
+    }
+
+    /// Mobiquity Networks Inc (`0xFE9D`)
+    static var mobiquityNetworks: BluetoothUUID {
+        return .bit16(0xFE9D)
+    }
+
+    /// Dialog Semiconductor B.V. (`0xFE9E`)
+    static var dialogSemiconductor: BluetoothUUID {
+        return .bit16(0xFE9E)
+    }
+
+    /// Google Inc. (`0xFE9F`)
+    static var google9: BluetoothUUID {
+        return .bit16(0xFE9F)
+    }
+
+    /// Google Inc. (`0xFEA0`)
+    static var google10: BluetoothUUID {
+        return .bit16(0xFEA0)
+    }
+
+    /// Intrepid Control Systems, Inc. (`0xFEA1`)
+    static var intrepidControlSystems: BluetoothUUID {
+        return .bit16(0xFEA1)
+    }
+
+    /// Intrepid Control Systems, Inc. (`0xFEA2`)
+    static var intrepidControlSystems2: BluetoothUUID {
+        return .bit16(0xFEA2)
+    }
+
+    /// ITT Industries (`0xFEA3`)
+    static var ittIndustries2: BluetoothUUID {
+        return .bit16(0xFEA3)
+    }
+
+    /// Paxton Access Ltd (`0xFEA4`)
+    static var paxtonAccess: BluetoothUUID {
+        return .bit16(0xFEA4)
+    }
+
+    /// GoPro, Inc. (`0xFEA5`)
+    static var gopro: BluetoothUUID {
+        return .bit16(0xFEA5)
+    }
+
+    /// GoPro, Inc. (`0xFEA6`)
+    static var gopro2: BluetoothUUID {
+        return .bit16(0xFEA6)
+    }
+
+    /// UTC Fire and Security (`0xFEA7`)
+    static var utcFireAndSecurity: BluetoothUUID {
+        return .bit16(0xFEA7)
+    }
+
+    /// Savant Systems LLC (`0xFEA8`)
+    static var savantSystems: BluetoothUUID {
+        return .bit16(0xFEA8)
+    }
+
+    /// Savant Systems LLC (`0xFEA9`)
+    static var savantSystems2: BluetoothUUID {
+        return .bit16(0xFEA9)
+    }
+
+    /// Google Inc. (`0xFEAA`)
+    static var google11: BluetoothUUID {
+        return .bit16(0xFEAA)
+    }
+
+    /// Nokia Corporation (`0xFEAB`)
+    static var nokia: BluetoothUUID {
+        return .bit16(0xFEAB)
+    }
+
+    /// Nokia Corporation (`0xFEAC`)
+    static var nokia2: BluetoothUUID {
+        return .bit16(0xFEAC)
+    }
+
+    /// Nokia Corporation (`0xFEAD`)
+    static var nokia3: BluetoothUUID {
+        return .bit16(0xFEAD)
+    }
+
+    /// Nokia Corporation (`0xFEAE`)
+    static var nokia4: BluetoothUUID {
+        return .bit16(0xFEAE)
+    }
+
+    /// Nest Labs Inc. (`0xFEAF`)
+    static var nestLabs: BluetoothUUID {
+        return .bit16(0xFEAF)
+    }
+
+    /// Nest Labs Inc. (`0xFEB0`)
+    static var nestLabs2: BluetoothUUID {
+        return .bit16(0xFEB0)
+    }
+
+    /// Electronics Tomorrow Limited (`0xFEB1`)
+    static var electronicsTomorrow: BluetoothUUID {
+        return .bit16(0xFEB1)
+    }
+
+    /// Microsoft Corporation (`0xFEB2`)
+    static var microsoft2: BluetoothUUID {
+        return .bit16(0xFEB2)
+    }
+
+    /// Taobao (`0xFEB3`)
+    static var taobao: BluetoothUUID {
+        return .bit16(0xFEB3)
+    }
+
+    /// WiSilica Inc. (`0xFEB4`)
+    static var wisilica: BluetoothUUID {
+        return .bit16(0xFEB4)
+    }
+
+    /// WiSilica Inc. (`0xFEB5`)
+    static var wisilica2: BluetoothUUID {
+        return .bit16(0xFEB5)
+    }
+
+    /// Vencer Co, Ltd (`0xFEB6`)
+    static var vencerCo: BluetoothUUID {
+        return .bit16(0xFEB6)
+    }
+
+    /// Facebook, Inc. (`0xFEB7`)
+    static var facebook: BluetoothUUID {
+        return .bit16(0xFEB7)
+    }
+
+    /// Facebook, Inc. (`0xFEB8`)
+    static var facebook2: BluetoothUUID {
+        return .bit16(0xFEB8)
+    }
+
+    /// LG Electronics (`0xFEB9`)
+    static var lgElectronics: BluetoothUUID {
+        return .bit16(0xFEB9)
+    }
+
+    /// Tencent Holdings Limited (`0xFEBA`)
+    static var tencentHoldings: BluetoothUUID {
+        return .bit16(0xFEBA)
+    }
+
+    /// adafruit industries (`0xFEBB`)
+    static var adafruitIndustries: BluetoothUUID {
+        return .bit16(0xFEBB)
+    }
+
+    /// Dexcom, Inc. (`0xFEBC`)
+    static var dexcom: BluetoothUUID {
+        return .bit16(0xFEBC)
+    }
+
+    /// Clover Network, Inc. (`0xFEBD`)
+    static var cloverNetwork: BluetoothUUID {
+        return .bit16(0xFEBD)
+    }
+
+    /// Bose Corporation (`0xFEBE`)
+    static var bose2: BluetoothUUID {
+        return .bit16(0xFEBE)
+    }
+
+    /// Nod, Inc. (`0xFEBF`)
+    static var nod: BluetoothUUID {
+        return .bit16(0xFEBF)
+    }
+
+    /// KDDI Corporation (`0xFEC0`)
+    static var kddi: BluetoothUUID {
+        return .bit16(0xFEC0)
+    }
+
+    /// KDDI Corporation (`0xFEC1`)
+    static var kddi2: BluetoothUUID {
+        return .bit16(0xFEC1)
+    }
+
+    /// Blue Spark Technologies, Inc. (`0xFEC2`)
+    static var blueSparkTechnologies: BluetoothUUID {
+        return .bit16(0xFEC2)
+    }
+
+    /// 360fly, Inc. (`0xFEC3`)
+    static var uuid360Fly: BluetoothUUID {
+        return .bit16(0xFEC3)
+    }
+
+    /// PLUS Location Systems (`0xFEC4`)
+    static var plusLocationSystems: BluetoothUUID {
+        return .bit16(0xFEC4)
+    }
+
+    /// Realtek Semiconductor Corp. (`0xFEC5`)
+    static var realtekSemiconductor: BluetoothUUID {
+        return .bit16(0xFEC5)
+    }
+
+    /// Kocomojo, LLC (`0xFEC6`)
+    static var kocomojo: BluetoothUUID {
+        return .bit16(0xFEC6)
+    }
+
+    /// Apple, Inc. (`0xFEC7`)
+    static var apple5: BluetoothUUID {
+        return .bit16(0xFEC7)
+    }
+
+    /// Apple, Inc. (`0xFEC8`)
+    static var apple6: BluetoothUUID {
+        return .bit16(0xFEC8)
+    }
+
+    /// Apple, Inc. (`0xFEC9`)
+    static var apple7: BluetoothUUID {
+        return .bit16(0xFEC9)
+    }
+
+    /// Apple, Inc. (`0xFECA`)
+    static var apple8: BluetoothUUID {
+        return .bit16(0xFECA)
+    }
+
+    /// Apple, Inc. (`0xFECB`)
+    static var apple9: BluetoothUUID {
+        return .bit16(0xFECB)
+    }
+
+    /// Apple, Inc. (`0xFECC`)
+    static var apple10: BluetoothUUID {
+        return .bit16(0xFECC)
+    }
+
+    /// Apple, Inc. (`0xFECD`)
+    static var apple11: BluetoothUUID {
+        return .bit16(0xFECD)
+    }
+
+    /// Apple, Inc. (`0xFECE`)
+    static var apple12: BluetoothUUID {
+        return .bit16(0xFECE)
+    }
+
+    /// Apple, Inc. (`0xFECF`)
+    static var apple13: BluetoothUUID {
+        return .bit16(0xFECF)
+    }
+
+    /// Apple, Inc. (`0xFED0`)
+    static var apple14: BluetoothUUID {
+        return .bit16(0xFED0)
+    }
+
+    /// Apple, Inc. (`0xFED1`)
+    static var apple15: BluetoothUUID {
+        return .bit16(0xFED1)
+    }
+
+    /// Apple, Inc. (`0xFED2`)
+    static var apple16: BluetoothUUID {
+        return .bit16(0xFED2)
+    }
+
+    /// Apple, Inc. (`0xFED3`)
+    static var apple17: BluetoothUUID {
+        return .bit16(0xFED3)
+    }
+
+    /// Apple, Inc. (`0xFED4`)
+    static var apple18: BluetoothUUID {
+        return .bit16(0xFED4)
+    }
+
+    /// Plantronics Inc. (`0xFED5`)
+    static var plantronics: BluetoothUUID {
+        return .bit16(0xFED5)
+    }
+
+    /// Broadcom Corporation (`0xFED6`)
+    static var broadcom: BluetoothUUID {
+        return .bit16(0xFED6)
+    }
+
+    /// Broadcom Corporation (`0xFED7`)
+    static var broadcom2: BluetoothUUID {
+        return .bit16(0xFED7)
+    }
+
+    /// Google Inc. (`0xFED8`)
+    static var google12: BluetoothUUID {
+        return .bit16(0xFED8)
+    }
+
+    /// Pebble Technology Corporation (`0xFED9`)
+    static var pebbleTechnology: BluetoothUUID {
+        return .bit16(0xFED9)
+    }
+
+    /// ISSC Technologies Corporation (`0xFEDA`)
+    static var isscTechnologies: BluetoothUUID {
+        return .bit16(0xFEDA)
+    }
+
+    /// Perka, Inc. (`0xFEDB`)
+    static var perka: BluetoothUUID {
+        return .bit16(0xFEDB)
+    }
+
+    /// Jawbone (`0xFEDC`)
+    static var jawbone: BluetoothUUID {
+        return .bit16(0xFEDC)
+    }
+
+    /// Jawbone (`0xFEDD`)
+    static var jawbone2: BluetoothUUID {
+        return .bit16(0xFEDD)
+    }
+
+    /// Coin, Inc. (`0xFEDE`)
+    static var coin: BluetoothUUID {
+        return .bit16(0xFEDE)
+    }
+
+    /// Design SHIFT (`0xFEDF`)
+    static var designShift: BluetoothUUID {
+        return .bit16(0xFEDF)
+    }
+
+    /// Anhui Huami Information Technology Co. (`0xFEE0`)
+    static var anhuiHuamiInformationTechnology: BluetoothUUID {
+        return .bit16(0xFEE0)
+    }
+
+    /// Anhui Huami Information Technology Co. (`0xFEE1`)
+    static var anhuiHuamiInformationTechnology2: BluetoothUUID {
+        return .bit16(0xFEE1)
+    }
+
+    /// Anki, Inc. (`0xFEE2`)
+    static var anki: BluetoothUUID {
+        return .bit16(0xFEE2)
+    }
+
+    /// Anki, Inc. (`0xFEE3`)
+    static var anki2: BluetoothUUID {
+        return .bit16(0xFEE3)
+    }
+
+    /// Nordic Semiconductor ASA (`0xFEE4`)
+    static var nordicSemiconductor3: BluetoothUUID {
+        return .bit16(0xFEE4)
+    }
+
+    /// Nordic Semiconductor ASA (`0xFEE5`)
+    static var nordicSemiconductor4: BluetoothUUID {
+        return .bit16(0xFEE5)
+    }
+
+    /// Silvair, Inc. (`0xFEE6`)
+    static var silvair: BluetoothUUID {
+        return .bit16(0xFEE6)
+    }
+
+    /// Tencent Holdings Limited (`0xFEE7`)
+    static var tencentHoldings2: BluetoothUUID {
+        return .bit16(0xFEE7)
+    }
+
+    /// Quintic Corp. (`0xFEE8`)
+    static var quintic: BluetoothUUID {
+        return .bit16(0xFEE8)
+    }
+
+    /// Quintic Corp. (`0xFEE9`)
+    static var quintic2: BluetoothUUID {
+        return .bit16(0xFEE9)
+    }
+
+    /// Swirl Networks, Inc. (`0xFEEA`)
+    static var swirlNetworks: BluetoothUUID {
+        return .bit16(0xFEEA)
+    }
+
+    /// Swirl Networks, Inc. (`0xFEEB`)
+    static var swirlNetworks2: BluetoothUUID {
+        return .bit16(0xFEEB)
+    }
+
+    /// Tile, Inc. (`0xFEEC`)
+    static var tile: BluetoothUUID {
+        return .bit16(0xFEEC)
+    }
+
+    /// Tile, Inc. (`0xFEED`)
+    static var tile2: BluetoothUUID {
+        return .bit16(0xFEED)
+    }
+
+    /// Polar Electro Oy (`0xFEEE`)
+    static var polarElectro: BluetoothUUID {
+        return .bit16(0xFEEE)
+    }
+
+    /// Polar Electro Oy (`0xFEEF`)
+    static var polarElectro2: BluetoothUUID {
+        return .bit16(0xFEEF)
+    }
+
+    /// Intel (`0xFEF0`)
+    static var intel2: BluetoothUUID {
+        return .bit16(0xFEF0)
+    }
+
+    /// CSR (`0xFEF1`)
+    static var csr2: BluetoothUUID {
+        return .bit16(0xFEF1)
+    }
+
+    /// CSR (`0xFEF2`)
+    static var csr3: BluetoothUUID {
+        return .bit16(0xFEF2)
+    }
+
+    /// Google Inc. (`0xFEF3`)
+    static var google13: BluetoothUUID {
+        return .bit16(0xFEF3)
+    }
+
+    /// Google Inc. (`0xFEF4`)
+    static var google14: BluetoothUUID {
+        return .bit16(0xFEF4)
+    }
+
+    /// Dialog Semiconductor GmbH (`0xFEF5`)
+    static var dialogSemiconductor2: BluetoothUUID {
+        return .bit16(0xFEF5)
+    }
+
+    /// Wicentric, Inc. (`0xFEF6`)
+    static var wicentric: BluetoothUUID {
+        return .bit16(0xFEF6)
+    }
+
+    /// Aplix Corporation (`0xFEF7`)
+    static var aplix: BluetoothUUID {
+        return .bit16(0xFEF7)
+    }
+
+    /// Aplix Corporation (`0xFEF8`)
+    static var aplix2: BluetoothUUID {
+        return .bit16(0xFEF8)
+    }
+
+    /// PayPal, Inc. (`0xFEF9`)
+    static var paypal: BluetoothUUID {
+        return .bit16(0xFEF9)
+    }
+
+    /// PayPal, Inc. (`0xFEFA`)
+    static var paypal2: BluetoothUUID {
+        return .bit16(0xFEFA)
+    }
+
+    /// Telit Wireless Solutions (`0xFEFB`)
+    static var telitWirelessSolutions2: BluetoothUUID {
+        return .bit16(0xFEFB)
+    }
+
+    /// Gimbal, Inc. (`0xFEFC`)
+    static var gimbal: BluetoothUUID {
+        return .bit16(0xFEFC)
+    }
+
+    /// Gimbal, Inc. (`0xFEFD`)
+    static var gimbal2: BluetoothUUID {
+        return .bit16(0xFEFD)
+    }
+
+    /// GN ReSound A/S (`0xFEFE`)
+    static var gnResound: BluetoothUUID {
+        return .bit16(0xFEFE)
+    }
+
+    /// GN Netcom (`0xFEFF`)
+    static var gnNetcom: BluetoothUUID {
+        return .bit16(0xFEFF)
+    }
+
+    /// Fast IDentity Online Alliance (FIDO) (`0xFFFD`)
+    static var fastIdentityOnlineAllianceFido: BluetoothUUID {
+        return .bit16(0xFFFD)
+    }
+
+    /// Alliance for Wireless Power (A4WP) (`0xFFFE`)
+    static var allianceForWirelessPowerA4Wp: BluetoothUUID {
+        return .bit16(0xFFFE)
+    }
+
+}

--- a/pico-w-ble-peripheral-sdk/Bluetooth/Extensions/Hexadecimal.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/Extensions/Hexadecimal.swift
@@ -1,0 +1,181 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+internal extension FixedWidthInteger {
+    
+    func toHexadecimal() -> String {
+        let length = MemoryLayout<Self>.size * 2
+        var string: String
+        #if hasFeature(Embedded) || (canImport(Darwin) && DEBUG)
+        string = ""
+        string.reserveCapacity(length)
+        self.bigEndian.forEachByte { byte in
+            string += String(hexadecimal: byte)
+        }
+        #else // Linux and non-Embedded release builds use Swift StdLib
+        string = String(self, radix: 16, uppercase: true)
+        // Add Zero padding
+        while string.utf8.count < length {
+            string = "0" + string
+        }
+        #endif
+        assert(string.utf8.count == length)
+        #if !hasFeature(Embedded)
+        assert(string == string.uppercased(), "String should be uppercased")
+        #endif
+        return string
+    }
+}
+
+internal extension String {
+    
+    /// Converts a byte to its uppercase hexadecimal representation.
+    init(hexadecimal byte: UInt8) {
+        let length = 2
+        #if hasFeature(Embedded) || (canImport(Darwin) && DEBUG)
+        self.init(format: "%02X", length: length, byte)!
+        #else
+        self.init(byte, radix: 16, uppercase: true)
+        // Add Zero padding
+        while self.utf8.count < length {
+            self = "0" + self
+        }
+        #endif
+        assert(self.utf8.count == length)
+        #if !hasFeature(Embedded)
+        assert(self == self.uppercased(), "String should be uppercased")
+        #endif
+    }
+}
+
+internal extension Collection where Element: FixedWidthInteger {
+    
+    func toHexadecimal() -> String {
+        let length = count * MemoryLayout<Element>.size * 2
+        var string = ""
+        string.reserveCapacity(length)
+        string = reduce(into: string) { $0 += $1.toHexadecimal() }
+        assert(string.utf8.count == length)
+        return string
+    }
+}
+
+internal extension FixedWidthInteger {
+    
+    init?<S: StringProtocol>(parse string: S, radix: Self) {
+        #if !hasFeature(Embedded)
+        let string = string.uppercased()
+        #endif
+        self.init(utf8: string.utf8, radix: radix)
+    }
+    
+    init?<S: StringProtocol>(hexadecimal string: S) {
+        guard string.utf8.count == MemoryLayout<Self>.size * 2 else {
+            return nil
+        }
+        #if hasFeature(Embedded) || DEBUG
+        guard let value = Self(parse: string, radix: 16) else {
+            return nil
+        }
+        self.init(value)
+        #else
+        self.init(string, radix: 16)
+        #endif
+    }
+    
+    init?<C>(hexadecimal utf8: C) where C: Collection, C.Element == UInt8 {
+        guard utf8.count == MemoryLayout<Self>.size * 2 else {
+            return nil
+        }
+        guard let value = Self(utf8: utf8, radix: 16) else {
+            return nil
+        }
+        self.init(value)
+    }
+    
+    /// Expects uppercase UTF8 data.
+    init?<C>(utf8: C, radix: Self) where C: Collection, C.Element == UInt8 {
+        #if !hasFeature(Embedded)
+        assert(String(decoding: utf8, as: UTF8.self) == String(decoding: utf8, as: UTF8.self).uppercased(), "Expected uppercase string")
+        #endif
+        let digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".utf8
+        var result = Self(0)
+        for character in utf8 {
+            if let stringIndex = digits.enumerated().first(where: { $0.element == character })?.offset {
+                let val = Self(stringIndex)
+                if val >= radix {
+                    return nil
+                }
+                result = result * radix + val
+            } else {
+                return nil
+            }
+        }
+        self = result
+    }
+}
+
+#if !hasFeature(Embedded)
+internal extension String.UTF16View.Element {
+    
+    // Convert 0 ... 9, a ... f, A ...F to their decimal value,
+    // return nil for all other input characters
+    func decodeHexNibble() -> UInt8? {
+        switch self {
+        case 0x30 ... 0x39:
+            return UInt8(self - 0x30)
+        case 0x41 ... 0x46:
+            return UInt8(self - 0x41 + 10)
+        case 0x61 ... 0x66:
+            return UInt8(self - 0x61 + 10)
+        default:
+            return nil
+        }
+    }
+}
+
+internal extension [UInt8] {
+    
+    init?<S: StringProtocol>(hexadecimal string: S) {
+        
+        let str = String(string)
+        let utf16: String.UTF16View
+        if (str.count % 2 == 1) {
+            utf16 = ("0" + str).utf16
+        } else {
+            utf16 = str.utf16
+        }
+        var data = [UInt8]()
+        data.reserveCapacity(utf16.count / 2)
+        
+        var i = utf16.startIndex
+        while i != utf16.endIndex {
+            guard let hi = utf16[i].decodeHexNibble(),
+                  let nxt = utf16.index(i, offsetBy:1, limitedBy: utf16.endIndex),
+                  let lo = utf16[nxt].decodeHexNibble()
+            else {
+                return nil
+            }
+            
+            let value = hi << 4 + lo
+            data.append(value)
+            
+            guard let next = utf16.index(i, offsetBy:2, limitedBy: utf16.endIndex) else {
+                break
+            }
+            i = next
+        }
+        
+        self = data
+        
+    }
+}
+#endif

--- a/pico-w-ble-peripheral-sdk/Bluetooth/Extensions/Integer.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/Extensions/Integer.swift
@@ -1,0 +1,120 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+internal extension UInt16 {
+    
+    /// Initializes value from two bytes.
+    init(bytes: (UInt8, UInt8)) {
+        self = unsafeBitCast(bytes, to: UInt16.self)
+    }
+    
+    /// Converts to two bytes. 
+    var bytes: (UInt8, UInt8) {
+        return unsafeBitCast(self, to: (UInt8, UInt8).self)
+    }
+}
+
+internal extension UInt32 {
+    
+    /// Initializes value from four bytes.
+    init(bytes: (UInt8, UInt8, UInt8, UInt8)) {
+        self = unsafeBitCast(bytes, to: UInt32.self)
+    }
+    
+    /// Converts to four bytes.
+    var bytes: (UInt8, UInt8, UInt8, UInt8) {
+        return unsafeBitCast(self, to: (UInt8, UInt8, UInt8, UInt8).self)
+    }
+}
+
+internal extension UInt64 {
+    
+    /// Initializes value from four bytes.
+    init(bytes: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) {
+        self = unsafeBitCast(bytes, to: UInt64.self)
+    }
+    
+    /// Converts to eight bytes.
+    var bytes: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) {
+        return unsafeBitCast(self, to: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8).self)
+    }
+}
+
+internal extension BinaryInteger {
+    
+    @inlinable
+    var bytes: [UInt8] {
+        withUnsafeBytes(of: self) { Array($0) }
+    }
+    
+    func forEachByte(_ block: (UInt8) -> ()) {
+        withUnsafeBytes(of: self) {
+            $0.forEach(block)
+        }
+    }
+}
+
+internal extension UInt8 {
+    
+    /// Initialize a byte from 2 bit enums.
+    static func bit2(_ enum1: UInt8, _ enum2: UInt8, _ enum3: UInt8, _ enum4: UInt8) -> UInt8 {
+        var value: UInt8 = 0
+        value += enum1 << 6
+        value += enum2 << 4
+        value += enum3 << 2
+        value += enum4
+        return value
+    }
+    
+    /// Get 2 bit values from a byte.
+    func bit2() -> (UInt8, UInt8, UInt8, UInt8) {
+        return (self >> 6, (self << 2) >> 6, (self << 4) >> 6, (self << 6) >> 6)
+    }
+}
+
+internal extension UInt64 {
+    
+    /// The value of the characteristic is a bit mask implemented as an array of unsigned 8 bit integers.
+    init?<Data: DataContainer>(bitmaskArray data: Data) {
+        
+        if data.count == MemoryLayout<UInt64>.size {
+            self = UInt64(littleEndian: UInt64(bytes: (data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7])))
+        } else if data.count >= MemoryLayout<UInt32>.size {
+            let rawValue = UInt32(littleEndian: UInt32(bytes: (data[0], data[1], data[2], data[3])))
+            self = UInt64(rawValue)
+        } else if data.count >= MemoryLayout<UInt16>.size {
+            let rawValue = UInt16(littleEndian: UInt16(bytes: (data[0], data[1])))
+            self = UInt64(rawValue)
+        } else if data.count >= MemoryLayout<UInt8>.size {
+            let rawValue = data[0]
+            self = UInt64(rawValue)
+        } else {
+            return nil
+        }
+    }
+    
+    /// The value of the characteristic is a bit mask implemented as an array of unsigned 8 bit integers.
+    var bitmaskArray: [UInt8] {
+        
+        if self <= numericCast(UInt8.max) {
+            return [UInt8]([UInt8(self)])
+        } else if self <= numericCast(UInt16.max) {
+            let bytes = UInt16(self).littleEndian.bytes
+            return [UInt8]([bytes.0, bytes.1])
+        } else if self <= numericCast(UInt32.max) {
+            let bytes = UInt32(self).littleEndian.bytes
+            return [UInt8]([bytes.0, bytes.1, bytes.2, bytes.3])
+        } else {
+            let bytes = self.littleEndian.bytes
+            return [UInt8]([bytes.0, bytes.1, bytes.2, bytes.3, bytes.4, bytes.5, bytes.6, bytes.7])
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/Bluetooth/Extensions/String.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/Extensions/String.swift
@@ -1,0 +1,51 @@
+///===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+internal extension String {
+    
+    /// Initialize from UTF8 data.
+    init?<Data: DataContainer>(utf8 data: Data) {
+        #if canImport(Darwin)
+        // Newer Darwin and other platforms use StdLib parsing
+        if #available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *) {
+            self.init(validating: data, as: UTF8.self)
+        } else {
+            // Older Darwin uses Foundation
+            self.init(bytes: data, encoding: .utf8)
+        }
+        #else
+        self.init(validating: data, as: UTF8.self)
+        #endif
+    }
+    
+    #if hasFeature(Embedded)
+    // Can't use `CVarArg` in Embedded Swift
+    init?(format: String, length: Int, _ value: UInt8) {
+        var cString: [CChar] = .init(repeating: 0, count: length + 1)
+        guard _snprintf_uint8_t(&cString, cString.count, format, value) >= 0 else {
+            return nil
+        }
+        self.init(cString: cString)
+    }
+    #elseif canImport(Darwin)
+    init?<T: CVarArg>(format: String, length: Int, _ value: T) {
+        var cString: [CChar] = .init(repeating: 0, count: length + 1)
+        guard snprintf(ptr: &cString, cString.count, format, value) >= 0 else {
+            return nil
+        }
+        self.init(cString: cString)
+    }
+    #endif
+}

--- a/pico-w-ble-peripheral-sdk/Bluetooth/Extensions/System.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/Extensions/System.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#elseif os(Windows)
+import ucrt
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(WASILibc)
+import WASILibc
+#elseif canImport(Bionic)
+import Bionic
+#endif
+
+// Declares the required C functions
+#if hasFeature(Embedded)
+@_silgen_name("memcmp")
+internal func _memcmp(
+    _ p1: UnsafeRawPointer?,
+    _ p2: UnsafeRawPointer?,
+    _ size: Int
+) -> Int32
+#else
+internal func _memcmp(
+    _ p1: UnsafeRawPointer,
+    _ p2: UnsafeRawPointer,
+    _ size: Int
+) -> Int32 {
+    memcmp(p1, p2, size)
+}
+#endif
+
+#if hasFeature(Embedded)
+@_silgen_name("snprintf")
+internal func _snprintf_uint8_t(
+    _ pointer: UnsafeMutablePointer<CChar>,
+    _ length: Int,
+    _ format: UnsafePointer<CChar>,
+    _ arg: UInt8
+) -> Int32
+#endif

--- a/pico-w-ble-peripheral-sdk/Bluetooth/Extensions/UUID.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/Extensions/UUID.swift
@@ -1,0 +1,322 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+internal extension UUID {
+    
+    static var stringLength: Int { return 36 }
+    static var unformattedStringLength: Int { return 32 }
+}
+
+extension UUID: ByteValue {
+        
+    public static var bitWidth: Int { return 128 }
+    
+    public init(bytes: ByteValue) {
+        self.init(uuid: bytes)
+    }
+    
+    public var bytes: ByteValue {
+        get { return uuid }
+        set { self = UUID(uuid: newValue) }
+    }
+}
+
+// MARK: - DataConvertible
+
+extension UUID: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == UUID.length
+            else { return nil }
+        self.init(bytes: (data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15]))
+    }
+}
+
+#if canImport(Foundation)
+public extension Foundation.UUID {
+    
+    typealias ByteValue = uuid_t
+}
+
+/// Internal UUID type.
+internal struct _UUID: Sendable {
+    
+    public typealias ByteValue = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+    
+    public let uuid: ByteValue
+    
+    /// Create a UUID from a `uuid_t`.
+    public init(uuid: ByteValue) {
+        self.uuid = uuid
+    }
+}
+
+#else
+
+// MARK: - Embedded Swift Support
+
+/// Represents UUID strings, which can be used to uniquely identify types, interfaces, and other items.
+public struct UUID: Sendable {
+    
+    public typealias ByteValue = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+    
+    public let uuid: ByteValue
+    
+    /// Create a UUID from a `uuid_t`.
+    public init(uuid: ByteValue) {
+        self.uuid = uuid
+    }
+}
+
+public typealias _UUID = UUID // Built-in UUID type
+
+#endif
+
+extension _UUID {
+    
+    /// Create a new UUID with RFC 4122 version 4 random bytes.
+    public init() {
+        var uuidBytes: ByteValue = (
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255),
+            .random(in: 0...255)
+        )
+        
+        // Set the version to 4 (random UUID)
+        uuidBytes.6 = (uuidBytes.6 & 0x0F) | 0x40
+        
+        // Set the variant to RFC 4122
+        uuidBytes.8 = (uuidBytes.8 & 0x3F) | 0x80
+        
+        self.init(uuid: uuidBytes)
+    }
+    
+    @inline(__always)
+    internal func withUUIDBytes<R>(_ work: (UnsafeBufferPointer<UInt8>) throws -> R) rethrows -> R {
+        return try withExtendedLifetime(self) {
+            try Swift.withUnsafeBytes(of: uuid) { rawBuffer in
+                return try rawBuffer.withMemoryRebound(to: UInt8.self) { buffer in
+                    return try work(buffer)
+                }
+            }
+        }
+    }
+    
+    /// Create a UUID from a string such as "E621E1F8-C36C-495A-93FC-0C247A3E6E5F".
+    ///
+    /// Returns nil for invalid strings.
+    public init?(uuidString string: String) {
+        guard let value = UInt128.bigEndian(uuidString: string) else {
+            return nil
+        }
+        self.init(uuid: value.bytes)
+    }
+    
+    /// Returns a string created from the UUID, such as "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
+    public var uuidString: String {
+        UInt128(bytes: uuid).bigEndianUUIDString
+    }
+}
+
+extension _UUID: Equatable {
+    
+    public static func ==(lhs: _UUID, rhs: _UUID) -> Bool {
+        Swift.withUnsafeBytes(of: lhs) { lhsPtr in
+            Swift.withUnsafeBytes(of: rhs) { rhsPtr in
+                let lhsTuple = lhsPtr.loadUnaligned(as: (UInt64, UInt64).self)
+                let rhsTuple = rhsPtr.loadUnaligned(as: (UInt64, UInt64).self)
+                return (lhsTuple.0 ^ rhsTuple.0) | (lhsTuple.1 ^ rhsTuple.1) == 0
+            }
+        }
+    }
+}
+
+extension _UUID: Hashable {
+    
+    public func hash(into hasher: inout Hasher) {
+        Swift.withUnsafeBytes(of: uuid) { buffer in
+            hasher.combine(bytes: buffer)
+        }
+    }
+}
+
+extension _UUID: CustomStringConvertible, CustomDebugStringConvertible {
+    
+    public var description: String {
+        return uuidString
+    }
+
+    public var debugDescription: String {
+        return description
+    }
+}
+
+#if !hasFeature(Embedded)
+@available(macOS 10.8, iOS 6.0, tvOS 9.0, watchOS 2.0, *)
+extension _UUID : CustomReflectable {
+    public var customMirror: Mirror {
+        let c : [(label: String?, value: Any)] = []
+        let m = Mirror(self, children:c, displayStyle: .struct)
+        return m
+    }
+}
+
+@available(macOS 10.8, iOS 6.0, tvOS 9.0, watchOS 2.0, *)
+extension _UUID : Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let uuidString = try container.decode(String.self)
+
+        guard let uuid = _UUID(uuidString: uuidString) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Attempted to decode UUID from invalid UUID string."))
+        }
+
+        self = uuid
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.uuidString)
+    }
+}
+#endif
+
+extension _UUID : Comparable {
+
+    public static func < (lhs: _UUID, rhs: _UUID) -> Bool {
+        var leftUUID = lhs.uuid
+        var rightUUID = rhs.uuid
+        var result: Int = 0
+        var diff: Int = 0
+        Swift.withUnsafeBytes(of: &leftUUID) { leftPtr in
+            Swift.withUnsafeBytes(of: &rightUUID) { rightPtr in
+                for offset in (0 ..< MemoryLayout<ByteValue>.size).reversed() {
+                    diff = Int(leftPtr.load(fromByteOffset: offset, as: UInt8.self)) -
+                        Int(rightPtr.load(fromByteOffset: offset, as: UInt8.self))
+                    // Constant time, no branching equivalent of
+                    // if (diff != 0) {
+                    //     result = diff;
+                    // }
+                    result = (result & (((diff - 1) & ~diff) >> 8)) | diff
+                }
+            }
+        }
+
+        return result < 0
+    }
+}
+
+// MARK: - UUID String
+
+fileprivate extension UInt128 {
+    
+    /// Parse a UUID string and return a value in big endian order.
+    static func bigEndian(uuidString string: String) -> UInt128? {
+        guard string.utf8.count == 36,
+            let separator = "-".utf8.first else {
+            return nil
+        }
+        let characters = string.utf8
+        guard characters[characters.index(characters.startIndex, offsetBy: 8)] == separator,
+              characters[characters.index(characters.startIndex, offsetBy: 13)] == separator,
+              characters[characters.index(characters.startIndex, offsetBy: 18)] == separator,
+              characters[characters.index(characters.startIndex, offsetBy: 23)] == separator,
+              let a = String(characters[characters.startIndex ..< characters.index(characters.startIndex, offsetBy: 8)]),
+              let b = String(characters[characters.index(characters.startIndex, offsetBy: 9) ..< characters.index(characters.startIndex, offsetBy: 13)]),
+              let c = String(characters[characters.index(characters.startIndex, offsetBy: 14) ..< characters.index(characters.startIndex, offsetBy: 18)]),
+              let d = String(characters[characters.index(characters.startIndex, offsetBy: 19) ..< characters.index(characters.startIndex, offsetBy: 23)]),
+              let e = String(characters[characters.index(characters.startIndex, offsetBy: 24) ..< characters.index(characters.startIndex, offsetBy: 36)])
+            else { return nil }
+        let hexadecimal = (a + b + c + d + e)
+        guard hexadecimal.utf8.count == 32 else {
+            return nil
+        }
+        if #available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *) {
+            guard let value = UInt128(hexadecimal: hexadecimal) else {
+                return nil
+            }
+            return value.bigEndian
+        } else {
+            #if hasFeature(Embedded)
+            // should never be executed
+            assertionFailure()
+            return nil
+            #else
+            guard let bytes = [UInt8](hexadecimal: hexadecimal),
+                  let value = UInt128(data: bytes) else {
+                return nil
+            }
+            return value
+            #endif
+        }
+    }
+    
+    /// Generate UUID string, e.g. `0F4DD6A4-0F71-48EF-98A5-996301B868F9` from a value initialized in its big endian order.
+    var bigEndianUUIDString: String {
+        
+        let a = (bytes.0.toHexadecimal()
+            + bytes.1.toHexadecimal()
+            + bytes.2.toHexadecimal()
+            + bytes.3.toHexadecimal())
+            
+        let b = (bytes.4.toHexadecimal()
+            + bytes.5.toHexadecimal())
+        
+        let c = (bytes.6.toHexadecimal()
+            + bytes.7.toHexadecimal())
+
+        let d = (bytes.8.toHexadecimal()
+            + bytes.9.toHexadecimal())
+
+        let e = (bytes.10.toHexadecimal()
+            + bytes.11.toHexadecimal()
+            + bytes.12.toHexadecimal()
+            + bytes.13.toHexadecimal()
+            + bytes.14.toHexadecimal()
+            + bytes.15.toHexadecimal())
+        
+        return a + "-" + b + "-" + c + "-" + d + "-" + e
+    }
+}
+
+internal extension UInt128 {
+    
+    /// Parse a UUID string.
+    init?(uuidString string: String) {
+        guard let bigEndian = Self.bigEndian(uuidString: string) else {
+            return nil
+        }
+        self.init(bigEndian: bigEndian)
+    }
+    
+    /// Generate UUID string, e.g. `0F4DD6A4-0F71-48EF-98A5-996301B868F9`.
+    var uuidString: String {
+        self.bigEndian.bigEndianUUIDString
+    }
+}

--- a/pico-w-ble-peripheral-sdk/Bluetooth/Generated/GeneratedCompanyIdentifiers.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/Generated/GeneratedCompanyIdentifiers.swift
@@ -1,0 +1,21898 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if (swift(<5.6) || !SWIFTPM_ENABLE_PLUGINS) && !os(WASI)
+public extension CompanyIdentifier {
+
+    /// Ericsson AB (`0`)
+    @_alwaysEmitIntoClient
+    static var ericsson: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 0)
+    }
+
+    /// Nokia Mobile Phones (`1`)
+    @_alwaysEmitIntoClient
+    static var nokiaMobilePhones: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1)
+    }
+
+    /// Intel Corp. (`2`)
+    @_alwaysEmitIntoClient
+    static var intel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2)
+    }
+
+    /// IBM Corp. (`3`)
+    @_alwaysEmitIntoClient
+    static var ibm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3)
+    }
+
+    /// Toshiba Corp. (`4`)
+    @_alwaysEmitIntoClient
+    static var toshiba: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 4)
+    }
+
+    /// 3Com (`5`)
+    @_alwaysEmitIntoClient
+    static var company3Com: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 5)
+    }
+
+    /// Microsoft (`6`)
+    @_alwaysEmitIntoClient
+    static var microsoft: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 6)
+    }
+
+    /// Lucent (`7`)
+    @_alwaysEmitIntoClient
+    static var lucent: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 7)
+    }
+
+    /// Motorola (`8`)
+    @_alwaysEmitIntoClient
+    static var motorola: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 8)
+    }
+
+    /// Infineon Technologies AG (`9`)
+    @_alwaysEmitIntoClient
+    static var infineonTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 9)
+    }
+
+    /// Qualcomm Technologies International, Ltd. (QTIL) (`10`)
+    @_alwaysEmitIntoClient
+    static var qualcommTechnologiesInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 10)
+    }
+
+    /// Silicon Wave (`11`)
+    @_alwaysEmitIntoClient
+    static var siliconWave: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 11)
+    }
+
+    /// Digianswer A/S (`12`)
+    @_alwaysEmitIntoClient
+    static var digianswer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 12)
+    }
+
+    /// Texas Instruments Inc. (`13`)
+    @_alwaysEmitIntoClient
+    static var texasInstruments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 13)
+    }
+
+    /// Parthus Technologies Inc. (`14`)
+    @_alwaysEmitIntoClient
+    static var parthusTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 14)
+    }
+
+    /// Broadcom Corporation (`15`)
+    @_alwaysEmitIntoClient
+    static var broadcom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 15)
+    }
+
+    /// Mitel Semiconductor (`16`)
+    @_alwaysEmitIntoClient
+    static var mitelSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 16)
+    }
+
+    /// Widcomm, Inc. (`17`)
+    @_alwaysEmitIntoClient
+    static var widcomm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 17)
+    }
+
+    /// Zeevo, Inc. (`18`)
+    @_alwaysEmitIntoClient
+    static var zeevo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 18)
+    }
+
+    /// Atmel Corporation (`19`)
+    @_alwaysEmitIntoClient
+    static var atmel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 19)
+    }
+
+    /// Mitsubishi Electric Corporation (`20`)
+    @_alwaysEmitIntoClient
+    static var mitsubishiElectric: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 20)
+    }
+
+    /// RTX A/S (`21`)
+    @_alwaysEmitIntoClient
+    static var rtx: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 21)
+    }
+
+    /// KC Technology Inc. (`22`)
+    @_alwaysEmitIntoClient
+    static var kcTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 22)
+    }
+
+    /// Newlogic (`23`)
+    @_alwaysEmitIntoClient
+    static var newlogic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 23)
+    }
+
+    /// Transilica, Inc. (`24`)
+    @_alwaysEmitIntoClient
+    static var transilica: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 24)
+    }
+
+    /// Rohde & Schwarz GmbH & Co. KG (`25`)
+    @_alwaysEmitIntoClient
+    static var rohdeSchwarz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 25)
+    }
+
+    /// TTPCom Limited (`26`)
+    @_alwaysEmitIntoClient
+    static var ttpcom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 26)
+    }
+
+    /// Signia Technologies, Inc. (`27`)
+    @_alwaysEmitIntoClient
+    static var signiaTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 27)
+    }
+
+    /// Conexant Systems Inc. (`28`)
+    @_alwaysEmitIntoClient
+    static var conexantSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 28)
+    }
+
+    /// Qualcomm (`29`)
+    @_alwaysEmitIntoClient
+    static var qualcomm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 29)
+    }
+
+    /// Inventel (`30`)
+    @_alwaysEmitIntoClient
+    static var inventel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 30)
+    }
+
+    /// AVM Berlin (`31`)
+    @_alwaysEmitIntoClient
+    static var avmBerlin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 31)
+    }
+
+    /// BandSpeed, Inc. (`32`)
+    @_alwaysEmitIntoClient
+    static var bandspeed: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 32)
+    }
+
+    /// Mansella Ltd (`33`)
+    @_alwaysEmitIntoClient
+    static var mansella: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 33)
+    }
+
+    /// NEC Corporation (`34`)
+    @_alwaysEmitIntoClient
+    static var nec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 34)
+    }
+
+    /// WavePlus Technology Co., Ltd. (`35`)
+    @_alwaysEmitIntoClient
+    static var waveplusTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 35)
+    }
+
+    /// Alcatel (`36`)
+    @_alwaysEmitIntoClient
+    static var alcatel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 36)
+    }
+
+    /// NXP B.V. (`37`)
+    @_alwaysEmitIntoClient
+    static var nxp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 37)
+    }
+
+    /// C Technologies (`38`)
+    @_alwaysEmitIntoClient
+    static var cTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 38)
+    }
+
+    /// Open Interface (`39`)
+    @_alwaysEmitIntoClient
+    static var openInterface: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 39)
+    }
+
+    /// R F Micro Devices (`40`)
+    @_alwaysEmitIntoClient
+    static var rFMicroDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 40)
+    }
+
+    /// Hitachi Ltd (`41`)
+    @_alwaysEmitIntoClient
+    static var hitachi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 41)
+    }
+
+    /// Symbol Technologies, Inc. (`42`)
+    @_alwaysEmitIntoClient
+    static var symbolTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 42)
+    }
+
+    /// Tenovis (`43`)
+    @_alwaysEmitIntoClient
+    static var tenovis: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 43)
+    }
+
+    /// Macronix International Co. Ltd. (`44`)
+    @_alwaysEmitIntoClient
+    static var macronixInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 44)
+    }
+
+    /// GCT Semiconductor (`45`)
+    @_alwaysEmitIntoClient
+    static var gctSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 45)
+    }
+
+    /// Norwood Systems (`46`)
+    @_alwaysEmitIntoClient
+    static var norwoodSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 46)
+    }
+
+    /// MewTel Technology Inc. (`47`)
+    @_alwaysEmitIntoClient
+    static var mewtelTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 47)
+    }
+
+    /// ST Microelectronics (`48`)
+    @_alwaysEmitIntoClient
+    static var stMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 48)
+    }
+
+    /// Synopsys, Inc. (`49`)
+    @_alwaysEmitIntoClient
+    static var synopsys: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 49)
+    }
+
+    /// Red-M (Communications) Ltd (`50`)
+    @_alwaysEmitIntoClient
+    static var redMCommunications: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 50)
+    }
+
+    /// Commil Ltd (`51`)
+    @_alwaysEmitIntoClient
+    static var commil: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 51)
+    }
+
+    /// Computer Access Technology Corporation (CATC) (`52`)
+    @_alwaysEmitIntoClient
+    static var computerAccessTechnologyCatc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 52)
+    }
+
+    /// Eclipse (HQ Espana) S.L. (`53`)
+    @_alwaysEmitIntoClient
+    static var eclipseHqEspana: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 53)
+    }
+
+    /// Renesas Electronics Corporation (`54`)
+    @_alwaysEmitIntoClient
+    static var renesasElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 54)
+    }
+
+    /// Mobilian Corporation (`55`)
+    @_alwaysEmitIntoClient
+    static var mobilian: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 55)
+    }
+
+    /// Syntronix Corporation (`56`)
+    @_alwaysEmitIntoClient
+    static var syntronix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 56)
+    }
+
+    /// Integrated System Solution Corp. (`57`)
+    @_alwaysEmitIntoClient
+    static var integratedSystemSolution: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 57)
+    }
+
+    /// Panasonic Holdings Corporation (`58`)
+    @_alwaysEmitIntoClient
+    static var panasonicHoldings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 58)
+    }
+
+    /// Gennum Corporation (`59`)
+    @_alwaysEmitIntoClient
+    static var gennum: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 59)
+    }
+
+    /// BlackBerry Limited (`60`)
+    @_alwaysEmitIntoClient
+    static var blackberry: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 60)
+    }
+
+    /// IPextreme, Inc. (`61`)
+    @_alwaysEmitIntoClient
+    static var ipextreme: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 61)
+    }
+
+    /// Systems and Chips, Inc (`62`)
+    @_alwaysEmitIntoClient
+    static var systemsAndChips: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 62)
+    }
+
+    /// Bluetooth SIG, Inc (`63`)
+    @_alwaysEmitIntoClient
+    static var bluetoothSig: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 63)
+    }
+
+    /// Seiko Epson Corporation (`64`)
+    @_alwaysEmitIntoClient
+    static var seikoEpson: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 64)
+    }
+
+    /// Integrated Silicon Solution Taiwan, Inc. (`65`)
+    @_alwaysEmitIntoClient
+    static var integratedSiliconSolutionTaiwan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 65)
+    }
+
+    /// CONWISE Technology Corporation Ltd (`66`)
+    @_alwaysEmitIntoClient
+    static var conwiseTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 66)
+    }
+
+    /// PARROT AUTOMOTIVE SAS (`67`)
+    @_alwaysEmitIntoClient
+    static var parrotAutomotives: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 67)
+    }
+
+    /// Socket Mobile (`68`)
+    @_alwaysEmitIntoClient
+    static var socketMobile: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 68)
+    }
+
+    /// Atheros Communications, Inc. (`69`)
+    @_alwaysEmitIntoClient
+    static var atherosCommunications: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 69)
+    }
+
+    /// MediaTek, Inc. (`70`)
+    @_alwaysEmitIntoClient
+    static var mediatek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 70)
+    }
+
+    /// Bluegiga (`71`)
+    @_alwaysEmitIntoClient
+    static var bluegiga: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 71)
+    }
+
+    /// Marvell Technology Group Ltd. (`72`)
+    @_alwaysEmitIntoClient
+    static var marvellTechnologyGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 72)
+    }
+
+    /// 3DSP Corporation (`73`)
+    @_alwaysEmitIntoClient
+    static var company3Dsp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 73)
+    }
+
+    /// Accel Semiconductor Ltd. (`74`)
+    @_alwaysEmitIntoClient
+    static var accelSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 74)
+    }
+
+    /// Continental Automotive Systems (`75`)
+    @_alwaysEmitIntoClient
+    static var continentalAutomotiveSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 75)
+    }
+
+    /// Apple, Inc. (`76`)
+    @_alwaysEmitIntoClient
+    static var apple: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 76)
+    }
+
+    /// Staccato Communications, Inc. (`77`)
+    @_alwaysEmitIntoClient
+    static var staccatoCommunications: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 77)
+    }
+
+    /// Avago Technologies (`78`)
+    @_alwaysEmitIntoClient
+    static var avagoTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 78)
+    }
+
+    /// APT Ltd. (`79`)
+    @_alwaysEmitIntoClient
+    static var apt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 79)
+    }
+
+    /// SiRF Technology, Inc. (`80`)
+    @_alwaysEmitIntoClient
+    static var sirfTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 80)
+    }
+
+    /// Tzero Technologies, Inc. (`81`)
+    @_alwaysEmitIntoClient
+    static var tzeroTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 81)
+    }
+
+    /// J&M Corporation (`82`)
+    @_alwaysEmitIntoClient
+    static var jM: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 82)
+    }
+
+    /// Free2move AB (`83`)
+    @_alwaysEmitIntoClient
+    static var free2Move: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 83)
+    }
+
+    /// 3DiJoy Corporation (`84`)
+    @_alwaysEmitIntoClient
+    static var company3Dijoy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 84)
+    }
+
+    /// Plantronics, Inc. (`85`)
+    @_alwaysEmitIntoClient
+    static var plantronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 85)
+    }
+
+    /// Sony Ericsson Mobile Communications (`86`)
+    @_alwaysEmitIntoClient
+    static var sonyEricssonMobileCommunications: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 86)
+    }
+
+    /// Harman International Industries, Inc. (`87`)
+    @_alwaysEmitIntoClient
+    static var harmanInternationalIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 87)
+    }
+
+    /// Vizio, Inc. (`88`)
+    @_alwaysEmitIntoClient
+    static var vizio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 88)
+    }
+
+    /// Nordic Semiconductor ASA (`89`)
+    @_alwaysEmitIntoClient
+    static var nordicSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 89)
+    }
+
+    /// EM Microelectronic-Marin SA (`90`)
+    @_alwaysEmitIntoClient
+    static var emMicroelectronicMarin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 90)
+    }
+
+    /// Ralink Technology Corporation (`91`)
+    @_alwaysEmitIntoClient
+    static var ralinkTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 91)
+    }
+
+    /// Belkin International, Inc. (`92`)
+    @_alwaysEmitIntoClient
+    static var belkinInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 92)
+    }
+
+    /// Realtek Semiconductor Corporation (`93`)
+    @_alwaysEmitIntoClient
+    static var realtekSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 93)
+    }
+
+    /// Stonestreet One, LLC (`94`)
+    @_alwaysEmitIntoClient
+    static var stonestreetOne: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 94)
+    }
+
+    /// Wicentric, Inc. (`95`)
+    @_alwaysEmitIntoClient
+    static var wicentric: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 95)
+    }
+
+    /// RivieraWaves S.A.S (`96`)
+    @_alwaysEmitIntoClient
+    static var rivierawaves: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 96)
+    }
+
+    /// RDA Microelectronics (`97`)
+    @_alwaysEmitIntoClient
+    static var rdaMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 97)
+    }
+
+    /// Gibson Guitars (`98`)
+    @_alwaysEmitIntoClient
+    static var gibsonGuitars: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 98)
+    }
+
+    /// MiCommand Inc. (`99`)
+    @_alwaysEmitIntoClient
+    static var micommand: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 99)
+    }
+
+    /// Band XI International, LLC (`100`)
+    @_alwaysEmitIntoClient
+    static var bandXiInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 100)
+    }
+
+    /// HP, Inc. (`101`)
+    @_alwaysEmitIntoClient
+    static var hp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 101)
+    }
+
+    /// 9Solutions Oy (`102`)
+    @_alwaysEmitIntoClient
+    static var company9Solutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 102)
+    }
+
+    /// GN Audio A/S (`103`)
+    @_alwaysEmitIntoClient
+    static var gnAudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 103)
+    }
+
+    /// General Motors (`104`)
+    @_alwaysEmitIntoClient
+    static var generalMotors: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 104)
+    }
+
+    /// A&D Engineering, Inc. (`105`)
+    @_alwaysEmitIntoClient
+    static var aDEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 105)
+    }
+
+    /// LTIMINDTREE LIMITED (`106`)
+    @_alwaysEmitIntoClient
+    static var ltimindtree: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 106)
+    }
+
+    /// Polar Electro OY (`107`)
+    @_alwaysEmitIntoClient
+    static var polarElectro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 107)
+    }
+
+    /// Beautiful Enterprise Co., Ltd. (`108`)
+    @_alwaysEmitIntoClient
+    static var beautifulEnterprise: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 108)
+    }
+
+    /// BriarTek, Inc (`109`)
+    @_alwaysEmitIntoClient
+    static var briartek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 109)
+    }
+
+    /// Summit Data Communications, Inc. (`110`)
+    @_alwaysEmitIntoClient
+    static var summitDataCommunications: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 110)
+    }
+
+    /// Sound ID (`111`)
+    @_alwaysEmitIntoClient
+    static var soundId: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 111)
+    }
+
+    /// Monster, LLC (`112`)
+    @_alwaysEmitIntoClient
+    static var monster: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 112)
+    }
+
+    /// connectBlue AB (`113`)
+    @_alwaysEmitIntoClient
+    static var connectblue: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 113)
+    }
+
+    /// ShangHai Super Smart Electronics Co. Ltd. (`114`)
+    @_alwaysEmitIntoClient
+    static var shanghaiSuperSmartElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 114)
+    }
+
+    /// Group Sense Ltd. (`115`)
+    @_alwaysEmitIntoClient
+    static var groupSense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 115)
+    }
+
+    /// Zomm, LLC (`116`)
+    @_alwaysEmitIntoClient
+    static var zomm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 116)
+    }
+
+    /// Samsung Electronics Co. Ltd. (`117`)
+    @_alwaysEmitIntoClient
+    static var samsungElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 117)
+    }
+
+    /// Creative Technology Ltd. (`118`)
+    @_alwaysEmitIntoClient
+    static var creativeTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 118)
+    }
+
+    /// Laird Connectivity LLC (`119`)
+    @_alwaysEmitIntoClient
+    static var lairdConnectivity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 119)
+    }
+
+    /// Nike, Inc. (`120`)
+    @_alwaysEmitIntoClient
+    static var nike: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 120)
+    }
+
+    /// lesswire AG (`121`)
+    @_alwaysEmitIntoClient
+    static var lesswire: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 121)
+    }
+
+    /// MStar Semiconductor, Inc. (`122`)
+    @_alwaysEmitIntoClient
+    static var mstarSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 122)
+    }
+
+    /// Hanlynn Technologies (`123`)
+    @_alwaysEmitIntoClient
+    static var hanlynnTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 123)
+    }
+
+    /// A & R Cambridge (`124`)
+    @_alwaysEmitIntoClient
+    static var aRCambridge: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 124)
+    }
+
+    /// Seers Technology Co., Ltd. (`125`)
+    @_alwaysEmitIntoClient
+    static var seersTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 125)
+    }
+
+    /// Sports Tracking Technologies Ltd. (`126`)
+    @_alwaysEmitIntoClient
+    static var sportsTrackingTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 126)
+    }
+
+    /// Autonet Mobile (`127`)
+    @_alwaysEmitIntoClient
+    static var autonetMobile: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 127)
+    }
+
+    /// DeLorme Publishing Company, Inc. (`128`)
+    @_alwaysEmitIntoClient
+    static var delormePublishing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 128)
+    }
+
+    /// WuXi Vimicro (`129`)
+    @_alwaysEmitIntoClient
+    static var wuxiVimicro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 129)
+    }
+
+    /// DSEA A/S (`130`)
+    @_alwaysEmitIntoClient
+    static var dsea: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 130)
+    }
+
+    /// TimeKeeping Systems, Inc. (`131`)
+    @_alwaysEmitIntoClient
+    static var timekeepingSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 131)
+    }
+
+    /// Ludus Helsinki Ltd. (`132`)
+    @_alwaysEmitIntoClient
+    static var ludusHelsinki: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 132)
+    }
+
+    /// BlueRadios, Inc. (`133`)
+    @_alwaysEmitIntoClient
+    static var blueradios: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 133)
+    }
+
+    /// Equinux AG (`134`)
+    @_alwaysEmitIntoClient
+    static var equinux: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 134)
+    }
+
+    /// Garmin International, Inc. (`135`)
+    @_alwaysEmitIntoClient
+    static var garminInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 135)
+    }
+
+    /// Ecotest (`136`)
+    @_alwaysEmitIntoClient
+    static var ecotest: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 136)
+    }
+
+    /// GN Hearing A/S (`137`)
+    @_alwaysEmitIntoClient
+    static var gnHearing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 137)
+    }
+
+    /// Jawbone (`138`)
+    @_alwaysEmitIntoClient
+    static var jawbone: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 138)
+    }
+
+    /// Topcon Positioning Systems, LLC (`139`)
+    @_alwaysEmitIntoClient
+    static var topconPositioningSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 139)
+    }
+
+    /// Gimbal Inc. (`140`)
+    @_alwaysEmitIntoClient
+    static var gimbal: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 140)
+    }
+
+    /// Zscan Software (`141`)
+    @_alwaysEmitIntoClient
+    static var zscanSoftware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 141)
+    }
+
+    /// Quintic Corp (`142`)
+    @_alwaysEmitIntoClient
+    static var quintic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 142)
+    }
+
+    /// Telit Wireless Solutions GmbH (`143`)
+    @_alwaysEmitIntoClient
+    static var telitWirelessSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 143)
+    }
+
+    /// Funai Electric Co., Ltd. (`144`)
+    @_alwaysEmitIntoClient
+    static var funaiElectric: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 144)
+    }
+
+    /// Advanced PANMOBIL systems GmbH & Co. KG (`145`)
+    @_alwaysEmitIntoClient
+    static var advancedPanmobilSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 145)
+    }
+
+    /// ThinkOptics, Inc. (`146`)
+    @_alwaysEmitIntoClient
+    static var thinkoptics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 146)
+    }
+
+    /// Universal Electronics, Inc. (`147`)
+    @_alwaysEmitIntoClient
+    static var universalElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 147)
+    }
+
+    /// Airoha Technology Corp. (`148`)
+    @_alwaysEmitIntoClient
+    static var airohaTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 148)
+    }
+
+    /// NEC Lighting, Ltd. (`149`)
+    @_alwaysEmitIntoClient
+    static var necLighting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 149)
+    }
+
+    /// ODM Technology, Inc. (`150`)
+    @_alwaysEmitIntoClient
+    static var odmTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 150)
+    }
+
+    /// ConnecteDevice Ltd. (`151`)
+    @_alwaysEmitIntoClient
+    static var connectedevice: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 151)
+    }
+
+    /// zero1.tv GmbH (`152`)
+    @_alwaysEmitIntoClient
+    static var zero1Tv: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 152)
+    }
+
+    /// i.Tech Dynamic Global Distribution Ltd. (`153`)
+    @_alwaysEmitIntoClient
+    static var iTechDynamicGlobalDistribution: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 153)
+    }
+
+    /// Alpwise (`154`)
+    @_alwaysEmitIntoClient
+    static var alpwise: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 154)
+    }
+
+    /// Jiangsu Toppower Automotive Electronics Co., Ltd. (`155`)
+    @_alwaysEmitIntoClient
+    static var jiangsuToppowerAutomotiveElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 155)
+    }
+
+    /// Colorfy, Inc. (`156`)
+    @_alwaysEmitIntoClient
+    static var colorfy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 156)
+    }
+
+    /// Geoforce Inc. (`157`)
+    @_alwaysEmitIntoClient
+    static var geoforce: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 157)
+    }
+
+    /// Bose Corporation (`158`)
+    @_alwaysEmitIntoClient
+    static var bose: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 158)
+    }
+
+    /// Suunto Oy (`159`)
+    @_alwaysEmitIntoClient
+    static var suunto: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 159)
+    }
+
+    /// Kensington Computer Products Group (`160`)
+    @_alwaysEmitIntoClient
+    static var kensingtonComputerProductsGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 160)
+    }
+
+    /// SR-Medizinelektronik (`161`)
+    @_alwaysEmitIntoClient
+    static var srMedizinelektronik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 161)
+    }
+
+    /// Vertu Corporation Limited (`162`)
+    @_alwaysEmitIntoClient
+    static var vertu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 162)
+    }
+
+    /// Meta Watch Ltd. (`163`)
+    @_alwaysEmitIntoClient
+    static var metaWatch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 163)
+    }
+
+    /// LINAK A/S (`164`)
+    @_alwaysEmitIntoClient
+    static var linak: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 164)
+    }
+
+    /// OTL Dynamics LLC (`165`)
+    @_alwaysEmitIntoClient
+    static var otlDynamics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 165)
+    }
+
+    /// Panda Ocean Inc. (`166`)
+    @_alwaysEmitIntoClient
+    static var pandaOcean: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 166)
+    }
+
+    /// Visteon Corporation (`167`)
+    @_alwaysEmitIntoClient
+    static var visteon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 167)
+    }
+
+    /// ARP Devices Limited (`168`)
+    @_alwaysEmitIntoClient
+    static var arpDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 168)
+    }
+
+    /// MARELLI EUROPE S.P.A. (`169`)
+    @_alwaysEmitIntoClient
+    static var marelliEurope: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 169)
+    }
+
+    /// CAEN RFID srl (`170`)
+    @_alwaysEmitIntoClient
+    static var caenRfid: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 170)
+    }
+
+    /// Ingenieur-Systemgruppe Zahn GmbH (`171`)
+    @_alwaysEmitIntoClient
+    static var ingenieurSystemgruppeZahn: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 171)
+    }
+
+    /// Green Throttle Games (`172`)
+    @_alwaysEmitIntoClient
+    static var greenThrottleGames: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 172)
+    }
+
+    /// Peter Systemtechnik GmbH (`173`)
+    @_alwaysEmitIntoClient
+    static var peterSystemtechnik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 173)
+    }
+
+    /// Omegawave Oy (`174`)
+    @_alwaysEmitIntoClient
+    static var omegawave: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 174)
+    }
+
+    /// Cinetix (`175`)
+    @_alwaysEmitIntoClient
+    static var cinetix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 175)
+    }
+
+    /// Passif Semiconductor Corp (`176`)
+    @_alwaysEmitIntoClient
+    static var passifSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 176)
+    }
+
+    /// Saris Cycling Group, Inc (`177`)
+    @_alwaysEmitIntoClient
+    static var sarisCyclingGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 177)
+    }
+
+    /// Bekey A/S (`178`)
+    @_alwaysEmitIntoClient
+    static var bekey: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 178)
+    }
+
+    /// Clarinox Technologies Pty. Ltd. (`179`)
+    @_alwaysEmitIntoClient
+    static var clarinoxTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 179)
+    }
+
+    /// BDE Technology Co., Ltd. (`180`)
+    @_alwaysEmitIntoClient
+    static var bdeTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 180)
+    }
+
+    /// Swirl Networks (`181`)
+    @_alwaysEmitIntoClient
+    static var swirlNetworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 181)
+    }
+
+    /// Meso international (`182`)
+    @_alwaysEmitIntoClient
+    static var mesoInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 182)
+    }
+
+    /// TreLab Ltd (`183`)
+    @_alwaysEmitIntoClient
+    static var trelab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 183)
+    }
+
+    /// Qualcomm Innovation Center, Inc. (QuIC) (`184`)
+    @_alwaysEmitIntoClient
+    static var qualcommInnovationCenterQuic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 184)
+    }
+
+    /// Johnson Controls, Inc. (`185`)
+    @_alwaysEmitIntoClient
+    static var johnsonControls: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 185)
+    }
+
+    /// Starkey Hearing Technologies (`186`)
+    @_alwaysEmitIntoClient
+    static var starkeyHearingTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 186)
+    }
+
+    /// S-Power Electronics Limited (`187`)
+    @_alwaysEmitIntoClient
+    static var sPowerElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 187)
+    }
+
+    /// Ace Sensor Inc (`188`)
+    @_alwaysEmitIntoClient
+    static var aceSensor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 188)
+    }
+
+    /// Aplix Corporation (`189`)
+    @_alwaysEmitIntoClient
+    static var aplix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 189)
+    }
+
+    /// AAMP of America (`190`)
+    @_alwaysEmitIntoClient
+    static var aampOfAmerica: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 190)
+    }
+
+    /// Stalmart Technology Limited (`191`)
+    @_alwaysEmitIntoClient
+    static var stalmartTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 191)
+    }
+
+    /// AMICCOM Electronics Corporation (`192`)
+    @_alwaysEmitIntoClient
+    static var amiccomElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 192)
+    }
+
+    /// Shenzhen Excelsecu Data Technology Co.,Ltd (`193`)
+    @_alwaysEmitIntoClient
+    static var shenzhenExcelsecuDataTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 193)
+    }
+
+    /// Geneq Inc. (`194`)
+    @_alwaysEmitIntoClient
+    static var geneq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 194)
+    }
+
+    /// adidas AG (`195`)
+    @_alwaysEmitIntoClient
+    static var adidas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 195)
+    }
+
+    /// LG Electronics (`196`)
+    @_alwaysEmitIntoClient
+    static var lgElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 196)
+    }
+
+    /// Onset Computer Corporation (`197`)
+    @_alwaysEmitIntoClient
+    static var onsetComputer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 197)
+    }
+
+    /// Selfly BV (`198`)
+    @_alwaysEmitIntoClient
+    static var selfly: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 198)
+    }
+
+    /// Quuppa Oy. (`199`)
+    @_alwaysEmitIntoClient
+    static var quuppa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 199)
+    }
+
+    /// GeLo Inc (`200`)
+    @_alwaysEmitIntoClient
+    static var gelo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 200)
+    }
+
+    /// Evluma (`201`)
+    @_alwaysEmitIntoClient
+    static var evluma: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 201)
+    }
+
+    /// MC10 (`202`)
+    @_alwaysEmitIntoClient
+    static var mc10: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 202)
+    }
+
+    /// Binauric SE (`203`)
+    @_alwaysEmitIntoClient
+    static var binauric: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 203)
+    }
+
+    /// Beats Electronics (`204`)
+    @_alwaysEmitIntoClient
+    static var beatsElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 204)
+    }
+
+    /// Microchip Technology Inc. (`205`)
+    @_alwaysEmitIntoClient
+    static var microchipTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 205)
+    }
+
+    /// Eve Systems GmbH (`206`)
+    @_alwaysEmitIntoClient
+    static var eveSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 206)
+    }
+
+    /// ARCHOS SA (`207`)
+    @_alwaysEmitIntoClient
+    static var archos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 207)
+    }
+
+    /// Dexcom, Inc. (`208`)
+    @_alwaysEmitIntoClient
+    static var dexcom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 208)
+    }
+
+    /// Polar Electro Europe B.V. (`209`)
+    @_alwaysEmitIntoClient
+    static var polarElectroEurope: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 209)
+    }
+
+    /// Dialog Semiconductor B.V. (`210`)
+    @_alwaysEmitIntoClient
+    static var dialogSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 210)
+    }
+
+    /// Taixingbang Technology (HK) Co,. LTD. (`211`)
+    @_alwaysEmitIntoClient
+    static var taixingbangTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 211)
+    }
+
+    /// Kawantech (`212`)
+    @_alwaysEmitIntoClient
+    static var kawantech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 212)
+    }
+
+    /// Austco Communication Systems (`213`)
+    @_alwaysEmitIntoClient
+    static var austcoCommunicationSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 213)
+    }
+
+    /// Timex Group USA, Inc. (`214`)
+    @_alwaysEmitIntoClient
+    static var timexGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 214)
+    }
+
+    /// Qualcomm Technologies, Inc. (`215`)
+    @_alwaysEmitIntoClient
+    static var qualcommTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 215)
+    }
+
+    /// Qualcomm Connected Experiences, Inc. (`216`)
+    @_alwaysEmitIntoClient
+    static var qualcommConnectedExperiences: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 216)
+    }
+
+    /// Voyetra Turtle Beach (`217`)
+    @_alwaysEmitIntoClient
+    static var voyetraTurtleBeach: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 217)
+    }
+
+    /// txtr GmbH (`218`)
+    @_alwaysEmitIntoClient
+    static var txtr: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 218)
+    }
+
+    /// Snuza (Pty) Ltd (`219`)
+    @_alwaysEmitIntoClient
+    static var snuzaPty: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 219)
+    }
+
+    /// Procter & Gamble (`220`)
+    @_alwaysEmitIntoClient
+    static var procterGamble: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 220)
+    }
+
+    /// Hosiden Corporation (`221`)
+    @_alwaysEmitIntoClient
+    static var hosiden: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 221)
+    }
+
+    /// Muzik LLC (`222`)
+    @_alwaysEmitIntoClient
+    static var muzik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 222)
+    }
+
+    /// Misfit Wearables Corp (`223`)
+    @_alwaysEmitIntoClient
+    static var misfitWearables: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 223)
+    }
+
+    /// Google (`224`)
+    @_alwaysEmitIntoClient
+    static var google: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 224)
+    }
+
+    /// Danlers Ltd (`225`)
+    @_alwaysEmitIntoClient
+    static var danlers: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 225)
+    }
+
+    /// Semilink Inc (`226`)
+    @_alwaysEmitIntoClient
+    static var semilink: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 226)
+    }
+
+    /// inMusic Brands, Inc (`227`)
+    @_alwaysEmitIntoClient
+    static var inmusicBrands: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 227)
+    }
+
+    /// L.S. Research, Inc. (`228`)
+    @_alwaysEmitIntoClient
+    static var lSResearch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 228)
+    }
+
+    /// Eden Software Consultants Ltd. (`229`)
+    @_alwaysEmitIntoClient
+    static var edenSoftwareConsultants: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 229)
+    }
+
+    /// Freshtemp (`230`)
+    @_alwaysEmitIntoClient
+    static var freshtemp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 230)
+    }
+
+    /// KS Technologies (`231`)
+    @_alwaysEmitIntoClient
+    static var ksTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 231)
+    }
+
+    /// ACTS Technologies (`232`)
+    @_alwaysEmitIntoClient
+    static var actsTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 232)
+    }
+
+    /// Vtrack Systems (`233`)
+    @_alwaysEmitIntoClient
+    static var vtrackSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 233)
+    }
+
+    /// www.vtracksystems.com (`234`)
+    @_alwaysEmitIntoClient
+    static var wwwVtracksystemsCom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 234)
+    }
+
+    /// Server Technology Inc. (`235`)
+    @_alwaysEmitIntoClient
+    static var serverTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 235)
+    }
+
+    /// BioResearch Associates (`236`)
+    @_alwaysEmitIntoClient
+    static var bioresearchAssociates: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 236)
+    }
+
+    /// Jolly Logic, LLC (`237`)
+    @_alwaysEmitIntoClient
+    static var jollyLogic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 237)
+    }
+
+    /// Above Average Outcomes, Inc. (`238`)
+    @_alwaysEmitIntoClient
+    static var aboveAverageOutcomes: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 238)
+    }
+
+    /// Bitsplitters GmbH (`239`)
+    @_alwaysEmitIntoClient
+    static var bitsplitters: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 239)
+    }
+
+    /// PayPal, Inc. (`240`)
+    @_alwaysEmitIntoClient
+    static var paypal: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 240)
+    }
+
+    /// Witron Technology Limited (`241`)
+    @_alwaysEmitIntoClient
+    static var witronTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 241)
+    }
+
+    /// Morse Project Inc. (`242`)
+    @_alwaysEmitIntoClient
+    static var morseProject: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 242)
+    }
+
+    /// Kent Displays Inc. (`243`)
+    @_alwaysEmitIntoClient
+    static var kentDisplays: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 243)
+    }
+
+    /// Nautilus Inc. (`244`)
+    @_alwaysEmitIntoClient
+    static var nautilus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 244)
+    }
+
+    /// Smartifier Oy (`245`)
+    @_alwaysEmitIntoClient
+    static var smartifier: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 245)
+    }
+
+    /// Elcometer Limited (`246`)
+    @_alwaysEmitIntoClient
+    static var elcometer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 246)
+    }
+
+    /// VSN Technologies, Inc. (`247`)
+    @_alwaysEmitIntoClient
+    static var vsnTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 247)
+    }
+
+    /// AceUni Corp., Ltd. (`248`)
+    @_alwaysEmitIntoClient
+    static var aceuni: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 248)
+    }
+
+    /// StickNFind (`249`)
+    @_alwaysEmitIntoClient
+    static var sticknfind: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 249)
+    }
+
+    /// Crystal Alarm AB (`250`)
+    @_alwaysEmitIntoClient
+    static var crystalAlarm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 250)
+    }
+
+    /// KOUKAAM a.s. (`251`)
+    @_alwaysEmitIntoClient
+    static var koukaam: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 251)
+    }
+
+    /// Delphi Corporation (`252`)
+    @_alwaysEmitIntoClient
+    static var delphi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 252)
+    }
+
+    /// ValenceTech Limited (`253`)
+    @_alwaysEmitIntoClient
+    static var valencetech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 253)
+    }
+
+    /// Stanley Black and Decker (`254`)
+    @_alwaysEmitIntoClient
+    static var stanleyBlackAndDecker: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 254)
+    }
+
+    /// Typo Products, LLC (`255`)
+    @_alwaysEmitIntoClient
+    static var typoProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 255)
+    }
+
+    /// TomTom International BV (`256`)
+    @_alwaysEmitIntoClient
+    static var tomtomInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 256)
+    }
+
+    /// Fugoo, Inc. (`257`)
+    @_alwaysEmitIntoClient
+    static var fugoo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 257)
+    }
+
+    /// Keiser Corporation (`258`)
+    @_alwaysEmitIntoClient
+    static var keiser: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 258)
+    }
+
+    /// Bang & Olufsen A/S (`259`)
+    @_alwaysEmitIntoClient
+    static var bangOlufsen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 259)
+    }
+
+    /// PLUS Location Systems Pty Ltd (`260`)
+    @_alwaysEmitIntoClient
+    static var plusLocationSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 260)
+    }
+
+    /// Ubiquitous Computing Technology Corporation (`261`)
+    @_alwaysEmitIntoClient
+    static var ubiquitousComputingTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 261)
+    }
+
+    /// Innovative Yachtter Solutions (`262`)
+    @_alwaysEmitIntoClient
+    static var innovativeYachtterSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 262)
+    }
+
+    /// Demant A/S (`263`)
+    @_alwaysEmitIntoClient
+    static var demant: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 263)
+    }
+
+    /// Chicony Electronics Co., Ltd. (`264`)
+    @_alwaysEmitIntoClient
+    static var chiconyElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 264)
+    }
+
+    /// Atus BV (`265`)
+    @_alwaysEmitIntoClient
+    static var atus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 265)
+    }
+
+    /// Codegate Ltd (`266`)
+    @_alwaysEmitIntoClient
+    static var codegate: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 266)
+    }
+
+    /// ERi, Inc (`267`)
+    @_alwaysEmitIntoClient
+    static var eri: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 267)
+    }
+
+    /// Transducers Direct, LLC (`268`)
+    @_alwaysEmitIntoClient
+    static var transducersDirect: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 268)
+    }
+
+    /// DENSO TEN Limited (`269`)
+    @_alwaysEmitIntoClient
+    static var densoTen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 269)
+    }
+
+    /// Audi AG (`270`)
+    @_alwaysEmitIntoClient
+    static var audi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 270)
+    }
+
+    /// HiSilicon Technologies CO., LIMITED (`271`)
+    @_alwaysEmitIntoClient
+    static var hisiliconTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 271)
+    }
+
+    /// Nippon Seiki Co., Ltd. (`272`)
+    @_alwaysEmitIntoClient
+    static var nipponSeiki: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 272)
+    }
+
+    /// Steelseries ApS (`273`)
+    @_alwaysEmitIntoClient
+    static var steelseries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 273)
+    }
+
+    /// Visybl Inc. (`274`)
+    @_alwaysEmitIntoClient
+    static var visybl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 274)
+    }
+
+    /// Openbrain Technologies, Co., Ltd. (`275`)
+    @_alwaysEmitIntoClient
+    static var openbrainTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 275)
+    }
+
+    /// Xensr (`276`)
+    @_alwaysEmitIntoClient
+    static var xensr: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 276)
+    }
+
+    /// e.solutions (`277`)
+    @_alwaysEmitIntoClient
+    static var eSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 277)
+    }
+
+    /// 10AK Technologies (`278`)
+    @_alwaysEmitIntoClient
+    static var company10AkTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 278)
+    }
+
+    /// Wimoto Technologies Inc (`279`)
+    @_alwaysEmitIntoClient
+    static var wimotoTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 279)
+    }
+
+    /// Radius Networks, Inc. (`280`)
+    @_alwaysEmitIntoClient
+    static var radiusNetworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 280)
+    }
+
+    /// Wize Technology Co., Ltd. (`281`)
+    @_alwaysEmitIntoClient
+    static var wizeTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 281)
+    }
+
+    /// Qualcomm Labs, Inc. (`282`)
+    @_alwaysEmitIntoClient
+    static var qualcommLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 282)
+    }
+
+    /// Hewlett Packard Enterprise (`283`)
+    @_alwaysEmitIntoClient
+    static var hewlettPackardEnterprise: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 283)
+    }
+
+    /// Baidu (`284`)
+    @_alwaysEmitIntoClient
+    static var baidu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 284)
+    }
+
+    /// Arendi AG (`285`)
+    @_alwaysEmitIntoClient
+    static var arendi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 285)
+    }
+
+    /// Skoda Auto a.s. (`286`)
+    @_alwaysEmitIntoClient
+    static var skodaAuto: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 286)
+    }
+
+    /// Volkswagen AG (`287`)
+    @_alwaysEmitIntoClient
+    static var volkswagen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 287)
+    }
+
+    /// Porsche AG (`288`)
+    @_alwaysEmitIntoClient
+    static var porsche: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 288)
+    }
+
+    /// Sino Wealth Electronic Ltd. (`289`)
+    @_alwaysEmitIntoClient
+    static var sinoWealthElectronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 289)
+    }
+
+    /// AirTurn, Inc. (`290`)
+    @_alwaysEmitIntoClient
+    static var airturn: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 290)
+    }
+
+    /// Kinsa, Inc (`291`)
+    @_alwaysEmitIntoClient
+    static var kinsa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 291)
+    }
+
+    /// HID Global (`292`)
+    @_alwaysEmitIntoClient
+    static var hidGlobal: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 292)
+    }
+
+    /// SEAT es (`293`)
+    @_alwaysEmitIntoClient
+    static var seatEs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 293)
+    }
+
+    /// Promethean Ltd. (`294`)
+    @_alwaysEmitIntoClient
+    static var promethean: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 294)
+    }
+
+    /// Salutica Allied Solutions (`295`)
+    @_alwaysEmitIntoClient
+    static var saluticaAlliedSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 295)
+    }
+
+    /// GPSI Group Pty Ltd (`296`)
+    @_alwaysEmitIntoClient
+    static var gpsiGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 296)
+    }
+
+    /// Nimble Devices Oy (`297`)
+    @_alwaysEmitIntoClient
+    static var nimbleDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 297)
+    }
+
+    /// Changzhou Yongse Infotech  Co., Ltd. (`298`)
+    @_alwaysEmitIntoClient
+    static var changzhouYongseInfotech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 298)
+    }
+
+    /// SportIQ (`299`)
+    @_alwaysEmitIntoClient
+    static var sportiq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 299)
+    }
+
+    /// TEMEC Instruments B.V. (`300`)
+    @_alwaysEmitIntoClient
+    static var temecInstruments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 300)
+    }
+
+    /// Sony Corporation (`301`)
+    @_alwaysEmitIntoClient
+    static var sony: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 301)
+    }
+
+    /// ASSA ABLOY (`302`)
+    @_alwaysEmitIntoClient
+    static var assaAbloy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 302)
+    }
+
+    /// Clarion Co. Inc. (`303`)
+    @_alwaysEmitIntoClient
+    static var clarion: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 303)
+    }
+
+    /// Warehouse Innovations (`304`)
+    @_alwaysEmitIntoClient
+    static var warehouseInnovations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 304)
+    }
+
+    /// Cypress Semiconductor (`305`)
+    @_alwaysEmitIntoClient
+    static var cypressSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 305)
+    }
+
+    /// MADS Inc (`306`)
+    @_alwaysEmitIntoClient
+    static var mads: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 306)
+    }
+
+    /// Blue Maestro Limited (`307`)
+    @_alwaysEmitIntoClient
+    static var blueMaestro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 307)
+    }
+
+    /// Resolution Products, Ltd. (`308`)
+    @_alwaysEmitIntoClient
+    static var resolutionProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 308)
+    }
+
+    /// Aireware LLC (`309`)
+    @_alwaysEmitIntoClient
+    static var aireware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 309)
+    }
+
+    /// Silvair, Inc. (`310`)
+    @_alwaysEmitIntoClient
+    static var silvair: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 310)
+    }
+
+    /// Prestigio Plaza Ltd. (`311`)
+    @_alwaysEmitIntoClient
+    static var prestigioPlaza: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 311)
+    }
+
+    /// NTEO Inc. (`312`)
+    @_alwaysEmitIntoClient
+    static var nteo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 312)
+    }
+
+    /// Focus Systems Corporation (`313`)
+    @_alwaysEmitIntoClient
+    static var focusSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 313)
+    }
+
+    /// Tencent Holdings Ltd. (`314`)
+    @_alwaysEmitIntoClient
+    static var tencentHoldings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 314)
+    }
+
+    /// Allegion (`315`)
+    @_alwaysEmitIntoClient
+    static var allegion: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 315)
+    }
+
+    /// Murata Manufacturing Co., Ltd. (`316`)
+    @_alwaysEmitIntoClient
+    static var murataManufacturing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 316)
+    }
+
+    /// WirelessWERX (`317`)
+    @_alwaysEmitIntoClient
+    static var wirelesswerx: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 317)
+    }
+
+    /// Nod, Inc. (`318`)
+    @_alwaysEmitIntoClient
+    static var nod: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 318)
+    }
+
+    /// B&B Manufacturing Company (`319`)
+    @_alwaysEmitIntoClient
+    static var bBManufacturing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 319)
+    }
+
+    /// Alpine Electronics (China) Co., Ltd (`320`)
+    @_alwaysEmitIntoClient
+    static var alpineElectronicsChina: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 320)
+    }
+
+    /// FedEx Services (`321`)
+    @_alwaysEmitIntoClient
+    static var fedexServices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 321)
+    }
+
+    /// Grape Systems Inc. (`322`)
+    @_alwaysEmitIntoClient
+    static var grapeSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 322)
+    }
+
+    /// Bkon Connect (`323`)
+    @_alwaysEmitIntoClient
+    static var bkonConnect: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 323)
+    }
+
+    /// Lintech GmbH (`324`)
+    @_alwaysEmitIntoClient
+    static var lintech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 324)
+    }
+
+    /// Novatel Wireless (`325`)
+    @_alwaysEmitIntoClient
+    static var novatelWireless: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 325)
+    }
+
+    /// Ciright (`326`)
+    @_alwaysEmitIntoClient
+    static var ciright: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 326)
+    }
+
+    /// Mighty Cast, Inc. (`327`)
+    @_alwaysEmitIntoClient
+    static var mightyCast: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 327)
+    }
+
+    /// Ambimat Electronics (`328`)
+    @_alwaysEmitIntoClient
+    static var ambimatElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 328)
+    }
+
+    /// Perytons Ltd. (`329`)
+    @_alwaysEmitIntoClient
+    static var perytons: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 329)
+    }
+
+    /// Tivoli Audio, LLC (`330`)
+    @_alwaysEmitIntoClient
+    static var tivoliAudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 330)
+    }
+
+    /// Master Lock (`331`)
+    @_alwaysEmitIntoClient
+    static var masterLock: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 331)
+    }
+
+    /// Mesh-Net Ltd (`332`)
+    @_alwaysEmitIntoClient
+    static var meshNet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 332)
+    }
+
+    /// HUIZHOU DESAY SV AUTOMOTIVE CO., LTD. (`333`)
+    @_alwaysEmitIntoClient
+    static var huizhouDesaySvAutomotive: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 333)
+    }
+
+    /// Tangerine, Inc. (`334`)
+    @_alwaysEmitIntoClient
+    static var tangerine: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 334)
+    }
+
+    /// B&W Group Ltd. (`335`)
+    @_alwaysEmitIntoClient
+    static var bWGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 335)
+    }
+
+    /// Pioneer Corporation (`336`)
+    @_alwaysEmitIntoClient
+    static var pioneer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 336)
+    }
+
+    /// OnBeep (`337`)
+    @_alwaysEmitIntoClient
+    static var onbeep: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 337)
+    }
+
+    /// Vernier Software & Technology (`338`)
+    @_alwaysEmitIntoClient
+    static var vernierSoftwareTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 338)
+    }
+
+    /// ROL Ergo (`339`)
+    @_alwaysEmitIntoClient
+    static var rolErgo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 339)
+    }
+
+    /// Pebble Technology (`340`)
+    @_alwaysEmitIntoClient
+    static var pebbleTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 340)
+    }
+
+    /// NETATMO (`341`)
+    @_alwaysEmitIntoClient
+    static var netatmo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 341)
+    }
+
+    /// Accumulate AB (`342`)
+    @_alwaysEmitIntoClient
+    static var accumulate: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 342)
+    }
+
+    /// Anhui Huami Information Technology Co., Ltd. (`343`)
+    @_alwaysEmitIntoClient
+    static var anhuiHuamiInformationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 343)
+    }
+
+    /// Inmite s.r.o. (`344`)
+    @_alwaysEmitIntoClient
+    static var inmite: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 344)
+    }
+
+    /// ChefSteps, Inc. (`345`)
+    @_alwaysEmitIntoClient
+    static var chefsteps: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 345)
+    }
+
+    /// micas AG (`346`)
+    @_alwaysEmitIntoClient
+    static var micas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 346)
+    }
+
+    /// Biomedical Research Ltd. (`347`)
+    @_alwaysEmitIntoClient
+    static var biomedicalResearch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 347)
+    }
+
+    /// Pitius Tec S.L. (`348`)
+    @_alwaysEmitIntoClient
+    static var pitiusTec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 348)
+    }
+
+    /// Estimote, Inc. (`349`)
+    @_alwaysEmitIntoClient
+    static var estimote: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 349)
+    }
+
+    /// Unikey Technologies, Inc. (`350`)
+    @_alwaysEmitIntoClient
+    static var unikeyTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 350)
+    }
+
+    /// Timer Cap Co. (`351`)
+    @_alwaysEmitIntoClient
+    static var timerCap: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 351)
+    }
+
+    /// AwoX (`352`)
+    @_alwaysEmitIntoClient
+    static var awox: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 352)
+    }
+
+    /// yikes (`353`)
+    @_alwaysEmitIntoClient
+    static var yikes: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 353)
+    }
+
+    /// MADSGlobalNZ Ltd. (`354`)
+    @_alwaysEmitIntoClient
+    static var madsglobalnz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 354)
+    }
+
+    /// PCH International (`355`)
+    @_alwaysEmitIntoClient
+    static var pchInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 355)
+    }
+
+    /// Qingdao Yeelink Information Technology Co., Ltd. (`356`)
+    @_alwaysEmitIntoClient
+    static var qingdaoYeelinkInformationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 356)
+    }
+
+    /// Milwaukee Electric Tools (`357`)
+    @_alwaysEmitIntoClient
+    static var milwaukeeElectricTools: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 357)
+    }
+
+    /// MISHIK Pte Ltd (`358`)
+    @_alwaysEmitIntoClient
+    static var mishikPte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 358)
+    }
+
+    /// Ascensia Diabetes Care US Inc. (`359`)
+    @_alwaysEmitIntoClient
+    static var ascensiaDiabetesCareUs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 359)
+    }
+
+    /// Spicebox LLC (`360`)
+    @_alwaysEmitIntoClient
+    static var spicebox: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 360)
+    }
+
+    /// emberlight (`361`)
+    @_alwaysEmitIntoClient
+    static var emberlight: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 361)
+    }
+
+    /// Copeland Cold Chain LP (`362`)
+    @_alwaysEmitIntoClient
+    static var copelandColdChainLp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 362)
+    }
+
+    /// Qblinks (`363`)
+    @_alwaysEmitIntoClient
+    static var qblinks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 363)
+    }
+
+    /// MYSPHERA (`364`)
+    @_alwaysEmitIntoClient
+    static var mysphera: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 364)
+    }
+
+    /// LifeScan Inc (`365`)
+    @_alwaysEmitIntoClient
+    static var lifescan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 365)
+    }
+
+    /// Volantic AB (`366`)
+    @_alwaysEmitIntoClient
+    static var volantic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 366)
+    }
+
+    /// Podo Labs, Inc (`367`)
+    @_alwaysEmitIntoClient
+    static var podoLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 367)
+    }
+
+    /// Roche Diabetes Care AG (`368`)
+    @_alwaysEmitIntoClient
+    static var rocheDiabetesCare: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 368)
+    }
+
+    /// Amazon.com Services LLC (`369`)
+    @_alwaysEmitIntoClient
+    static var amazonComServices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 369)
+    }
+
+    /// Connovate Technology Private Limited (`370`)
+    @_alwaysEmitIntoClient
+    static var connovateTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 370)
+    }
+
+    /// Kocomojo, LLC (`371`)
+    @_alwaysEmitIntoClient
+    static var kocomojo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 371)
+    }
+
+    /// Everykey Inc. (`372`)
+    @_alwaysEmitIntoClient
+    static var everykey: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 372)
+    }
+
+    /// Dynamic Controls (`373`)
+    @_alwaysEmitIntoClient
+    static var dynamicControls: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 373)
+    }
+
+    /// SentriLock (`374`)
+    @_alwaysEmitIntoClient
+    static var sentrilock: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 374)
+    }
+
+    /// I-SYST inc. (`375`)
+    @_alwaysEmitIntoClient
+    static var iSyst: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 375)
+    }
+
+    /// CASIO COMPUTER CO., LTD. (`376`)
+    @_alwaysEmitIntoClient
+    static var casioComputer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 376)
+    }
+
+    /// LAPIS Semiconductor Co.,Ltd (`377`)
+    @_alwaysEmitIntoClient
+    static var lapisSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 377)
+    }
+
+    /// Telemonitor, Inc. (`378`)
+    @_alwaysEmitIntoClient
+    static var telemonitor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 378)
+    }
+
+    /// taskit GmbH (`379`)
+    @_alwaysEmitIntoClient
+    static var taskit: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 379)
+    }
+
+    /// Mercedes-Benz Group AG (`380`)
+    @_alwaysEmitIntoClient
+    static var mercedesBenzGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 380)
+    }
+
+    /// BatAndCat (`381`)
+    @_alwaysEmitIntoClient
+    static var batandcat: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 381)
+    }
+
+    /// BluDotz Ltd (`382`)
+    @_alwaysEmitIntoClient
+    static var bludotz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 382)
+    }
+
+    /// XTel Wireless ApS (`383`)
+    @_alwaysEmitIntoClient
+    static var xtelWireless: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 383)
+    }
+
+    /// Gigaset Technologies GmbH (`384`)
+    @_alwaysEmitIntoClient
+    static var gigasetTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 384)
+    }
+
+    /// Gecko Health Innovations, Inc. (`385`)
+    @_alwaysEmitIntoClient
+    static var geckoHealthInnovations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 385)
+    }
+
+    /// HOP Ubiquitous (`386`)
+    @_alwaysEmitIntoClient
+    static var hopUbiquitous: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 386)
+    }
+
+    /// Walt Disney (`387`)
+    @_alwaysEmitIntoClient
+    static var waltDisney: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 387)
+    }
+
+    /// Nectar (`388`)
+    @_alwaysEmitIntoClient
+    static var nectar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 388)
+    }
+
+    /// bel'apps LLC (`389`)
+    @_alwaysEmitIntoClient
+    static var belApps: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 389)
+    }
+
+    /// CORE Lighting Ltd (`390`)
+    @_alwaysEmitIntoClient
+    static var coreLighting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 390)
+    }
+
+    /// Seraphim Sense Ltd (`391`)
+    @_alwaysEmitIntoClient
+    static var seraphimSense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 391)
+    }
+
+    /// Unico RBC (`392`)
+    @_alwaysEmitIntoClient
+    static var unicoRbc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 392)
+    }
+
+    /// Physical Enterprises Inc. (`393`)
+    @_alwaysEmitIntoClient
+    static var physicalEnterprises: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 393)
+    }
+
+    /// Able Trend Technology Limited (`394`)
+    @_alwaysEmitIntoClient
+    static var ableTrendTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 394)
+    }
+
+    /// Konica Minolta, Inc. (`395`)
+    @_alwaysEmitIntoClient
+    static var konicaMinolta: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 395)
+    }
+
+    /// Wilo SE (`396`)
+    @_alwaysEmitIntoClient
+    static var wilo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 396)
+    }
+
+    /// Extron Design Services (`397`)
+    @_alwaysEmitIntoClient
+    static var extronDesignServices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 397)
+    }
+
+    /// Google LLC (`398`)
+    @_alwaysEmitIntoClient
+    static var google2: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 398)
+    }
+
+    /// Fireflies Systems (`399`)
+    @_alwaysEmitIntoClient
+    static var firefliesSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 399)
+    }
+
+    /// Intelletto Technologies Inc. (`400`)
+    @_alwaysEmitIntoClient
+    static var intellettoTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 400)
+    }
+
+    /// FDK CORPORATION (`401`)
+    @_alwaysEmitIntoClient
+    static var fdk: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 401)
+    }
+
+    /// Cloudleaf, Inc (`402`)
+    @_alwaysEmitIntoClient
+    static var cloudleaf: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 402)
+    }
+
+    /// Maveric Automation LLC (`403`)
+    @_alwaysEmitIntoClient
+    static var mavericAutomation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 403)
+    }
+
+    /// Acoustic Stream Corporation (`404`)
+    @_alwaysEmitIntoClient
+    static var acousticStream: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 404)
+    }
+
+    /// Zuli (`405`)
+    @_alwaysEmitIntoClient
+    static var zuli: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 405)
+    }
+
+    /// Paxton Access Ltd (`406`)
+    @_alwaysEmitIntoClient
+    static var paxtonAccess: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 406)
+    }
+
+    /// WiSilica Inc. (`407`)
+    @_alwaysEmitIntoClient
+    static var wisilica: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 407)
+    }
+
+    /// VENGIT Korlatolt Felelossegu Tarsasag (`408`)
+    @_alwaysEmitIntoClient
+    static var vengitKorlatoltFelelosseguTarsasag: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 408)
+    }
+
+    /// SALTO SYSTEMS S.L. (`409`)
+    @_alwaysEmitIntoClient
+    static var saltoSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 409)
+    }
+
+    /// TRON Forum (`410`)
+    @_alwaysEmitIntoClient
+    static var tronForum: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 410)
+    }
+
+    /// CUBETECH s.r.o. (`411`)
+    @_alwaysEmitIntoClient
+    static var cubetech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 411)
+    }
+
+    /// Cokiya Incorporated (`412`)
+    @_alwaysEmitIntoClient
+    static var cokiya: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 412)
+    }
+
+    /// CVS Health (`413`)
+    @_alwaysEmitIntoClient
+    static var cvsHealth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 413)
+    }
+
+    /// Ceruus (`414`)
+    @_alwaysEmitIntoClient
+    static var ceruus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 414)
+    }
+
+    /// Strainstall Ltd (`415`)
+    @_alwaysEmitIntoClient
+    static var strainstall: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 415)
+    }
+
+    /// Channel Enterprises (HK) Ltd. (`416`)
+    @_alwaysEmitIntoClient
+    static var channelEnterprises: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 416)
+    }
+
+    /// FIAMM (`417`)
+    @_alwaysEmitIntoClient
+    static var fiamm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 417)
+    }
+
+    /// GIGALANE.CO.,LTD (`418`)
+    @_alwaysEmitIntoClient
+    static var gigalane: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 418)
+    }
+
+    /// EROAD (`419`)
+    @_alwaysEmitIntoClient
+    static var eroad: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 419)
+    }
+
+    /// MSA Innovation, LLC (`420`)
+    @_alwaysEmitIntoClient
+    static var msaInnovation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 420)
+    }
+
+    /// Icon Health and Fitness (`421`)
+    @_alwaysEmitIntoClient
+    static var iconHealthAndFitness: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 421)
+    }
+
+    /// Wille Engineering (`422`)
+    @_alwaysEmitIntoClient
+    static var willeEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 422)
+    }
+
+    /// ENERGOUS CORPORATION (`423`)
+    @_alwaysEmitIntoClient
+    static var energous: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 423)
+    }
+
+    /// Taobao (`424`)
+    @_alwaysEmitIntoClient
+    static var taobao: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 424)
+    }
+
+    /// Canon Inc. (`425`)
+    @_alwaysEmitIntoClient
+    static var canon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 425)
+    }
+
+    /// Geophysical Technology Inc. (`426`)
+    @_alwaysEmitIntoClient
+    static var geophysicalTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 426)
+    }
+
+    /// Meta Platforms, Inc. (`427`)
+    @_alwaysEmitIntoClient
+    static var metaPlatforms: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 427)
+    }
+
+    /// Trividia Health, Inc. (`428`)
+    @_alwaysEmitIntoClient
+    static var trividiaHealth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 428)
+    }
+
+    /// FlightSafety International (`429`)
+    @_alwaysEmitIntoClient
+    static var flightsafetyInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 429)
+    }
+
+    /// Earlens Corporation (`430`)
+    @_alwaysEmitIntoClient
+    static var earlens: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 430)
+    }
+
+    /// Sunrise Micro Devices, Inc. (`431`)
+    @_alwaysEmitIntoClient
+    static var sunriseMicroDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 431)
+    }
+
+    /// Star Micronics Co., Ltd. (`432`)
+    @_alwaysEmitIntoClient
+    static var starMicronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 432)
+    }
+
+    /// Netizens Sp. z o.o. (`433`)
+    @_alwaysEmitIntoClient
+    static var netizens: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 433)
+    }
+
+    /// Nymi Inc. (`434`)
+    @_alwaysEmitIntoClient
+    static var nymi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 434)
+    }
+
+    /// Nytec, Inc. (`435`)
+    @_alwaysEmitIntoClient
+    static var nytec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 435)
+    }
+
+    /// Trineo Sp. z o.o. (`436`)
+    @_alwaysEmitIntoClient
+    static var trineo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 436)
+    }
+
+    /// Nest Labs Inc. (`437`)
+    @_alwaysEmitIntoClient
+    static var nestLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 437)
+    }
+
+    /// LM Technologies Ltd (`438`)
+    @_alwaysEmitIntoClient
+    static var lmTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 438)
+    }
+
+    /// General Electric Company (`439`)
+    @_alwaysEmitIntoClient
+    static var generalElectric: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 439)
+    }
+
+    /// i+D3 S.L. (`440`)
+    @_alwaysEmitIntoClient
+    static var iD3: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 440)
+    }
+
+    /// HANA Micron (`441`)
+    @_alwaysEmitIntoClient
+    static var hanaMicron: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 441)
+    }
+
+    /// Stages Cycling LLC (`442`)
+    @_alwaysEmitIntoClient
+    static var stagesCycling: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 442)
+    }
+
+    /// Cochlear Bone Anchored Solutions AB (`443`)
+    @_alwaysEmitIntoClient
+    static var cochlearBoneAnchoredSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 443)
+    }
+
+    /// SenionLab AB (`444`)
+    @_alwaysEmitIntoClient
+    static var senionlab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 444)
+    }
+
+    /// Syszone Co., Ltd (`445`)
+    @_alwaysEmitIntoClient
+    static var syszone: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 445)
+    }
+
+    /// Pulsate Mobile Ltd. (`446`)
+    @_alwaysEmitIntoClient
+    static var pulsateMobile: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 446)
+    }
+
+    /// Hongkong OnMicro Electronics Limited (`447`)
+    @_alwaysEmitIntoClient
+    static var hongkongOnmicroElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 447)
+    }
+
+    /// pironex GmbH (`448`)
+    @_alwaysEmitIntoClient
+    static var pironex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 448)
+    }
+
+    /// BRADATECH Corp. (`449`)
+    @_alwaysEmitIntoClient
+    static var bradatech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 449)
+    }
+
+    /// Transenergooil AG (`450`)
+    @_alwaysEmitIntoClient
+    static var transenergooil: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 450)
+    }
+
+    /// Bunch (`451`)
+    @_alwaysEmitIntoClient
+    static var bunch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 451)
+    }
+
+    /// DME Microelectronics (`452`)
+    @_alwaysEmitIntoClient
+    static var dmeMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 452)
+    }
+
+    /// Bitcraze AB (`453`)
+    @_alwaysEmitIntoClient
+    static var bitcraze: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 453)
+    }
+
+    /// HASWARE Inc. (`454`)
+    @_alwaysEmitIntoClient
+    static var hasware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 454)
+    }
+
+    /// Abiogenix Inc. (`455`)
+    @_alwaysEmitIntoClient
+    static var abiogenix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 455)
+    }
+
+    /// Poly-Control ApS (`456`)
+    @_alwaysEmitIntoClient
+    static var polyControl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 456)
+    }
+
+    /// Avi-on (`457`)
+    @_alwaysEmitIntoClient
+    static var aviOn: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 457)
+    }
+
+    /// Laerdal Medical AS (`458`)
+    @_alwaysEmitIntoClient
+    static var laerdalMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 458)
+    }
+
+    /// Fetch My Pet (`459`)
+    @_alwaysEmitIntoClient
+    static var fetchMyPet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 459)
+    }
+
+    /// Sam Labs Ltd. (`460`)
+    @_alwaysEmitIntoClient
+    static var samLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 460)
+    }
+
+    /// Chengdu Synwing Technology Ltd (`461`)
+    @_alwaysEmitIntoClient
+    static var chengduSynwingTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 461)
+    }
+
+    /// HOUWA SYSTEM DESIGN, k.k. (`462`)
+    @_alwaysEmitIntoClient
+    static var houwaSystemDesignKK: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 462)
+    }
+
+    /// BSH (`463`)
+    @_alwaysEmitIntoClient
+    static var bsh: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 463)
+    }
+
+    /// Primus Inter Pares Ltd (`464`)
+    @_alwaysEmitIntoClient
+    static var primusInterPares: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 464)
+    }
+
+    /// August Home, Inc (`465`)
+    @_alwaysEmitIntoClient
+    static var augustHome: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 465)
+    }
+
+    /// Gill Electronics (`466`)
+    @_alwaysEmitIntoClient
+    static var gillElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 466)
+    }
+
+    /// Sky Wave Design (`467`)
+    @_alwaysEmitIntoClient
+    static var skyWaveDesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 467)
+    }
+
+    /// Newlab S.r.l. (`468`)
+    @_alwaysEmitIntoClient
+    static var newlab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 468)
+    }
+
+    /// ELAD srl (`469`)
+    @_alwaysEmitIntoClient
+    static var elad: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 469)
+    }
+
+    /// G-wearables inc. (`470`)
+    @_alwaysEmitIntoClient
+    static var gWearables: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 470)
+    }
+
+    /// Squadrone Systems Inc. (`471`)
+    @_alwaysEmitIntoClient
+    static var squadroneSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 471)
+    }
+
+    /// Code Corporation (`472`)
+    @_alwaysEmitIntoClient
+    static var code: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 472)
+    }
+
+    /// Savant Systems LLC (`473`)
+    @_alwaysEmitIntoClient
+    static var savantSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 473)
+    }
+
+    /// Logitech International SA (`474`)
+    @_alwaysEmitIntoClient
+    static var logitechInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 474)
+    }
+
+    /// Innblue Consulting (`475`)
+    @_alwaysEmitIntoClient
+    static var innblueConsulting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 475)
+    }
+
+    /// iParking Ltd. (`476`)
+    @_alwaysEmitIntoClient
+    static var iparking: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 476)
+    }
+
+    /// Koninklijke Philips N.V. (`477`)
+    @_alwaysEmitIntoClient
+    static var koninklijkePhilips: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 477)
+    }
+
+    /// Minelab Electronics Pty Limited (`478`)
+    @_alwaysEmitIntoClient
+    static var minelabElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 478)
+    }
+
+    /// Bison Group Ltd. (`479`)
+    @_alwaysEmitIntoClient
+    static var bisonGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 479)
+    }
+
+    /// Widex A/S (`480`)
+    @_alwaysEmitIntoClient
+    static var widex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 480)
+    }
+
+    /// Jolla Ltd (`481`)
+    @_alwaysEmitIntoClient
+    static var jolla: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 481)
+    }
+
+    /// Lectronix, Inc. (`482`)
+    @_alwaysEmitIntoClient
+    static var lectronix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 482)
+    }
+
+    /// Caterpillar Inc (`483`)
+    @_alwaysEmitIntoClient
+    static var caterpillar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 483)
+    }
+
+    /// Freedom Innovations (`484`)
+    @_alwaysEmitIntoClient
+    static var freedomInnovations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 484)
+    }
+
+    /// Dynamic Devices Ltd (`485`)
+    @_alwaysEmitIntoClient
+    static var dynamicDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 485)
+    }
+
+    /// Technology Solutions (UK) Ltd (`486`)
+    @_alwaysEmitIntoClient
+    static var technologySolutionsUk: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 486)
+    }
+
+    /// IPS Group Inc. (`487`)
+    @_alwaysEmitIntoClient
+    static var ipsGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 487)
+    }
+
+    /// STIR (`488`)
+    @_alwaysEmitIntoClient
+    static var stir: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 488)
+    }
+
+    /// Sano, Inc. (`489`)
+    @_alwaysEmitIntoClient
+    static var sano: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 489)
+    }
+
+    /// Advanced Application Design, Inc. (`490`)
+    @_alwaysEmitIntoClient
+    static var advancedApplicationDesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 490)
+    }
+
+    /// AutoMap LLC (`491`)
+    @_alwaysEmitIntoClient
+    static var automap: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 491)
+    }
+
+    /// Spreadtrum Communications Shanghai Ltd (`492`)
+    @_alwaysEmitIntoClient
+    static var spreadtrumCommunicationsShanghai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 492)
+    }
+
+    /// CuteCircuit LTD (`493`)
+    @_alwaysEmitIntoClient
+    static var cutecircuit: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 493)
+    }
+
+    /// Valeo Service (`494`)
+    @_alwaysEmitIntoClient
+    static var valeoService: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 494)
+    }
+
+    /// Fullpower Technologies, Inc. (`495`)
+    @_alwaysEmitIntoClient
+    static var fullpowerTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 495)
+    }
+
+    /// KloudNation (`496`)
+    @_alwaysEmitIntoClient
+    static var kloudnation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 496)
+    }
+
+    /// Zebra Technologies Corporation (`497`)
+    @_alwaysEmitIntoClient
+    static var zebraTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 497)
+    }
+
+    /// Itron, Inc. (`498`)
+    @_alwaysEmitIntoClient
+    static var itron: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 498)
+    }
+
+    /// The University of Tokyo (`499`)
+    @_alwaysEmitIntoClient
+    static var universityOfTokyo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 499)
+    }
+
+    /// UTC Fire and Security (`500`)
+    @_alwaysEmitIntoClient
+    static var utcFireAndSecurity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 500)
+    }
+
+    /// Cool Webthings Limited (`501`)
+    @_alwaysEmitIntoClient
+    static var coolWebthings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 501)
+    }
+
+    /// DJO Global (`502`)
+    @_alwaysEmitIntoClient
+    static var djoGlobal: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 502)
+    }
+
+    /// Gelliner Limited (`503`)
+    @_alwaysEmitIntoClient
+    static var gelliner: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 503)
+    }
+
+    /// Anyka (Guangzhou) Microelectronics Technology Co, LTD (`504`)
+    @_alwaysEmitIntoClient
+    static var anykaGuangzhouMicroelectronicsTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 504)
+    }
+
+    /// Medtronic Inc. (`505`)
+    @_alwaysEmitIntoClient
+    static var medtronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 505)
+    }
+
+    /// Gozio Inc. (`506`)
+    @_alwaysEmitIntoClient
+    static var gozio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 506)
+    }
+
+    /// Form Lifting, LLC (`507`)
+    @_alwaysEmitIntoClient
+    static var formLifting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 507)
+    }
+
+    /// Wahoo Fitness, LLC (`508`)
+    @_alwaysEmitIntoClient
+    static var wahooFitness: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 508)
+    }
+
+    /// Kontakt Micro-Location Sp. z o.o. (`509`)
+    @_alwaysEmitIntoClient
+    static var kontaktMicroLocation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 509)
+    }
+
+    /// Radio Systems Corporation (`510`)
+    @_alwaysEmitIntoClient
+    static var radioSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 510)
+    }
+
+    /// Freescale Semiconductor, Inc. (`511`)
+    @_alwaysEmitIntoClient
+    static var freescaleSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 511)
+    }
+
+    /// Verifone Systems Pte Ltd. Taiwan Branch (`512`)
+    @_alwaysEmitIntoClient
+    static var verifoneSystemsPteTaiwanBranch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 512)
+    }
+
+    /// AR Timing (`513`)
+    @_alwaysEmitIntoClient
+    static var arTiming: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 513)
+    }
+
+    /// Rigado LLC (`514`)
+    @_alwaysEmitIntoClient
+    static var rigado: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 514)
+    }
+
+    /// Kemppi Oy (`515`)
+    @_alwaysEmitIntoClient
+    static var kemppi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 515)
+    }
+
+    /// Tapcentive Inc. (`516`)
+    @_alwaysEmitIntoClient
+    static var tapcentive: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 516)
+    }
+
+    /// Smartbotics Inc. (`517`)
+    @_alwaysEmitIntoClient
+    static var smartbotics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 517)
+    }
+
+    /// Otter Products, LLC (`518`)
+    @_alwaysEmitIntoClient
+    static var otterProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 518)
+    }
+
+    /// STEMP Inc. (`519`)
+    @_alwaysEmitIntoClient
+    static var stemp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 519)
+    }
+
+    /// LumiGeek LLC (`520`)
+    @_alwaysEmitIntoClient
+    static var lumigeek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 520)
+    }
+
+    /// InvisionHeart Inc. (`521`)
+    @_alwaysEmitIntoClient
+    static var invisionheart: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 521)
+    }
+
+    /// Macnica Inc. (`522`)
+    @_alwaysEmitIntoClient
+    static var macnica: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 522)
+    }
+
+    /// Jaguar Land Rover Limited (`523`)
+    @_alwaysEmitIntoClient
+    static var jaguarLandRover: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 523)
+    }
+
+    /// CoroWare Technologies, Inc (`524`)
+    @_alwaysEmitIntoClient
+    static var corowareTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 524)
+    }
+
+    /// Simplo Technology Co., LTD (`525`)
+    @_alwaysEmitIntoClient
+    static var simploTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 525)
+    }
+
+    /// Omron Healthcare Co., LTD (`526`)
+    @_alwaysEmitIntoClient
+    static var omronHealthcare: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 526)
+    }
+
+    /// Comodule GMBH (`527`)
+    @_alwaysEmitIntoClient
+    static var comodule: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 527)
+    }
+
+    /// ikeGPS (`528`)
+    @_alwaysEmitIntoClient
+    static var ikegps: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 528)
+    }
+
+    /// Telink Semiconductor Co. Ltd (`529`)
+    @_alwaysEmitIntoClient
+    static var telinkSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 529)
+    }
+
+    /// Interplan Co., Ltd (`530`)
+    @_alwaysEmitIntoClient
+    static var interplan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 530)
+    }
+
+    /// Wyler AG (`531`)
+    @_alwaysEmitIntoClient
+    static var wyler: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 531)
+    }
+
+    /// IK Multimedia Production srl (`532`)
+    @_alwaysEmitIntoClient
+    static var ikMultimediaProduction: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 532)
+    }
+
+    /// Lukoton Experience Oy (`533`)
+    @_alwaysEmitIntoClient
+    static var lukotonExperience: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 533)
+    }
+
+    /// MTI Ltd (`534`)
+    @_alwaysEmitIntoClient
+    static var mti: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 534)
+    }
+
+    /// Tech4home, Lda (`535`)
+    @_alwaysEmitIntoClient
+    static var tech4HomeLda: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 535)
+    }
+
+    /// Hiotech AB (`536`)
+    @_alwaysEmitIntoClient
+    static var hiotech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 536)
+    }
+
+    /// DOTT Limited (`537`)
+    @_alwaysEmitIntoClient
+    static var dott: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 537)
+    }
+
+    /// Blue Speck Labs, LLC (`538`)
+    @_alwaysEmitIntoClient
+    static var blueSpeckLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 538)
+    }
+
+    /// Cisco Systems, Inc (`539`)
+    @_alwaysEmitIntoClient
+    static var ciscoSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 539)
+    }
+
+    /// Mobicomm Inc (`540`)
+    @_alwaysEmitIntoClient
+    static var mobicomm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 540)
+    }
+
+    /// Edamic (`541`)
+    @_alwaysEmitIntoClient
+    static var edamic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 541)
+    }
+
+    /// Goodnet, Ltd (`542`)
+    @_alwaysEmitIntoClient
+    static var goodnet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 542)
+    }
+
+    /// Luster Leaf Products  Inc (`543`)
+    @_alwaysEmitIntoClient
+    static var lusterLeafProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 543)
+    }
+
+    /// Manus Machina BV (`544`)
+    @_alwaysEmitIntoClient
+    static var manusMachina: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 544)
+    }
+
+    /// Mobiquity Networks Inc (`545`)
+    @_alwaysEmitIntoClient
+    static var mobiquityNetworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 545)
+    }
+
+    /// Praxis Dynamics (`546`)
+    @_alwaysEmitIntoClient
+    static var praxisDynamics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 546)
+    }
+
+    /// Philip Morris Products S.A. (`547`)
+    @_alwaysEmitIntoClient
+    static var philipMorrisProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 547)
+    }
+
+    /// Comarch SA (`548`)
+    @_alwaysEmitIntoClient
+    static var comarch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 548)
+    }
+
+    /// Nestlé Nespresso S.A. (`549`)
+    @_alwaysEmitIntoClient
+    static var nestleNespresso: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 549)
+    }
+
+    /// Merlinia A/S (`550`)
+    @_alwaysEmitIntoClient
+    static var merlinia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 550)
+    }
+
+    /// LifeBEAM Technologies (`551`)
+    @_alwaysEmitIntoClient
+    static var lifebeamTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 551)
+    }
+
+    /// Twocanoes Labs, LLC (`552`)
+    @_alwaysEmitIntoClient
+    static var twocanoesLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 552)
+    }
+
+    /// Muoverti Limited (`553`)
+    @_alwaysEmitIntoClient
+    static var muoverti: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 553)
+    }
+
+    /// Stamer Musikanlagen GMBH (`554`)
+    @_alwaysEmitIntoClient
+    static var stamerMusikanlagen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 554)
+    }
+
+    /// Tesla, Inc. (`555`)
+    @_alwaysEmitIntoClient
+    static var tesla: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 555)
+    }
+
+    /// Pharynks Corporation (`556`)
+    @_alwaysEmitIntoClient
+    static var pharynks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 556)
+    }
+
+    /// Lupine (`557`)
+    @_alwaysEmitIntoClient
+    static var lupine: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 557)
+    }
+
+    /// Siemens AG (`558`)
+    @_alwaysEmitIntoClient
+    static var siemens: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 558)
+    }
+
+    /// Huami (Shanghai) Culture Communication CO., LTD (`559`)
+    @_alwaysEmitIntoClient
+    static var huamiShanghaiCultureCommunication: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 559)
+    }
+
+    /// Foster Electric Company, Ltd (`560`)
+    @_alwaysEmitIntoClient
+    static var fosterElectric: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 560)
+    }
+
+    /// ETA SA (`561`)
+    @_alwaysEmitIntoClient
+    static var eta: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 561)
+    }
+
+    /// x-Senso Solutions Kft (`562`)
+    @_alwaysEmitIntoClient
+    static var xSensoSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 562)
+    }
+
+    /// Shenzhen SuLong Communication Ltd (`563`)
+    @_alwaysEmitIntoClient
+    static var shenzhenSulongCommunication: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 563)
+    }
+
+    /// FengFan (BeiJing) Technology Co, Ltd (`564`)
+    @_alwaysEmitIntoClient
+    static var fengfanBeijingTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 564)
+    }
+
+    /// Qrio Inc (`565`)
+    @_alwaysEmitIntoClient
+    static var qrio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 565)
+    }
+
+    /// Pitpatpet Ltd (`566`)
+    @_alwaysEmitIntoClient
+    static var pitpatpet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 566)
+    }
+
+    /// MSHeli s.r.l. (`567`)
+    @_alwaysEmitIntoClient
+    static var msheli: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 567)
+    }
+
+    /// Trakm8 Ltd (`568`)
+    @_alwaysEmitIntoClient
+    static var trakm8: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 568)
+    }
+
+    /// JIN CO, Ltd (`569`)
+    @_alwaysEmitIntoClient
+    static var jin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 569)
+    }
+
+    /// Alatech Tehnology (`570`)
+    @_alwaysEmitIntoClient
+    static var alatechTehnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 570)
+    }
+
+    /// Beijing CarePulse Electronic Technology Co, Ltd (`571`)
+    @_alwaysEmitIntoClient
+    static var beijingCarepulseElectronicTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 571)
+    }
+
+    /// Awarepoint (`572`)
+    @_alwaysEmitIntoClient
+    static var awarepoint: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 572)
+    }
+
+    /// ViCentra B.V. (`573`)
+    @_alwaysEmitIntoClient
+    static var vicentra: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 573)
+    }
+
+    /// Raven Industries (`574`)
+    @_alwaysEmitIntoClient
+    static var ravenIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 574)
+    }
+
+    /// WaveWare Technologies Inc. (`575`)
+    @_alwaysEmitIntoClient
+    static var wavewareTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 575)
+    }
+
+    /// Argenox Technologies (`576`)
+    @_alwaysEmitIntoClient
+    static var argenoxTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 576)
+    }
+
+    /// Bragi GmbH (`577`)
+    @_alwaysEmitIntoClient
+    static var bragi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 577)
+    }
+
+    /// 16Lab Inc (`578`)
+    @_alwaysEmitIntoClient
+    static var company16Lab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 578)
+    }
+
+    /// Masimo Corp (`579`)
+    @_alwaysEmitIntoClient
+    static var masimo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 579)
+    }
+
+    /// Iotera Inc (`580`)
+    @_alwaysEmitIntoClient
+    static var iotera: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 580)
+    }
+
+    /// Endress+Hauser (`581`)
+    @_alwaysEmitIntoClient
+    static var endressHauser: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 581)
+    }
+
+    /// ACKme Networks, Inc. (`582`)
+    @_alwaysEmitIntoClient
+    static var ackmeNetworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 582)
+    }
+
+    /// FiftyThree Inc. (`583`)
+    @_alwaysEmitIntoClient
+    static var fiftythree: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 583)
+    }
+
+    /// Parker Hannifin Corp (`584`)
+    @_alwaysEmitIntoClient
+    static var parkerHannifin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 584)
+    }
+
+    /// Transcranial Ltd (`585`)
+    @_alwaysEmitIntoClient
+    static var transcranial: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 585)
+    }
+
+    /// Uwatec AG (`586`)
+    @_alwaysEmitIntoClient
+    static var uwatec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 586)
+    }
+
+    /// Orlan LLC (`587`)
+    @_alwaysEmitIntoClient
+    static var orlan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 587)
+    }
+
+    /// Blue Clover Devices (`588`)
+    @_alwaysEmitIntoClient
+    static var blueCloverDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 588)
+    }
+
+    /// M-Way Solutions GmbH (`589`)
+    @_alwaysEmitIntoClient
+    static var mWaySolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 589)
+    }
+
+    /// Microtronics Engineering GmbH (`590`)
+    @_alwaysEmitIntoClient
+    static var microtronicsEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 590)
+    }
+
+    /// Schneider Schreibgeräte GmbH (`591`)
+    @_alwaysEmitIntoClient
+    static var schneiderSchreibgerate: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 591)
+    }
+
+    /// Sapphire Circuits LLC (`592`)
+    @_alwaysEmitIntoClient
+    static var sapphireCircuits: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 592)
+    }
+
+    /// Lumo Bodytech Inc. (`593`)
+    @_alwaysEmitIntoClient
+    static var lumoBodytech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 593)
+    }
+
+    /// UKC Technosolution (`594`)
+    @_alwaysEmitIntoClient
+    static var ukcTechnosolution: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 594)
+    }
+
+    /// Xicato Inc. (`595`)
+    @_alwaysEmitIntoClient
+    static var xicato: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 595)
+    }
+
+    /// Playbrush (`596`)
+    @_alwaysEmitIntoClient
+    static var playbrush: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 596)
+    }
+
+    /// Dai Nippon Printing Co., Ltd. (`597`)
+    @_alwaysEmitIntoClient
+    static var daiNipponPrinting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 597)
+    }
+
+    /// G24 Power Limited (`598`)
+    @_alwaysEmitIntoClient
+    static var g24Power: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 598)
+    }
+
+    /// AdBabble Local Commerce Inc. (`599`)
+    @_alwaysEmitIntoClient
+    static var adbabbleLocalCommerce: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 599)
+    }
+
+    /// Devialet SA (`600`)
+    @_alwaysEmitIntoClient
+    static var devialet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 600)
+    }
+
+    /// ALTYOR (`601`)
+    @_alwaysEmitIntoClient
+    static var altyor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 601)
+    }
+
+    /// University of Applied Sciences Valais/Haute Ecole Valaisanne (`602`)
+    @_alwaysEmitIntoClient
+    static var universityOfAppliedSciencesValaisHauteEcoleValaisanne: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 602)
+    }
+
+    /// Five Interactive, LLC dba Zendo (`603`)
+    @_alwaysEmitIntoClient
+    static var fiveInteractiveDbaZendo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 603)
+    }
+
+    /// NetEase（Hangzhou）Network co.Ltd. (`604`)
+    @_alwaysEmitIntoClient
+    static var neteaseHangzhouNetwork: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 604)
+    }
+
+    /// Lexmark International Inc. (`605`)
+    @_alwaysEmitIntoClient
+    static var lexmarkInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 605)
+    }
+
+    /// Fluke Corporation (`606`)
+    @_alwaysEmitIntoClient
+    static var fluke: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 606)
+    }
+
+    /// Yardarm Technologies (`607`)
+    @_alwaysEmitIntoClient
+    static var yardarmTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 607)
+    }
+
+    /// SensaRx (`608`)
+    @_alwaysEmitIntoClient
+    static var sensarx: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 608)
+    }
+
+    /// SECVRE GmbH (`609`)
+    @_alwaysEmitIntoClient
+    static var secvre: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 609)
+    }
+
+    /// Glacial Ridge Technologies (`610`)
+    @_alwaysEmitIntoClient
+    static var glacialRidgeTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 610)
+    }
+
+    /// Identiv, Inc. (`611`)
+    @_alwaysEmitIntoClient
+    static var identiv: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 611)
+    }
+
+    /// DDS, Inc. (`612`)
+    @_alwaysEmitIntoClient
+    static var dds: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 612)
+    }
+
+    /// SMK Corporation (`613`)
+    @_alwaysEmitIntoClient
+    static var smk: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 613)
+    }
+
+    /// Schawbel Technologies LLC (`614`)
+    @_alwaysEmitIntoClient
+    static var schawbelTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 614)
+    }
+
+    /// XMI Systems SA (`615`)
+    @_alwaysEmitIntoClient
+    static var xmiSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 615)
+    }
+
+    /// Cerevo (`616`)
+    @_alwaysEmitIntoClient
+    static var cerevo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 616)
+    }
+
+    /// Torrox GmbH & Co KG (`617`)
+    @_alwaysEmitIntoClient
+    static var torrox: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 617)
+    }
+
+    /// Gemalto (`618`)
+    @_alwaysEmitIntoClient
+    static var gemalto: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 618)
+    }
+
+    /// DEKA Research & Development Corp. (`619`)
+    @_alwaysEmitIntoClient
+    static var dekaResearchDevelopment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 619)
+    }
+
+    /// Domster Tadeusz Szydlowski (`620`)
+    @_alwaysEmitIntoClient
+    static var domsterTadeuszSzydlowski: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 620)
+    }
+
+    /// Technogym SPA (`621`)
+    @_alwaysEmitIntoClient
+    static var technogymSpa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 621)
+    }
+
+    /// FLEURBAEY BVBA (`622`)
+    @_alwaysEmitIntoClient
+    static var fleurbaeyba: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 622)
+    }
+
+    /// Aptcode Solutions (`623`)
+    @_alwaysEmitIntoClient
+    static var aptcodeSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 623)
+    }
+
+    /// LSI ADL Technology (`624`)
+    @_alwaysEmitIntoClient
+    static var lsiAdlTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 624)
+    }
+
+    /// Animas Corp (`625`)
+    @_alwaysEmitIntoClient
+    static var animas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 625)
+    }
+
+    /// Alps Alpine Co., Ltd. (`626`)
+    @_alwaysEmitIntoClient
+    static var alpsAlpine: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 626)
+    }
+
+    /// OCEASOFT (`627`)
+    @_alwaysEmitIntoClient
+    static var oceasoft: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 627)
+    }
+
+    /// Motsai Research (`628`)
+    @_alwaysEmitIntoClient
+    static var motsaiResearch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 628)
+    }
+
+    /// Geotab (`629`)
+    @_alwaysEmitIntoClient
+    static var geotab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 629)
+    }
+
+    /// E.G.O. Elektro-Geraetebau GmbH (`630`)
+    @_alwaysEmitIntoClient
+    static var eGOElektroGeraetebau: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 630)
+    }
+
+    /// bewhere inc (`631`)
+    @_alwaysEmitIntoClient
+    static var bewhere: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 631)
+    }
+
+    /// Johnson Outdoors Inc (`632`)
+    @_alwaysEmitIntoClient
+    static var johnsonOutdoors: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 632)
+    }
+
+    /// steute Schaltgerate GmbH & Co. KG (`633`)
+    @_alwaysEmitIntoClient
+    static var steuteSchaltgerate: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 633)
+    }
+
+    /// Ekomini inc. (`634`)
+    @_alwaysEmitIntoClient
+    static var ekomini: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 634)
+    }
+
+    /// DEFA AS (`635`)
+    @_alwaysEmitIntoClient
+    static var defa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 635)
+    }
+
+    /// Aseptika Ltd (`636`)
+    @_alwaysEmitIntoClient
+    static var aseptika: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 636)
+    }
+
+    /// HUAWEI Technologies Co., Ltd. (`637`)
+    @_alwaysEmitIntoClient
+    static var huaweiTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 637)
+    }
+
+    /// HabitAware, LLC (`638`)
+    @_alwaysEmitIntoClient
+    static var habitaware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 638)
+    }
+
+    /// ruwido austria gmbh (`639`)
+    @_alwaysEmitIntoClient
+    static var ruwidoAustria: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 639)
+    }
+
+    /// ITEC corporation (`640`)
+    @_alwaysEmitIntoClient
+    static var itec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 640)
+    }
+
+    /// StoneL (`641`)
+    @_alwaysEmitIntoClient
+    static var stonel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 641)
+    }
+
+    /// Sonova AG (`642`)
+    @_alwaysEmitIntoClient
+    static var sonova: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 642)
+    }
+
+    /// Maven Machines, Inc. (`643`)
+    @_alwaysEmitIntoClient
+    static var mavenMachines: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 643)
+    }
+
+    /// Synapse Electronics (`644`)
+    @_alwaysEmitIntoClient
+    static var synapseElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 644)
+    }
+
+    /// WOWTech Canada Ltd. (`645`)
+    @_alwaysEmitIntoClient
+    static var wowtechCanada: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 645)
+    }
+
+    /// RF Code, Inc. (`646`)
+    @_alwaysEmitIntoClient
+    static var rfCode: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 646)
+    }
+
+    /// Wally Ventures S.L. (`647`)
+    @_alwaysEmitIntoClient
+    static var wallyVentures: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 647)
+    }
+
+    /// Willowbank Electronics Ltd (`648`)
+    @_alwaysEmitIntoClient
+    static var willowbankElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 648)
+    }
+
+    /// SK Telecom (`649`)
+    @_alwaysEmitIntoClient
+    static var skTelecom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 649)
+    }
+
+    /// Jetro AS (`650`)
+    @_alwaysEmitIntoClient
+    static var jetro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 650)
+    }
+
+    /// Code Gears LTD (`651`)
+    @_alwaysEmitIntoClient
+    static var codeGears: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 651)
+    }
+
+    /// NANOLINK APS (`652`)
+    @_alwaysEmitIntoClient
+    static var nanolink: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 652)
+    }
+
+    /// IF, LLC (`653`)
+    @_alwaysEmitIntoClient
+    static var ifllc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 653)
+    }
+
+    /// RF Digital Corp (`654`)
+    @_alwaysEmitIntoClient
+    static var rfDigital: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 654)
+    }
+
+    /// Church & Dwight Co., Inc (`655`)
+    @_alwaysEmitIntoClient
+    static var churchDwight: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 655)
+    }
+
+    /// Multibit Oy (`656`)
+    @_alwaysEmitIntoClient
+    static var multibit: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 656)
+    }
+
+    /// CliniCloud Inc (`657`)
+    @_alwaysEmitIntoClient
+    static var clinicloud: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 657)
+    }
+
+    /// SwiftSensors (`658`)
+    @_alwaysEmitIntoClient
+    static var swiftsensors: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 658)
+    }
+
+    /// Blue Bite (`659`)
+    @_alwaysEmitIntoClient
+    static var blueBite: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 659)
+    }
+
+    /// ELIAS GmbH (`660`)
+    @_alwaysEmitIntoClient
+    static var elias: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 660)
+    }
+
+    /// Sivantos GmbH (`661`)
+    @_alwaysEmitIntoClient
+    static var sivantos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 661)
+    }
+
+    /// Petzl (`662`)
+    @_alwaysEmitIntoClient
+    static var petzl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 662)
+    }
+
+    /// storm power ltd (`663`)
+    @_alwaysEmitIntoClient
+    static var stormPower: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 663)
+    }
+
+    /// EISST Ltd (`664`)
+    @_alwaysEmitIntoClient
+    static var eisst: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 664)
+    }
+
+    /// Inexess Technology Simma KG (`665`)
+    @_alwaysEmitIntoClient
+    static var inexessTechnologySimmaKg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 665)
+    }
+
+    /// Currant, Inc. (`666`)
+    @_alwaysEmitIntoClient
+    static var currant: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 666)
+    }
+
+    /// C2 Development, Inc. (`667`)
+    @_alwaysEmitIntoClient
+    static var c2Development: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 667)
+    }
+
+    /// Blue Sky Scientific, LLC (`668`)
+    @_alwaysEmitIntoClient
+    static var blueSkyScientific: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 668)
+    }
+
+    /// ALOTTAZS LABS, LLC (`669`)
+    @_alwaysEmitIntoClient
+    static var alottazsLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 669)
+    }
+
+    /// Kupson spol. s r.o. (`670`)
+    @_alwaysEmitIntoClient
+    static var kupsonSpolSRO: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 670)
+    }
+
+    /// Areus Engineering GmbH (`671`)
+    @_alwaysEmitIntoClient
+    static var areusEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 671)
+    }
+
+    /// Impossible Camera GmbH (`672`)
+    @_alwaysEmitIntoClient
+    static var impossibleCamera: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 672)
+    }
+
+    /// InventureTrack Systems (`673`)
+    @_alwaysEmitIntoClient
+    static var inventuretrackSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 673)
+    }
+
+    /// Sera4 Ltd. (`674`)
+    @_alwaysEmitIntoClient
+    static var sera4: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 674)
+    }
+
+    /// Itude (`675`)
+    @_alwaysEmitIntoClient
+    static var itude: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 675)
+    }
+
+    /// Pacific Lock Company (`676`)
+    @_alwaysEmitIntoClient
+    static var pacificLock: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 676)
+    }
+
+    /// Tendyron Corporation (`677`)
+    @_alwaysEmitIntoClient
+    static var tendyron: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 677)
+    }
+
+    /// Robert Bosch GmbH (`678`)
+    @_alwaysEmitIntoClient
+    static var robertBosch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 678)
+    }
+
+    /// Illuxtron international B.V. (`679`)
+    @_alwaysEmitIntoClient
+    static var illuxtronInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 679)
+    }
+
+    /// miSport Ltd. (`680`)
+    @_alwaysEmitIntoClient
+    static var misport: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 680)
+    }
+
+    /// Chargelib (`681`)
+    @_alwaysEmitIntoClient
+    static var chargelib: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 681)
+    }
+
+    /// Doppler Lab (`682`)
+    @_alwaysEmitIntoClient
+    static var dopplerLab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 682)
+    }
+
+    /// BBPOS Limited (`683`)
+    @_alwaysEmitIntoClient
+    static var bbpos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 683)
+    }
+
+    /// RTB Elektronik GmbH & Co. KG (`684`)
+    @_alwaysEmitIntoClient
+    static var rtbElektronik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 684)
+    }
+
+    /// Rx Networks, Inc. (`685`)
+    @_alwaysEmitIntoClient
+    static var rxNetworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 685)
+    }
+
+    /// WeatherFlow, Inc. (`686`)
+    @_alwaysEmitIntoClient
+    static var weatherflow: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 686)
+    }
+
+    /// Technicolor USA Inc. (`687`)
+    @_alwaysEmitIntoClient
+    static var technicolor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 687)
+    }
+
+    /// Bestechnic(Shanghai),Ltd (`688`)
+    @_alwaysEmitIntoClient
+    static var bestechnicShanghaiLtd: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 688)
+    }
+
+    /// Raden Inc (`689`)
+    @_alwaysEmitIntoClient
+    static var raden: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 689)
+    }
+
+    /// Oura Health Oy (`690`)
+    @_alwaysEmitIntoClient
+    static var ouraHealth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 690)
+    }
+
+    /// CLABER S.P.A. (`691`)
+    @_alwaysEmitIntoClient
+    static var claber: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 691)
+    }
+
+    /// Hyginex, Inc. (`692`)
+    @_alwaysEmitIntoClient
+    static var hyginex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 692)
+    }
+
+    /// HANSHIN ELECTRIC RAILWAY CO.,LTD. (`693`)
+    @_alwaysEmitIntoClient
+    static var hanshinElectricRailway: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 693)
+    }
+
+    /// Schneider Electric (`694`)
+    @_alwaysEmitIntoClient
+    static var schneiderElectric: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 694)
+    }
+
+    /// Oort Technologies LLC (`695`)
+    @_alwaysEmitIntoClient
+    static var oortTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 695)
+    }
+
+    /// Chrono Therapeutics (`696`)
+    @_alwaysEmitIntoClient
+    static var chronoTherapeutics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 696)
+    }
+
+    /// Rinnai Corporation (`697`)
+    @_alwaysEmitIntoClient
+    static var rinnai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 697)
+    }
+
+    /// Swissprime Technologies AG (`698`)
+    @_alwaysEmitIntoClient
+    static var swissprimeTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 698)
+    }
+
+    /// Koha.,Co.Ltd (`699`)
+    @_alwaysEmitIntoClient
+    static var koha: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 699)
+    }
+
+    /// Genevac Ltd (`700`)
+    @_alwaysEmitIntoClient
+    static var genevac: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 700)
+    }
+
+    /// Chemtronics (`701`)
+    @_alwaysEmitIntoClient
+    static var chemtronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 701)
+    }
+
+    /// Seguro Technology Sp. z o.o. (`702`)
+    @_alwaysEmitIntoClient
+    static var seguroTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 702)
+    }
+
+    /// Redbird Flight Simulations (`703`)
+    @_alwaysEmitIntoClient
+    static var redbirdFlightSimulations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 703)
+    }
+
+    /// Dash Robotics (`704`)
+    @_alwaysEmitIntoClient
+    static var dashRobotics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 704)
+    }
+
+    /// LINE Corporation (`705`)
+    @_alwaysEmitIntoClient
+    static var line: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 705)
+    }
+
+    /// Guillemot Corporation (`706`)
+    @_alwaysEmitIntoClient
+    static var guillemot: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 706)
+    }
+
+    /// Techtronic Power Tools Technology Limited (`707`)
+    @_alwaysEmitIntoClient
+    static var techtronicPowerToolsTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 707)
+    }
+
+    /// Wilson Sporting Goods (`708`)
+    @_alwaysEmitIntoClient
+    static var wilsonSportingGoods: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 708)
+    }
+
+    /// Lenovo (Singapore) Pte Ltd. (`709`)
+    @_alwaysEmitIntoClient
+    static var lenovoSingaporePte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 709)
+    }
+
+    /// Ayatan Sensors (`710`)
+    @_alwaysEmitIntoClient
+    static var ayatanSensors: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 710)
+    }
+
+    /// Electronics Tomorrow Limited (`711`)
+    @_alwaysEmitIntoClient
+    static var electronicsTomorrow: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 711)
+    }
+
+    /// OneSpan (`712`)
+    @_alwaysEmitIntoClient
+    static var onespan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 712)
+    }
+
+    /// PayRange Inc. (`713`)
+    @_alwaysEmitIntoClient
+    static var payrange: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 713)
+    }
+
+    /// ABOV Semiconductor (`714`)
+    @_alwaysEmitIntoClient
+    static var abovSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 714)
+    }
+
+    /// AINA-Wireless Inc. (`715`)
+    @_alwaysEmitIntoClient
+    static var ainaWireless: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 715)
+    }
+
+    /// Eijkelkamp Soil & Water (`716`)
+    @_alwaysEmitIntoClient
+    static var eijkelkampSoilWater: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 716)
+    }
+
+    /// BMA ergonomics b.v. (`717`)
+    @_alwaysEmitIntoClient
+    static var bmaErgonomics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 717)
+    }
+
+    /// Teva Branded Pharmaceutical Products R&D, Inc. (`718`)
+    @_alwaysEmitIntoClient
+    static var tevaBrandedPharmaceuticalProductsRD: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 718)
+    }
+
+    /// Anima (`719`)
+    @_alwaysEmitIntoClient
+    static var anima: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 719)
+    }
+
+    /// 3M (`720`)
+    @_alwaysEmitIntoClient
+    static var company3M: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 720)
+    }
+
+    /// Empatica Srl (`721`)
+    @_alwaysEmitIntoClient
+    static var empatica: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 721)
+    }
+
+    /// Afero, Inc. (`722`)
+    @_alwaysEmitIntoClient
+    static var afero: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 722)
+    }
+
+    /// Powercast Corporation (`723`)
+    @_alwaysEmitIntoClient
+    static var powercast: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 723)
+    }
+
+    /// Secuyou ApS (`724`)
+    @_alwaysEmitIntoClient
+    static var secuyou: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 724)
+    }
+
+    /// OMRON Corporation (`725`)
+    @_alwaysEmitIntoClient
+    static var omron: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 725)
+    }
+
+    /// Send Solutions (`726`)
+    @_alwaysEmitIntoClient
+    static var sendSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 726)
+    }
+
+    /// NIPPON SYSTEMWARE CO.,LTD. (`727`)
+    @_alwaysEmitIntoClient
+    static var nipponSystemware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 727)
+    }
+
+    /// Neosfar (`728`)
+    @_alwaysEmitIntoClient
+    static var neosfar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 728)
+    }
+
+    /// Fliegl Agrartechnik GmbH (`729`)
+    @_alwaysEmitIntoClient
+    static var flieglAgrartechnik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 729)
+    }
+
+    /// Gilvader (`730`)
+    @_alwaysEmitIntoClient
+    static var gilvader: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 730)
+    }
+
+    /// Digi International Inc (R) (`731`)
+    @_alwaysEmitIntoClient
+    static var digiInternationalR: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 731)
+    }
+
+    /// DeWalch Technologies, Inc. (`732`)
+    @_alwaysEmitIntoClient
+    static var dewalchTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 732)
+    }
+
+    /// Flint Rehabilitation Devices, LLC (`733`)
+    @_alwaysEmitIntoClient
+    static var flintRehabilitationDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 733)
+    }
+
+    /// Samsung SDS Co., Ltd. (`734`)
+    @_alwaysEmitIntoClient
+    static var samsungSds: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 734)
+    }
+
+    /// Blur Product Development (`735`)
+    @_alwaysEmitIntoClient
+    static var blurProductDevelopment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 735)
+    }
+
+    /// University of Michigan (`736`)
+    @_alwaysEmitIntoClient
+    static var universityOfMichigan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 736)
+    }
+
+    /// Victron Energy BV (`737`)
+    @_alwaysEmitIntoClient
+    static var victronEnergy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 737)
+    }
+
+    /// NTT docomo (`738`)
+    @_alwaysEmitIntoClient
+    static var nttDocomo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 738)
+    }
+
+    /// Carmanah Technologies Corp. (`739`)
+    @_alwaysEmitIntoClient
+    static var carmanahTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 739)
+    }
+
+    /// Bytestorm Ltd. (`740`)
+    @_alwaysEmitIntoClient
+    static var bytestorm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 740)
+    }
+
+    /// Espressif Systems (Shanghai) Co., Ltd. (`741`)
+    @_alwaysEmitIntoClient
+    static var espressifSystemsShanghai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 741)
+    }
+
+    /// Unwire (`742`)
+    @_alwaysEmitIntoClient
+    static var unwire: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 742)
+    }
+
+    /// Connected Yard, Inc. (`743`)
+    @_alwaysEmitIntoClient
+    static var connectedYard: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 743)
+    }
+
+    /// American Music Environments (`744`)
+    @_alwaysEmitIntoClient
+    static var americanMusicEnvironments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 744)
+    }
+
+    /// Sensogram Technologies, Inc. (`745`)
+    @_alwaysEmitIntoClient
+    static var sensogramTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 745)
+    }
+
+    /// Fujitsu Limited (`746`)
+    @_alwaysEmitIntoClient
+    static var fujitsu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 746)
+    }
+
+    /// Ardic Technology (`747`)
+    @_alwaysEmitIntoClient
+    static var ardicTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 747)
+    }
+
+    /// Delta Systems, Inc (`748`)
+    @_alwaysEmitIntoClient
+    static var deltaSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 748)
+    }
+
+    /// HTC Corporation (`749`)
+    @_alwaysEmitIntoClient
+    static var htc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 749)
+    }
+
+    /// Citizen Holdings Co., Ltd. (`750`)
+    @_alwaysEmitIntoClient
+    static var citizenHoldings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 750)
+    }
+
+    /// SMART-INNOVATION.inc (`751`)
+    @_alwaysEmitIntoClient
+    static var smartInnovationInc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 751)
+    }
+
+    /// Blackrat Software (`752`)
+    @_alwaysEmitIntoClient
+    static var blackratSoftware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 752)
+    }
+
+    /// The Idea Cave, LLC (`753`)
+    @_alwaysEmitIntoClient
+    static var ideaCave: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 753)
+    }
+
+    /// GoPro, Inc. (`754`)
+    @_alwaysEmitIntoClient
+    static var gopro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 754)
+    }
+
+    /// AuthAir, Inc (`755`)
+    @_alwaysEmitIntoClient
+    static var authair: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 755)
+    }
+
+    /// Vensi, Inc. (`756`)
+    @_alwaysEmitIntoClient
+    static var vensi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 756)
+    }
+
+    /// Indagem Tech LLC (`757`)
+    @_alwaysEmitIntoClient
+    static var indagemTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 757)
+    }
+
+    /// Intemo Technologies (`758`)
+    @_alwaysEmitIntoClient
+    static var intemoTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 758)
+    }
+
+    /// DreamVisions co., Ltd. (`759`)
+    @_alwaysEmitIntoClient
+    static var dreamvisions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 759)
+    }
+
+    /// Runteq Oy Ltd (`760`)
+    @_alwaysEmitIntoClient
+    static var runteq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 760)
+    }
+
+    /// IMAGINATION TECHNOLOGIES LTD (`761`)
+    @_alwaysEmitIntoClient
+    static var imaginationTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 761)
+    }
+
+    /// CoSTAR TEchnologies (`762`)
+    @_alwaysEmitIntoClient
+    static var costarTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 762)
+    }
+
+    /// Clarius Mobile Health Corp. (`763`)
+    @_alwaysEmitIntoClient
+    static var clariusMobileHealth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 763)
+    }
+
+    /// Shanghai Frequen Microelectronics Co., Ltd. (`764`)
+    @_alwaysEmitIntoClient
+    static var shanghaiFrequenMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 764)
+    }
+
+    /// Uwanna, Inc. (`765`)
+    @_alwaysEmitIntoClient
+    static var uwanna: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 765)
+    }
+
+    /// Lierda Science & Technology Group Co., Ltd. (`766`)
+    @_alwaysEmitIntoClient
+    static var lierdaScienceTechnologyGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 766)
+    }
+
+    /// Silicon Laboratories (`767`)
+    @_alwaysEmitIntoClient
+    static var siliconLaboratories: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 767)
+    }
+
+    /// World Moto Inc. (`768`)
+    @_alwaysEmitIntoClient
+    static var worldMoto: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 768)
+    }
+
+    /// Giatec Scientific Inc. (`769`)
+    @_alwaysEmitIntoClient
+    static var giatecScientific: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 769)
+    }
+
+    /// Loop Devices, Inc (`770`)
+    @_alwaysEmitIntoClient
+    static var loopDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 770)
+    }
+
+    /// IACA electronique (`771`)
+    @_alwaysEmitIntoClient
+    static var iacaElectronique: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 771)
+    }
+
+    /// Oura Health Ltd (`772`)
+    @_alwaysEmitIntoClient
+    static var ouraHealth2: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 772)
+    }
+
+    /// Swipp ApS (`773`)
+    @_alwaysEmitIntoClient
+    static var swipp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 773)
+    }
+
+    /// Life Laboratory Inc. (`774`)
+    @_alwaysEmitIntoClient
+    static var lifeLaboratory: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 774)
+    }
+
+    /// FUJI INDUSTRIAL CO.,LTD. (`775`)
+    @_alwaysEmitIntoClient
+    static var fujiIndustrial: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 775)
+    }
+
+    /// Surefire, LLC (`776`)
+    @_alwaysEmitIntoClient
+    static var surefire: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 776)
+    }
+
+    /// Dolby Labs (`777`)
+    @_alwaysEmitIntoClient
+    static var dolbyLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 777)
+    }
+
+    /// Ellisys (`778`)
+    @_alwaysEmitIntoClient
+    static var ellisys: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 778)
+    }
+
+    /// Magnitude Lighting Converters (`779`)
+    @_alwaysEmitIntoClient
+    static var magnitudeLightingConverters: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 779)
+    }
+
+    /// Hilti AG (`780`)
+    @_alwaysEmitIntoClient
+    static var hilti: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 780)
+    }
+
+    /// Devdata S.r.l. (`781`)
+    @_alwaysEmitIntoClient
+    static var devdata: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 781)
+    }
+
+    /// Deviceworx (`782`)
+    @_alwaysEmitIntoClient
+    static var deviceworx: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 782)
+    }
+
+    /// Shortcut Labs (`783`)
+    @_alwaysEmitIntoClient
+    static var shortcutLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 783)
+    }
+
+    /// SGL Italia S.r.l. (`784`)
+    @_alwaysEmitIntoClient
+    static var sglItalia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 784)
+    }
+
+    /// PEEQ DATA (`785`)
+    @_alwaysEmitIntoClient
+    static var peeqData: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 785)
+    }
+
+    /// Ducere Technologies Pvt Ltd (`786`)
+    @_alwaysEmitIntoClient
+    static var ducereTechnologiesPvt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 786)
+    }
+
+    /// DiveNav, Inc. (`787`)
+    @_alwaysEmitIntoClient
+    static var divenav: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 787)
+    }
+
+    /// RIIG AI Sp. z o.o. (`788`)
+    @_alwaysEmitIntoClient
+    static var riigAi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 788)
+    }
+
+    /// Thermo Fisher Scientific (`789`)
+    @_alwaysEmitIntoClient
+    static var thermoFisherScientific: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 789)
+    }
+
+    /// AG Measurematics Pvt. Ltd. (`790`)
+    @_alwaysEmitIntoClient
+    static var agMeasurematics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 790)
+    }
+
+    /// CHUO Electronics CO., LTD. (`791`)
+    @_alwaysEmitIntoClient
+    static var chuoElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 791)
+    }
+
+    /// Aspenta International (`792`)
+    @_alwaysEmitIntoClient
+    static var aspentaInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 792)
+    }
+
+    /// Eugster Frismag AG (`793`)
+    @_alwaysEmitIntoClient
+    static var eugsterFrismag: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 793)
+    }
+
+    /// Wurth Elektronik eiSos GmbH & Co. KG (`794`)
+    @_alwaysEmitIntoClient
+    static var wurthElektronikEisos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 794)
+    }
+
+    /// HQ Inc (`795`)
+    @_alwaysEmitIntoClient
+    static var hq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 795)
+    }
+
+    /// Lab Sensor Solutions (`796`)
+    @_alwaysEmitIntoClient
+    static var labSensorSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 796)
+    }
+
+    /// Enterlab ApS (`797`)
+    @_alwaysEmitIntoClient
+    static var enterlab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 797)
+    }
+
+    /// Eyefi, Inc. (`798`)
+    @_alwaysEmitIntoClient
+    static var eyefi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 798)
+    }
+
+    /// MetaSystem S.p.A. (`799`)
+    @_alwaysEmitIntoClient
+    static var metasystem: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 799)
+    }
+
+    /// SONO ELECTRONICS. CO., LTD (`800`)
+    @_alwaysEmitIntoClient
+    static var sonoElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 800)
+    }
+
+    /// Jewelbots (`801`)
+    @_alwaysEmitIntoClient
+    static var jewelbots: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 801)
+    }
+
+    /// Compumedics Limited (`802`)
+    @_alwaysEmitIntoClient
+    static var compumedics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 802)
+    }
+
+    /// Rotor Bike Components (`803`)
+    @_alwaysEmitIntoClient
+    static var rotorBikeComponents: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 803)
+    }
+
+    /// Astro, Inc. (`804`)
+    @_alwaysEmitIntoClient
+    static var astro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 804)
+    }
+
+    /// Amotus Solutions (`805`)
+    @_alwaysEmitIntoClient
+    static var amotusSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 805)
+    }
+
+    /// Healthwear Technologies (Changzhou)Ltd (`806`)
+    @_alwaysEmitIntoClient
+    static var healthwearTechnologiesChangzhouLtd: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 806)
+    }
+
+    /// Essex Electronics (`807`)
+    @_alwaysEmitIntoClient
+    static var essexElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 807)
+    }
+
+    /// Grundfos A/S (`808`)
+    @_alwaysEmitIntoClient
+    static var grundfos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 808)
+    }
+
+    /// Eargo, Inc. (`809`)
+    @_alwaysEmitIntoClient
+    static var eargo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 809)
+    }
+
+    /// Electronic Design Lab (`810`)
+    @_alwaysEmitIntoClient
+    static var electronicDesignLab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 810)
+    }
+
+    /// ESYLUX (`811`)
+    @_alwaysEmitIntoClient
+    static var esylux: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 811)
+    }
+
+    /// NIPPON SMT.CO.,Ltd (`812`)
+    @_alwaysEmitIntoClient
+    static var nipponSmt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 812)
+    }
+
+    /// BM innovations GmbH (`813`)
+    @_alwaysEmitIntoClient
+    static var bmInnovations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 813)
+    }
+
+    /// indoormap (`814`)
+    @_alwaysEmitIntoClient
+    static var indoormap: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 814)
+    }
+
+    /// OttoQ Inc (`815`)
+    @_alwaysEmitIntoClient
+    static var ottoq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 815)
+    }
+
+    /// North Pole Engineering (`816`)
+    @_alwaysEmitIntoClient
+    static var northPoleEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 816)
+    }
+
+    /// 3flares Technologies Inc. (`817`)
+    @_alwaysEmitIntoClient
+    static var company3FlaresTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 817)
+    }
+
+    /// Electrocompaniet A.S. (`818`)
+    @_alwaysEmitIntoClient
+    static var electrocompaniet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 818)
+    }
+
+    /// Mul-T-Lock (`819`)
+    @_alwaysEmitIntoClient
+    static var mulTLock: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 819)
+    }
+
+    /// Airthings ASA (`820`)
+    @_alwaysEmitIntoClient
+    static var airthings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 820)
+    }
+
+    /// Enlighted Inc (`821`)
+    @_alwaysEmitIntoClient
+    static var enlighted: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 821)
+    }
+
+    /// GISTIC (`822`)
+    @_alwaysEmitIntoClient
+    static var gistic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 822)
+    }
+
+    /// AJP2 Holdings, LLC (`823`)
+    @_alwaysEmitIntoClient
+    static var ajp2Holdings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 823)
+    }
+
+    /// COBI GmbH (`824`)
+    @_alwaysEmitIntoClient
+    static var cobi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 824)
+    }
+
+    /// Blue Sky Scientific, LLC (`825`)
+    @_alwaysEmitIntoClient
+    static var blueSkyScientific2: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 825)
+    }
+
+    /// Appception, Inc. (`826`)
+    @_alwaysEmitIntoClient
+    static var appception: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 826)
+    }
+
+    /// Courtney Thorne Limited (`827`)
+    @_alwaysEmitIntoClient
+    static var courtneyThorne: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 827)
+    }
+
+    /// Virtuosys (`828`)
+    @_alwaysEmitIntoClient
+    static var virtuosys: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 828)
+    }
+
+    /// TPV Technology Limited (`829`)
+    @_alwaysEmitIntoClient
+    static var tpvTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 829)
+    }
+
+    /// Monitra SA (`830`)
+    @_alwaysEmitIntoClient
+    static var monitra: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 830)
+    }
+
+    /// Automation Components, Inc. (`831`)
+    @_alwaysEmitIntoClient
+    static var automationComponents: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 831)
+    }
+
+    /// Letsense s.r.l. (`832`)
+    @_alwaysEmitIntoClient
+    static var letsense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 832)
+    }
+
+    /// Etesian Technologies LLC (`833`)
+    @_alwaysEmitIntoClient
+    static var etesianTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 833)
+    }
+
+    /// GERTEC BRASIL LTDA. (`834`)
+    @_alwaysEmitIntoClient
+    static var gertecBrasil: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 834)
+    }
+
+    /// Drekker Development Pty. Ltd. (`835`)
+    @_alwaysEmitIntoClient
+    static var drekkerDevelopment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 835)
+    }
+
+    /// Whirl Inc (`836`)
+    @_alwaysEmitIntoClient
+    static var whirl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 836)
+    }
+
+    /// Locus Positioning (`837`)
+    @_alwaysEmitIntoClient
+    static var locusPositioning: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 837)
+    }
+
+    /// Acuity Brands Lighting, Inc (`838`)
+    @_alwaysEmitIntoClient
+    static var acuityBrandsLighting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 838)
+    }
+
+    /// Prevent Biometrics (`839`)
+    @_alwaysEmitIntoClient
+    static var preventBiometrics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 839)
+    }
+
+    /// Arioneo (`840`)
+    @_alwaysEmitIntoClient
+    static var arioneo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 840)
+    }
+
+    /// VersaMe (`841`)
+    @_alwaysEmitIntoClient
+    static var versame: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 841)
+    }
+
+    /// Vaddio (`842`)
+    @_alwaysEmitIntoClient
+    static var vaddio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 842)
+    }
+
+    /// Libratone A/S (`843`)
+    @_alwaysEmitIntoClient
+    static var libratone: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 843)
+    }
+
+    /// HM Electronics, Inc. (`844`)
+    @_alwaysEmitIntoClient
+    static var hmElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 844)
+    }
+
+    /// TASER International, Inc. (`845`)
+    @_alwaysEmitIntoClient
+    static var taserInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 845)
+    }
+
+    /// SafeTrust Inc. (`846`)
+    @_alwaysEmitIntoClient
+    static var safetrust: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 846)
+    }
+
+    /// Heartland Payment Systems (`847`)
+    @_alwaysEmitIntoClient
+    static var heartlandPaymentSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 847)
+    }
+
+    /// Bitstrata Systems Inc. (`848`)
+    @_alwaysEmitIntoClient
+    static var bitstrataSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 848)
+    }
+
+    /// Pieps GmbH (`849`)
+    @_alwaysEmitIntoClient
+    static var pieps: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 849)
+    }
+
+    /// iRiding(Xiamen)Technology Co.,Ltd. (`850`)
+    @_alwaysEmitIntoClient
+    static var iridingXiamenTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 850)
+    }
+
+    /// Alpha Audiotronics, Inc. (`851`)
+    @_alwaysEmitIntoClient
+    static var alphaAudiotronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 851)
+    }
+
+    /// TOPPAN FORMS CO.,LTD. (`852`)
+    @_alwaysEmitIntoClient
+    static var toppanForms: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 852)
+    }
+
+    /// Sigma Designs, Inc. (`853`)
+    @_alwaysEmitIntoClient
+    static var sigmaDesigns: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 853)
+    }
+
+    /// Spectrum Brands, Inc. (`854`)
+    @_alwaysEmitIntoClient
+    static var spectrumBrands: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 854)
+    }
+
+    /// Polymap Wireless (`855`)
+    @_alwaysEmitIntoClient
+    static var polymapWireless: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 855)
+    }
+
+    /// MagniWare Ltd. (`856`)
+    @_alwaysEmitIntoClient
+    static var magniware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 856)
+    }
+
+    /// Novotec Medical GmbH (`857`)
+    @_alwaysEmitIntoClient
+    static var novotecMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 857)
+    }
+
+    /// Phillips-Medisize A/S (`858`)
+    @_alwaysEmitIntoClient
+    static var phillipsMedisize: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 858)
+    }
+
+    /// Matrix Inc. (`859`)
+    @_alwaysEmitIntoClient
+    static var matrix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 859)
+    }
+
+    /// Eaton Corporation (`860`)
+    @_alwaysEmitIntoClient
+    static var eaton: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 860)
+    }
+
+    /// KYS (`861`)
+    @_alwaysEmitIntoClient
+    static var kys: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 861)
+    }
+
+    /// Naya Health, Inc. (`862`)
+    @_alwaysEmitIntoClient
+    static var nayaHealth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 862)
+    }
+
+    /// Acromag (`863`)
+    @_alwaysEmitIntoClient
+    static var acromag: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 863)
+    }
+
+    /// Insulet Corporation (`864`)
+    @_alwaysEmitIntoClient
+    static var insulet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 864)
+    }
+
+    /// Wellinks Inc. (`865`)
+    @_alwaysEmitIntoClient
+    static var wellinks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 865)
+    }
+
+    /// ON Semiconductor (`866`)
+    @_alwaysEmitIntoClient
+    static var onSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 866)
+    }
+
+    /// FREELAP SA (`867`)
+    @_alwaysEmitIntoClient
+    static var freelap: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 867)
+    }
+
+    /// Favero Electronics Srl (`868`)
+    @_alwaysEmitIntoClient
+    static var faveroElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 868)
+    }
+
+    /// BioMech Sensor LLC (`869`)
+    @_alwaysEmitIntoClient
+    static var biomechSensor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 869)
+    }
+
+    /// BOLTT Sports technologies Private limited (`870`)
+    @_alwaysEmitIntoClient
+    static var bolttSportsTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 870)
+    }
+
+    /// Saphe International (`871`)
+    @_alwaysEmitIntoClient
+    static var sapheInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 871)
+    }
+
+    /// Metormote AB (`872`)
+    @_alwaysEmitIntoClient
+    static var metormote: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 872)
+    }
+
+    /// littleBits (`873`)
+    @_alwaysEmitIntoClient
+    static var littlebits: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 873)
+    }
+
+    /// SetPoint Medical (`874`)
+    @_alwaysEmitIntoClient
+    static var setpointMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 874)
+    }
+
+    /// BRControls Products BV (`875`)
+    @_alwaysEmitIntoClient
+    static var brcontrolsProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 875)
+    }
+
+    /// Zipcar (`876`)
+    @_alwaysEmitIntoClient
+    static var zipcar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 876)
+    }
+
+    /// AirBolt Pty Ltd (`877`)
+    @_alwaysEmitIntoClient
+    static var airbolt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 877)
+    }
+
+    /// MOTIVE TECHNOLOGIES, INC. (`878`)
+    @_alwaysEmitIntoClient
+    static var motiveTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 878)
+    }
+
+    /// Motiv, Inc. (`879`)
+    @_alwaysEmitIntoClient
+    static var motiv: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 879)
+    }
+
+    /// Wazombi Labs OÜ (`880`)
+    @_alwaysEmitIntoClient
+    static var wazombiLabsOu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 880)
+    }
+
+    /// ORBCOMM (`881`)
+    @_alwaysEmitIntoClient
+    static var orbcomm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 881)
+    }
+
+    /// Nixie Labs, Inc. (`882`)
+    @_alwaysEmitIntoClient
+    static var nixieLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 882)
+    }
+
+    /// AppNearMe Ltd (`883`)
+    @_alwaysEmitIntoClient
+    static var appnearme: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 883)
+    }
+
+    /// Holman Industries (`884`)
+    @_alwaysEmitIntoClient
+    static var holmanIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 884)
+    }
+
+    /// Expain AS (`885`)
+    @_alwaysEmitIntoClient
+    static var expain: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 885)
+    }
+
+    /// Electronic Temperature Instruments Ltd (`886`)
+    @_alwaysEmitIntoClient
+    static var electronicTemperatureInstruments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 886)
+    }
+
+    /// Plejd AB (`887`)
+    @_alwaysEmitIntoClient
+    static var plejd: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 887)
+    }
+
+    /// Propeller Health (`888`)
+    @_alwaysEmitIntoClient
+    static var propellerHealth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 888)
+    }
+
+    /// Shenzhen iMCO Electronic Technology Co.,Ltd (`889`)
+    @_alwaysEmitIntoClient
+    static var shenzhenImcoElectronicTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 889)
+    }
+
+    /// Algoria (`890`)
+    @_alwaysEmitIntoClient
+    static var algoria: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 890)
+    }
+
+    /// Apption Labs Inc. (`891`)
+    @_alwaysEmitIntoClient
+    static var apptionLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 891)
+    }
+
+    /// Cronologics Corporation (`892`)
+    @_alwaysEmitIntoClient
+    static var cronologics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 892)
+    }
+
+    /// MICRODIA Ltd. (`893`)
+    @_alwaysEmitIntoClient
+    static var microdia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 893)
+    }
+
+    /// lulabytes S.L. (`894`)
+    @_alwaysEmitIntoClient
+    static var lulabytes: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 894)
+    }
+
+    /// Société des Produits Nestlé S.A. (`895`)
+    @_alwaysEmitIntoClient
+    static var societeDesProduitsNestle: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 895)
+    }
+
+    /// LLC "MEGA-F service" (`896`)
+    @_alwaysEmitIntoClient
+    static var megaFService: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 896)
+    }
+
+    /// Sharp Corporation (`897`)
+    @_alwaysEmitIntoClient
+    static var sharp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 897)
+    }
+
+    /// Precision Outcomes Ltd (`898`)
+    @_alwaysEmitIntoClient
+    static var precisionOutcomes: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 898)
+    }
+
+    /// Kronos Incorporated (`899`)
+    @_alwaysEmitIntoClient
+    static var kronos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 899)
+    }
+
+    /// OCOSMOS Co., Ltd. (`900`)
+    @_alwaysEmitIntoClient
+    static var ocosmos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 900)
+    }
+
+    /// Embedded Electronic Solutions Ltd. dba e2Solutions (`901`)
+    @_alwaysEmitIntoClient
+    static var embeddedElectronicSolutionsDbaE2Solutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 901)
+    }
+
+    /// Aterica Inc. (`902`)
+    @_alwaysEmitIntoClient
+    static var aterica: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 902)
+    }
+
+    /// BluStor PMC, Inc. (`903`)
+    @_alwaysEmitIntoClient
+    static var blustorPmc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 903)
+    }
+
+    /// Kapsch TrafficCom AB (`904`)
+    @_alwaysEmitIntoClient
+    static var kapschTrafficcom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 904)
+    }
+
+    /// ActiveBlu Corporation (`905`)
+    @_alwaysEmitIntoClient
+    static var activeblu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 905)
+    }
+
+    /// Kohler Mira Limited (`906`)
+    @_alwaysEmitIntoClient
+    static var kohlerMira: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 906)
+    }
+
+    /// Noke (`907`)
+    @_alwaysEmitIntoClient
+    static var noke: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 907)
+    }
+
+    /// Appion Inc. (`908`)
+    @_alwaysEmitIntoClient
+    static var appion: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 908)
+    }
+
+    /// Resmed Ltd (`909`)
+    @_alwaysEmitIntoClient
+    static var resmed: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 909)
+    }
+
+    /// Crownstone B.V. (`910`)
+    @_alwaysEmitIntoClient
+    static var crownstone: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 910)
+    }
+
+    /// Xiaomi Inc. (`911`)
+    @_alwaysEmitIntoClient
+    static var xiaomi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 911)
+    }
+
+    /// INFOTECH s.r.o. (`912`)
+    @_alwaysEmitIntoClient
+    static var infotech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 912)
+    }
+
+    /// Thingsquare AB (`913`)
+    @_alwaysEmitIntoClient
+    static var thingsquare: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 913)
+    }
+
+    /// T&D (`914`)
+    @_alwaysEmitIntoClient
+    static var tD: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 914)
+    }
+
+    /// LAVAZZA S.p.A. (`915`)
+    @_alwaysEmitIntoClient
+    static var lavazza: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 915)
+    }
+
+    /// Netclearance Systems, Inc. (`916`)
+    @_alwaysEmitIntoClient
+    static var netclearanceSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 916)
+    }
+
+    /// SDATAWAY (`917`)
+    @_alwaysEmitIntoClient
+    static var sdataway: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 917)
+    }
+
+    /// BLOKS GmbH (`918`)
+    @_alwaysEmitIntoClient
+    static var bloks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 918)
+    }
+
+    /// LEGO System A/S (`919`)
+    @_alwaysEmitIntoClient
+    static var legoSystem: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 919)
+    }
+
+    /// Thetatronics Ltd (`920`)
+    @_alwaysEmitIntoClient
+    static var thetatronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 920)
+    }
+
+    /// Nikon Corporation (`921`)
+    @_alwaysEmitIntoClient
+    static var nikon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 921)
+    }
+
+    /// NeST (`922`)
+    @_alwaysEmitIntoClient
+    static var nest: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 922)
+    }
+
+    /// South Silicon Valley Microelectronics (`923`)
+    @_alwaysEmitIntoClient
+    static var southSiliconValleyMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 923)
+    }
+
+    /// ALE International (`924`)
+    @_alwaysEmitIntoClient
+    static var aleInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 924)
+    }
+
+    /// CareView Communications, Inc. (`925`)
+    @_alwaysEmitIntoClient
+    static var careviewCommunications: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 925)
+    }
+
+    /// SchoolBoard Limited (`926`)
+    @_alwaysEmitIntoClient
+    static var schoolboard: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 926)
+    }
+
+    /// Molex Corporation (`927`)
+    @_alwaysEmitIntoClient
+    static var molex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 927)
+    }
+
+    /// IVT Wireless Limited (`928`)
+    @_alwaysEmitIntoClient
+    static var ivtWireless: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 928)
+    }
+
+    /// Alpine Labs LLC (`929`)
+    @_alwaysEmitIntoClient
+    static var alpineLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 929)
+    }
+
+    /// Candura Instruments (`930`)
+    @_alwaysEmitIntoClient
+    static var canduraInstruments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 930)
+    }
+
+    /// SmartMovt Technology Co., Ltd (`931`)
+    @_alwaysEmitIntoClient
+    static var smartmovtTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 931)
+    }
+
+    /// Token Zero Ltd (`932`)
+    @_alwaysEmitIntoClient
+    static var tokenZero: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 932)
+    }
+
+    /// ACE CAD Enterprise Co., Ltd. (ACECAD) (`933`)
+    @_alwaysEmitIntoClient
+    static var aceCadEnterpriseAcecad: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 933)
+    }
+
+    /// Medela, Inc (`934`)
+    @_alwaysEmitIntoClient
+    static var medela: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 934)
+    }
+
+    /// AeroScout (`935`)
+    @_alwaysEmitIntoClient
+    static var aeroscout: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 935)
+    }
+
+    /// Esrille Inc. (`936`)
+    @_alwaysEmitIntoClient
+    static var esrille: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 936)
+    }
+
+    /// THINKERLY SRL (`937`)
+    @_alwaysEmitIntoClient
+    static var thinkerly: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 937)
+    }
+
+    /// Exon Sp. z o.o. (`938`)
+    @_alwaysEmitIntoClient
+    static var exon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 938)
+    }
+
+    /// Meizu Technology Co., Ltd. (`939`)
+    @_alwaysEmitIntoClient
+    static var meizuTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 939)
+    }
+
+    /// Smablo LTD (`940`)
+    @_alwaysEmitIntoClient
+    static var smablo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 940)
+    }
+
+    /// XiQ (`941`)
+    @_alwaysEmitIntoClient
+    static var xiq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 941)
+    }
+
+    /// Allswell Inc. (`942`)
+    @_alwaysEmitIntoClient
+    static var allswell: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 942)
+    }
+
+    /// Comm-N-Sense Corp DBA Verigo (`943`)
+    @_alwaysEmitIntoClient
+    static var commNSenseDbaVerigo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 943)
+    }
+
+    /// VIBRADORM GmbH (`944`)
+    @_alwaysEmitIntoClient
+    static var vibradorm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 944)
+    }
+
+    /// Otodata Wireless Network Inc. (`945`)
+    @_alwaysEmitIntoClient
+    static var otodataWirelessNetwork: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 945)
+    }
+
+    /// Propagation Systems Limited (`946`)
+    @_alwaysEmitIntoClient
+    static var propagationSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 946)
+    }
+
+    /// Midwest Instruments & Controls (`947`)
+    @_alwaysEmitIntoClient
+    static var midwestInstrumentsControls: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 947)
+    }
+
+    /// Alpha Nodus, inc. (`948`)
+    @_alwaysEmitIntoClient
+    static var alphaNodus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 948)
+    }
+
+    /// petPOMM, Inc (`949`)
+    @_alwaysEmitIntoClient
+    static var petpomm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 949)
+    }
+
+    /// Mattel (`950`)
+    @_alwaysEmitIntoClient
+    static var mattel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 950)
+    }
+
+    /// Airbly Inc. (`951`)
+    @_alwaysEmitIntoClient
+    static var airbly: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 951)
+    }
+
+    /// A-Safe Limited (`952`)
+    @_alwaysEmitIntoClient
+    static var aSafe: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 952)
+    }
+
+    /// FREDERIQUE CONSTANT SA (`953`)
+    @_alwaysEmitIntoClient
+    static var frederiqueConstant: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 953)
+    }
+
+    /// Maxscend Microelectronics Company Limited (`954`)
+    @_alwaysEmitIntoClient
+    static var maxscendMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 954)
+    }
+
+    /// Abbott (`955`)
+    @_alwaysEmitIntoClient
+    static var abbott: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 955)
+    }
+
+    /// ASB Bank Ltd (`956`)
+    @_alwaysEmitIntoClient
+    static var asbBank: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 956)
+    }
+
+    /// amadas (`957`)
+    @_alwaysEmitIntoClient
+    static var amadas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 957)
+    }
+
+    /// Applied Science, Inc. (`958`)
+    @_alwaysEmitIntoClient
+    static var appliedScience: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 958)
+    }
+
+    /// iLumi Solutions Inc. (`959`)
+    @_alwaysEmitIntoClient
+    static var ilumiSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 959)
+    }
+
+    /// Arch Systems Inc. (`960`)
+    @_alwaysEmitIntoClient
+    static var archSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 960)
+    }
+
+    /// Ember Technologies, Inc. (`961`)
+    @_alwaysEmitIntoClient
+    static var emberTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 961)
+    }
+
+    /// Snapchat Inc (`962`)
+    @_alwaysEmitIntoClient
+    static var snapchat: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 962)
+    }
+
+    /// Casambi Technologies Oy (`963`)
+    @_alwaysEmitIntoClient
+    static var casambiTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 963)
+    }
+
+    /// Pico Technology Inc. (`964`)
+    @_alwaysEmitIntoClient
+    static var picoTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 964)
+    }
+
+    /// St. Jude Medical, Inc. (`965`)
+    @_alwaysEmitIntoClient
+    static var stJudeMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 965)
+    }
+
+    /// Intricon (`966`)
+    @_alwaysEmitIntoClient
+    static var intricon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 966)
+    }
+
+    /// Structural Health Systems, Inc. (`967`)
+    @_alwaysEmitIntoClient
+    static var structuralHealthSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 967)
+    }
+
+    /// Avvel International (`968`)
+    @_alwaysEmitIntoClient
+    static var avvelInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 968)
+    }
+
+    /// Gallagher Group (`969`)
+    @_alwaysEmitIntoClient
+    static var gallagherGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 969)
+    }
+
+    /// In2things Automation Pvt. Ltd. (`970`)
+    @_alwaysEmitIntoClient
+    static var in2ThingsAutomation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 970)
+    }
+
+    /// SYSDEV Srl (`971`)
+    @_alwaysEmitIntoClient
+    static var sysdev: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 971)
+    }
+
+    /// Vonkil Technologies Ltd (`972`)
+    @_alwaysEmitIntoClient
+    static var vonkilTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 972)
+    }
+
+    /// Wynd Technologies, Inc. (`973`)
+    @_alwaysEmitIntoClient
+    static var wyndTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 973)
+    }
+
+    /// CONTRINEX S.A. (`974`)
+    @_alwaysEmitIntoClient
+    static var contrinex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 974)
+    }
+
+    /// MIRA, Inc. (`975`)
+    @_alwaysEmitIntoClient
+    static var mira: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 975)
+    }
+
+    /// Watteam Ltd (`976`)
+    @_alwaysEmitIntoClient
+    static var watteam: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 976)
+    }
+
+    /// Density Inc. (`977`)
+    @_alwaysEmitIntoClient
+    static var density: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 977)
+    }
+
+    /// IOT Pot India Private Limited (`978`)
+    @_alwaysEmitIntoClient
+    static var iotPotIndia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 978)
+    }
+
+    /// Sigma Connectivity AB (`979`)
+    @_alwaysEmitIntoClient
+    static var sigmaConnectivity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 979)
+    }
+
+    /// PEG PEREGO SPA (`980`)
+    @_alwaysEmitIntoClient
+    static var pegPeregoSpa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 980)
+    }
+
+    /// Wyzelink Systems Inc. (`981`)
+    @_alwaysEmitIntoClient
+    static var wyzelinkSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 981)
+    }
+
+    /// Yota Devices LTD (`982`)
+    @_alwaysEmitIntoClient
+    static var yotaDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 982)
+    }
+
+    /// FINSECUR (`983`)
+    @_alwaysEmitIntoClient
+    static var finsecur: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 983)
+    }
+
+    /// Zen-Me Labs Ltd (`984`)
+    @_alwaysEmitIntoClient
+    static var zenMeLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 984)
+    }
+
+    /// 3IWare Co., Ltd. (`985`)
+    @_alwaysEmitIntoClient
+    static var company3Iware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 985)
+    }
+
+    /// EnOcean GmbH (`986`)
+    @_alwaysEmitIntoClient
+    static var enocean: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 986)
+    }
+
+    /// Instabeat, Inc (`987`)
+    @_alwaysEmitIntoClient
+    static var instabeat: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 987)
+    }
+
+    /// Nima Labs (`988`)
+    @_alwaysEmitIntoClient
+    static var nimaLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 988)
+    }
+
+    /// Andreas Stihl AG & Co. KG (`989`)
+    @_alwaysEmitIntoClient
+    static var andreasStihl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 989)
+    }
+
+    /// Nathan Rhoades LLC (`990`)
+    @_alwaysEmitIntoClient
+    static var nathanRhoades: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 990)
+    }
+
+    /// Grob Technologies, LLC (`991`)
+    @_alwaysEmitIntoClient
+    static var grobTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 991)
+    }
+
+    /// Actions Technology Co.,Ltd (`992`)
+    @_alwaysEmitIntoClient
+    static var actionsTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 992)
+    }
+
+    /// SPD Development Company Ltd (`993`)
+    @_alwaysEmitIntoClient
+    static var spdDevelopment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 993)
+    }
+
+    /// Sensoan Oy (`994`)
+    @_alwaysEmitIntoClient
+    static var sensoan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 994)
+    }
+
+    /// Qualcomm Life Inc (`995`)
+    @_alwaysEmitIntoClient
+    static var qualcommLife: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 995)
+    }
+
+    /// Chip-ing AG (`996`)
+    @_alwaysEmitIntoClient
+    static var chipIng: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 996)
+    }
+
+    /// ffly4u (`997`)
+    @_alwaysEmitIntoClient
+    static var ffly4U: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 997)
+    }
+
+    /// IoT Instruments Oy (`998`)
+    @_alwaysEmitIntoClient
+    static var iotInstruments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 998)
+    }
+
+    /// TRUE Fitness Technology (`999`)
+    @_alwaysEmitIntoClient
+    static var trueFitnessTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 999)
+    }
+
+    /// Reiner Kartengeraete GmbH & Co. KG. (`1000`)
+    @_alwaysEmitIntoClient
+    static var reinerKartengeraete: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1000)
+    }
+
+    /// SHENZHEN LEMONJOY TECHNOLOGY CO., LTD. (`1001`)
+    @_alwaysEmitIntoClient
+    static var shenzhenLemonjoyTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1001)
+    }
+
+    /// Hello Inc. (`1002`)
+    @_alwaysEmitIntoClient
+    static var hello: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1002)
+    }
+
+    /// Ozo Edu, Inc. (`1003`)
+    @_alwaysEmitIntoClient
+    static var ozoEdu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1003)
+    }
+
+    /// Jigowatts Inc. (`1004`)
+    @_alwaysEmitIntoClient
+    static var jigowatts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1004)
+    }
+
+    /// BASIC MICRO.COM,INC. (`1005`)
+    @_alwaysEmitIntoClient
+    static var basicMicroCom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1005)
+    }
+
+    /// CUBE TECHNOLOGIES (`1006`)
+    @_alwaysEmitIntoClient
+    static var cubeTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1006)
+    }
+
+    /// foolography GmbH (`1007`)
+    @_alwaysEmitIntoClient
+    static var foolography: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1007)
+    }
+
+    /// CLINK (`1008`)
+    @_alwaysEmitIntoClient
+    static var clink: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1008)
+    }
+
+    /// Hestan Smart Cooking Inc. (`1009`)
+    @_alwaysEmitIntoClient
+    static var hestanSmartCooking: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1009)
+    }
+
+    /// WindowMaster A/S (`1010`)
+    @_alwaysEmitIntoClient
+    static var windowmaster: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1010)
+    }
+
+    /// Flowscape AB (`1011`)
+    @_alwaysEmitIntoClient
+    static var flowscape: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1011)
+    }
+
+    /// PAL Technologies Ltd (`1012`)
+    @_alwaysEmitIntoClient
+    static var palTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1012)
+    }
+
+    /// WHERE, Inc. (`1013`)
+    @_alwaysEmitIntoClient
+    static var whereinc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1013)
+    }
+
+    /// Iton Technology Corp. (`1014`)
+    @_alwaysEmitIntoClient
+    static var itonTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1014)
+    }
+
+    /// Owl Labs Inc. (`1015`)
+    @_alwaysEmitIntoClient
+    static var owlLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1015)
+    }
+
+    /// Rockford Corp. (`1016`)
+    @_alwaysEmitIntoClient
+    static var rockford: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1016)
+    }
+
+    /// Becon Technologies Co.,Ltd. (`1017`)
+    @_alwaysEmitIntoClient
+    static var beconTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1017)
+    }
+
+    /// Vyassoft Technologies Inc (`1018`)
+    @_alwaysEmitIntoClient
+    static var vyassoftTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1018)
+    }
+
+    /// Nox Medical (`1019`)
+    @_alwaysEmitIntoClient
+    static var noxMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1019)
+    }
+
+    /// Kimberly-Clark (`1020`)
+    @_alwaysEmitIntoClient
+    static var kimberlyClark: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1020)
+    }
+
+    /// Trimble Inc. (`1021`)
+    @_alwaysEmitIntoClient
+    static var trimble: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1021)
+    }
+
+    /// Littelfuse (`1022`)
+    @_alwaysEmitIntoClient
+    static var littelfuse: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1022)
+    }
+
+    /// Withings (`1023`)
+    @_alwaysEmitIntoClient
+    static var withings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1023)
+    }
+
+    /// i-developer IT Beratung UG (`1024`)
+    @_alwaysEmitIntoClient
+    static var iDeveloperItBeratungUg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1024)
+    }
+
+    /// Relations Inc. (`1025`)
+    @_alwaysEmitIntoClient
+    static var relations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1025)
+    }
+
+    /// Sears Holdings Corporation (`1026`)
+    @_alwaysEmitIntoClient
+    static var searsHoldings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1026)
+    }
+
+    /// Gantner Electronic GmbH (`1027`)
+    @_alwaysEmitIntoClient
+    static var gantnerElectronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1027)
+    }
+
+    /// Authomate Inc (`1028`)
+    @_alwaysEmitIntoClient
+    static var authomate: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1028)
+    }
+
+    /// Vertex International, Inc. (`1029`)
+    @_alwaysEmitIntoClient
+    static var vertexInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1029)
+    }
+
+    /// Airtago (`1030`)
+    @_alwaysEmitIntoClient
+    static var airtago: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1030)
+    }
+
+    /// Swiss Audio SA (`1031`)
+    @_alwaysEmitIntoClient
+    static var swissAudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1031)
+    }
+
+    /// ToGetHome Inc. (`1032`)
+    @_alwaysEmitIntoClient
+    static var togethome: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1032)
+    }
+
+    /// RYSE INC. (`1033`)
+    @_alwaysEmitIntoClient
+    static var ryse: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1033)
+    }
+
+    /// ZF OPENMATICS s.r.o. (`1034`)
+    @_alwaysEmitIntoClient
+    static var zfOpenmatics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1034)
+    }
+
+    /// Jana Care Inc. (`1035`)
+    @_alwaysEmitIntoClient
+    static var janaCare: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1035)
+    }
+
+    /// Senix Corporation (`1036`)
+    @_alwaysEmitIntoClient
+    static var senix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1036)
+    }
+
+    /// NorthStar Battery Company, LLC (`1037`)
+    @_alwaysEmitIntoClient
+    static var northstarBattery: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1037)
+    }
+
+    /// SKF (U.K.) Limited (`1038`)
+    @_alwaysEmitIntoClient
+    static var skfUK: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1038)
+    }
+
+    /// CO-AX Technology, Inc. (`1039`)
+    @_alwaysEmitIntoClient
+    static var coAxTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1039)
+    }
+
+    /// Fender Musical Instruments (`1040`)
+    @_alwaysEmitIntoClient
+    static var fenderMusicalInstruments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1040)
+    }
+
+    /// Luidia Inc (`1041`)
+    @_alwaysEmitIntoClient
+    static var luidia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1041)
+    }
+
+    /// SEFAM (`1042`)
+    @_alwaysEmitIntoClient
+    static var sefam: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1042)
+    }
+
+    /// Wireless Cables Inc (`1043`)
+    @_alwaysEmitIntoClient
+    static var wirelessCables: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1043)
+    }
+
+    /// Lightning Protection International Pty Ltd (`1044`)
+    @_alwaysEmitIntoClient
+    static var lightningProtectionInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1044)
+    }
+
+    /// Uber Technologies Inc (`1045`)
+    @_alwaysEmitIntoClient
+    static var uberTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1045)
+    }
+
+    /// SODA GmbH (`1046`)
+    @_alwaysEmitIntoClient
+    static var soda: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1046)
+    }
+
+    /// Fatigue Science (`1047`)
+    @_alwaysEmitIntoClient
+    static var fatigueScience: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1047)
+    }
+
+    /// Novalogy LTD (`1049`)
+    @_alwaysEmitIntoClient
+    static var novalogy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1049)
+    }
+
+    /// Friday Labs Limited (`1050`)
+    @_alwaysEmitIntoClient
+    static var fridayLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1050)
+    }
+
+    /// OrthoAccel Technologies (`1051`)
+    @_alwaysEmitIntoClient
+    static var orthoaccelTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1051)
+    }
+
+    /// WaterGuru, Inc. (`1052`)
+    @_alwaysEmitIntoClient
+    static var waterguru: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1052)
+    }
+
+    /// Benning Elektrotechnik und Elektronik GmbH & Co. KG (`1053`)
+    @_alwaysEmitIntoClient
+    static var benningElektrotechnikUndElektronik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1053)
+    }
+
+    /// Dell Computer Corporation (`1054`)
+    @_alwaysEmitIntoClient
+    static var dellComputer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1054)
+    }
+
+    /// Kopin Corporation (`1055`)
+    @_alwaysEmitIntoClient
+    static var kopin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1055)
+    }
+
+    /// TecBakery GmbH (`1056`)
+    @_alwaysEmitIntoClient
+    static var tecbakery: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1056)
+    }
+
+    /// Backbone Labs, Inc. (`1057`)
+    @_alwaysEmitIntoClient
+    static var backboneLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1057)
+    }
+
+    /// DELSEY SA (`1058`)
+    @_alwaysEmitIntoClient
+    static var delsey: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1058)
+    }
+
+    /// Chargifi Limited (`1059`)
+    @_alwaysEmitIntoClient
+    static var chargifi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1059)
+    }
+
+    /// Trainesense Ltd. (`1060`)
+    @_alwaysEmitIntoClient
+    static var trainesense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1060)
+    }
+
+    /// Unify Software and Solutions GmbH & Co. KG (`1061`)
+    @_alwaysEmitIntoClient
+    static var unifySoftwareAndSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1061)
+    }
+
+    /// Husqvarna AB (`1062`)
+    @_alwaysEmitIntoClient
+    static var husqvarna: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1062)
+    }
+
+    /// Focus fleet and fuel management inc (`1063`)
+    @_alwaysEmitIntoClient
+    static var focusFleetAndFuelManagement: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1063)
+    }
+
+    /// SmallLoop, LLC (`1064`)
+    @_alwaysEmitIntoClient
+    static var smallloop: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1064)
+    }
+
+    /// Prolon Inc. (`1065`)
+    @_alwaysEmitIntoClient
+    static var prolon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1065)
+    }
+
+    /// BD Medical (`1066`)
+    @_alwaysEmitIntoClient
+    static var bdMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1066)
+    }
+
+    /// iMicroMed Incorporated (`1067`)
+    @_alwaysEmitIntoClient
+    static var imicromed: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1067)
+    }
+
+    /// Ticto N.V. (`1068`)
+    @_alwaysEmitIntoClient
+    static var ticto: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1068)
+    }
+
+    /// Meshtech AS (`1069`)
+    @_alwaysEmitIntoClient
+    static var meshtech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1069)
+    }
+
+    /// MemCachier Inc. (`1070`)
+    @_alwaysEmitIntoClient
+    static var memcachier: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1070)
+    }
+
+    /// Danfoss A/S (`1071`)
+    @_alwaysEmitIntoClient
+    static var danfoss: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1071)
+    }
+
+    /// SnapStyk Inc. (`1072`)
+    @_alwaysEmitIntoClient
+    static var snapstyk: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1072)
+    }
+
+    /// Alticor Inc. (`1073`)
+    @_alwaysEmitIntoClient
+    static var alticor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1073)
+    }
+
+    /// Silk Labs, Inc. (`1074`)
+    @_alwaysEmitIntoClient
+    static var silkLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1074)
+    }
+
+    /// Pillsy Inc. (`1075`)
+    @_alwaysEmitIntoClient
+    static var pillsy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1075)
+    }
+
+    /// Hatch Baby, Inc. (`1076`)
+    @_alwaysEmitIntoClient
+    static var hatchBaby: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1076)
+    }
+
+    /// Blocks Wearables Ltd. (`1077`)
+    @_alwaysEmitIntoClient
+    static var blocksWearables: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1077)
+    }
+
+    /// Drayson Technologies (Europe) Limited (`1078`)
+    @_alwaysEmitIntoClient
+    static var draysonTechnologiesEurope: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1078)
+    }
+
+    /// eBest IOT Inc. (`1079`)
+    @_alwaysEmitIntoClient
+    static var ebestIot: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1079)
+    }
+
+    /// Helvar Ltd (`1080`)
+    @_alwaysEmitIntoClient
+    static var helvar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1080)
+    }
+
+    /// Radiance Technologies (`1081`)
+    @_alwaysEmitIntoClient
+    static var radianceTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1081)
+    }
+
+    /// Nuheara Limited (`1082`)
+    @_alwaysEmitIntoClient
+    static var nuheara: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1082)
+    }
+
+    /// Appside co., ltd. (`1083`)
+    @_alwaysEmitIntoClient
+    static var appside: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1083)
+    }
+
+    /// DeLaval (`1084`)
+    @_alwaysEmitIntoClient
+    static var delaval: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1084)
+    }
+
+    /// Coiler Corporation (`1085`)
+    @_alwaysEmitIntoClient
+    static var coiler: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1085)
+    }
+
+    /// Thermomedics, Inc. (`1086`)
+    @_alwaysEmitIntoClient
+    static var thermomedics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1086)
+    }
+
+    /// Tentacle Sync GmbH (`1087`)
+    @_alwaysEmitIntoClient
+    static var tentacleSync: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1087)
+    }
+
+    /// Valencell, Inc. (`1088`)
+    @_alwaysEmitIntoClient
+    static var valencell: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1088)
+    }
+
+    /// iProtoXi Oy (`1089`)
+    @_alwaysEmitIntoClient
+    static var iprotoxi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1089)
+    }
+
+    /// SECOM CO., LTD. (`1090`)
+    @_alwaysEmitIntoClient
+    static var secom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1090)
+    }
+
+    /// Tucker International LLC (`1091`)
+    @_alwaysEmitIntoClient
+    static var tuckerInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1091)
+    }
+
+    /// Metanate Limited (`1092`)
+    @_alwaysEmitIntoClient
+    static var metanate: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1092)
+    }
+
+    /// Kobian Canada Inc. (`1093`)
+    @_alwaysEmitIntoClient
+    static var kobianCanada: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1093)
+    }
+
+    /// NETGEAR, Inc. (`1094`)
+    @_alwaysEmitIntoClient
+    static var netgear: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1094)
+    }
+
+    /// Fabtronics Australia Pty Ltd (`1095`)
+    @_alwaysEmitIntoClient
+    static var fabtronicsAustralia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1095)
+    }
+
+    /// Grand Centrix GmbH (`1096`)
+    @_alwaysEmitIntoClient
+    static var grandCentrix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1096)
+    }
+
+    /// 1UP USA.com llc (`1097`)
+    @_alwaysEmitIntoClient
+    static var company1UpUsaCom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1097)
+    }
+
+    /// SHIMANO INC. (`1098`)
+    @_alwaysEmitIntoClient
+    static var shimano: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1098)
+    }
+
+    /// Nain Inc. (`1099`)
+    @_alwaysEmitIntoClient
+    static var nain: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1099)
+    }
+
+    /// LifeStyle Lock, LLC (`1100`)
+    @_alwaysEmitIntoClient
+    static var lifestyleLock: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1100)
+    }
+
+    /// VEGA Grieshaber KG (`1101`)
+    @_alwaysEmitIntoClient
+    static var vegaGrieshaberKg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1101)
+    }
+
+    /// Xtrava Inc. (`1102`)
+    @_alwaysEmitIntoClient
+    static var xtrava: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1102)
+    }
+
+    /// TTS Tooltechnic Systems AG & Co. KG (`1103`)
+    @_alwaysEmitIntoClient
+    static var ttsTooltechnicSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1103)
+    }
+
+    /// Teenage Engineering AB (`1104`)
+    @_alwaysEmitIntoClient
+    static var teenageEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1104)
+    }
+
+    /// Tunstall Nordic AB (`1105`)
+    @_alwaysEmitIntoClient
+    static var tunstallNordic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1105)
+    }
+
+    /// Svep Design Center AB (`1106`)
+    @_alwaysEmitIntoClient
+    static var svepDesignCenter: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1106)
+    }
+
+    /// Qorvo Utrecht B.V. (`1107`)
+    @_alwaysEmitIntoClient
+    static var qorvoUtrecht: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1107)
+    }
+
+    /// Sphinx Electronics GmbH & Co KG (`1108`)
+    @_alwaysEmitIntoClient
+    static var sphinxElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1108)
+    }
+
+    /// Atomation (`1109`)
+    @_alwaysEmitIntoClient
+    static var atomation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1109)
+    }
+
+    /// Nemik Consulting Inc (`1110`)
+    @_alwaysEmitIntoClient
+    static var nemikConsulting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1110)
+    }
+
+    /// RF INNOVATION (`1111`)
+    @_alwaysEmitIntoClient
+    static var rfInnovation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1111)
+    }
+
+    /// Mini Solution Co., Ltd. (`1112`)
+    @_alwaysEmitIntoClient
+    static var miniSolution: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1112)
+    }
+
+    /// Lumenetix, Inc (`1113`)
+    @_alwaysEmitIntoClient
+    static var lumenetix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1113)
+    }
+
+    /// 2048450 Ontario Inc (`1114`)
+    @_alwaysEmitIntoClient
+    static var company2048450Ontario: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1114)
+    }
+
+    /// SPACEEK LTD (`1115`)
+    @_alwaysEmitIntoClient
+    static var spaceek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1115)
+    }
+
+    /// Delta T Corporation (`1116`)
+    @_alwaysEmitIntoClient
+    static var deltaT: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1116)
+    }
+
+    /// Boston Scientific Corporation (`1117`)
+    @_alwaysEmitIntoClient
+    static var bostonScientific: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1117)
+    }
+
+    /// Nuviz, Inc. (`1118`)
+    @_alwaysEmitIntoClient
+    static var nuviz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1118)
+    }
+
+    /// Real Time Automation, Inc. (`1119`)
+    @_alwaysEmitIntoClient
+    static var realTimeAutomation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1119)
+    }
+
+    /// Kolibree (`1120`)
+    @_alwaysEmitIntoClient
+    static var kolibree: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1120)
+    }
+
+    /// vhf elektronik GmbH (`1121`)
+    @_alwaysEmitIntoClient
+    static var vhfElektronik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1121)
+    }
+
+    /// Bonsai Systems GmbH (`1122`)
+    @_alwaysEmitIntoClient
+    static var bonsaiSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1122)
+    }
+
+    /// Fathom Systems Inc. (`1123`)
+    @_alwaysEmitIntoClient
+    static var fathomSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1123)
+    }
+
+    /// Bellman & Symfon Group AB (`1124`)
+    @_alwaysEmitIntoClient
+    static var bellmanSymfonGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1124)
+    }
+
+    /// International Forte Group LLC (`1125`)
+    @_alwaysEmitIntoClient
+    static var internationalForteGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1125)
+    }
+
+    /// CycleLabs Solutions inc. (`1126`)
+    @_alwaysEmitIntoClient
+    static var cyclelabsSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1126)
+    }
+
+    /// Codenex Oy (`1127`)
+    @_alwaysEmitIntoClient
+    static var codenex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1127)
+    }
+
+    /// Kynesim Ltd (`1128`)
+    @_alwaysEmitIntoClient
+    static var kynesim: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1128)
+    }
+
+    /// Palago AB (`1129`)
+    @_alwaysEmitIntoClient
+    static var palago: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1129)
+    }
+
+    /// INSIGMA INC. (`1130`)
+    @_alwaysEmitIntoClient
+    static var insigma: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1130)
+    }
+
+    /// PMD Solutions (`1131`)
+    @_alwaysEmitIntoClient
+    static var pmdSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1131)
+    }
+
+    /// Qingdao Realtime Technology Co., Ltd. (`1132`)
+    @_alwaysEmitIntoClient
+    static var qingdaoRealtimeTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1132)
+    }
+
+    /// BEGA Gantenbrink-Leuchten KG (`1133`)
+    @_alwaysEmitIntoClient
+    static var begaGantenbrinkLeuchtenKg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1133)
+    }
+
+    /// Pambor Ltd. (`1134`)
+    @_alwaysEmitIntoClient
+    static var pambor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1134)
+    }
+
+    /// Develco Products A/S (`1135`)
+    @_alwaysEmitIntoClient
+    static var develcoProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1135)
+    }
+
+    /// iDesign s.r.l. (`1136`)
+    @_alwaysEmitIntoClient
+    static var idesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1136)
+    }
+
+    /// TiVo Corp (`1137`)
+    @_alwaysEmitIntoClient
+    static var tivo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1137)
+    }
+
+    /// Control-J Pty Ltd (`1138`)
+    @_alwaysEmitIntoClient
+    static var controlJ: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1138)
+    }
+
+    /// Steelcase, Inc. (`1139`)
+    @_alwaysEmitIntoClient
+    static var steelcase: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1139)
+    }
+
+    /// iApartment co., ltd. (`1140`)
+    @_alwaysEmitIntoClient
+    static var iapartment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1140)
+    }
+
+    /// Icom inc. (`1141`)
+    @_alwaysEmitIntoClient
+    static var icom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1141)
+    }
+
+    /// Oxstren Wearable Technologies Private Limited (`1142`)
+    @_alwaysEmitIntoClient
+    static var oxstrenWearableTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1142)
+    }
+
+    /// Blue Spark Technologies (`1143`)
+    @_alwaysEmitIntoClient
+    static var blueSparkTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1143)
+    }
+
+    /// FarSite Communications Limited (`1144`)
+    @_alwaysEmitIntoClient
+    static var farsiteCommunications: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1144)
+    }
+
+    /// mywerk system GmbH (`1145`)
+    @_alwaysEmitIntoClient
+    static var mywerkSystem: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1145)
+    }
+
+    /// Sinosun Technology Co., Ltd. (`1146`)
+    @_alwaysEmitIntoClient
+    static var sinosunTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1146)
+    }
+
+    /// MIYOSHI ELECTRONICS CORPORATION (`1147`)
+    @_alwaysEmitIntoClient
+    static var miyoshiElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1147)
+    }
+
+    /// POWERMAT LTD (`1148`)
+    @_alwaysEmitIntoClient
+    static var powermat: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1148)
+    }
+
+    /// Occly LLC (`1149`)
+    @_alwaysEmitIntoClient
+    static var occly: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1149)
+    }
+
+    /// OurHub Dev IvS (`1150`)
+    @_alwaysEmitIntoClient
+    static var ourhubDevIvs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1150)
+    }
+
+    /// Pro-Mark, Inc. (`1151`)
+    @_alwaysEmitIntoClient
+    static var proMark: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1151)
+    }
+
+    /// Dynometrics Inc. (`1152`)
+    @_alwaysEmitIntoClient
+    static var dynometrics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1152)
+    }
+
+    /// Quintrax Limited (`1153`)
+    @_alwaysEmitIntoClient
+    static var quintrax: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1153)
+    }
+
+    /// POS Tuning Udo Vosshenrich GmbH & Co. KG (`1154`)
+    @_alwaysEmitIntoClient
+    static var posTuningUdoVosshenrich: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1154)
+    }
+
+    /// Multi Care Systems B.V. (`1155`)
+    @_alwaysEmitIntoClient
+    static var multiCareSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1155)
+    }
+
+    /// Revol Technologies Inc (`1156`)
+    @_alwaysEmitIntoClient
+    static var revolTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1156)
+    }
+
+    /// SKIDATA AG (`1157`)
+    @_alwaysEmitIntoClient
+    static var skidata: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1157)
+    }
+
+    /// DEV TECNOLOGIA INDUSTRIA, COMERCIO E MANUTENCAO DE EQUIPAMENTOS LTDA. - ME (`1158`)
+    @_alwaysEmitIntoClient
+    static var devTecnologiaIndustriaComercioEManutencaoDeEquipamentos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1158)
+    }
+
+    /// Centrica Connected Home (`1159`)
+    @_alwaysEmitIntoClient
+    static var centricaConnectedHome: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1159)
+    }
+
+    /// Automotive Data Solutions Inc (`1160`)
+    @_alwaysEmitIntoClient
+    static var automotiveDataSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1160)
+    }
+
+    /// Igarashi Engineering (`1161`)
+    @_alwaysEmitIntoClient
+    static var igarashiEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1161)
+    }
+
+    /// Taelek Oy (`1162`)
+    @_alwaysEmitIntoClient
+    static var taelek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1162)
+    }
+
+    /// CP Electronics Limited (`1163`)
+    @_alwaysEmitIntoClient
+    static var cpElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1163)
+    }
+
+    /// Vectronix AG (`1164`)
+    @_alwaysEmitIntoClient
+    static var vectronix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1164)
+    }
+
+    /// S-Labs Sp. z o.o. (`1165`)
+    @_alwaysEmitIntoClient
+    static var sLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1165)
+    }
+
+    /// Companion Medical, Inc. (`1166`)
+    @_alwaysEmitIntoClient
+    static var companionMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1166)
+    }
+
+    /// BlueKitchen GmbH (`1167`)
+    @_alwaysEmitIntoClient
+    static var bluekitchen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1167)
+    }
+
+    /// Matting AB (`1168`)
+    @_alwaysEmitIntoClient
+    static var matting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1168)
+    }
+
+    /// SOREX - Wireless Solutions GmbH (`1169`)
+    @_alwaysEmitIntoClient
+    static var sorexWirelessSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1169)
+    }
+
+    /// ADC Technology, Inc. (`1170`)
+    @_alwaysEmitIntoClient
+    static var adcTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1170)
+    }
+
+    /// Lynxemi Pte Ltd (`1171`)
+    @_alwaysEmitIntoClient
+    static var lynxemiPte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1171)
+    }
+
+    /// SENNHEISER electronic GmbH & Co. KG (`1172`)
+    @_alwaysEmitIntoClient
+    static var sennheiserElectronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1172)
+    }
+
+    /// LMT Mercer Group, Inc (`1173`)
+    @_alwaysEmitIntoClient
+    static var lmtMercerGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1173)
+    }
+
+    /// Polymorphic Labs LLC (`1174`)
+    @_alwaysEmitIntoClient
+    static var polymorphicLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1174)
+    }
+
+    /// Cochlear Limited (`1175`)
+    @_alwaysEmitIntoClient
+    static var cochlear: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1175)
+    }
+
+    /// METER Group, Inc. USA (`1176`)
+    @_alwaysEmitIntoClient
+    static var meterGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1176)
+    }
+
+    /// Ruuvi Innovations Ltd. (`1177`)
+    @_alwaysEmitIntoClient
+    static var ruuviInnovations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1177)
+    }
+
+    /// Situne AS (`1178`)
+    @_alwaysEmitIntoClient
+    static var situne: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1178)
+    }
+
+    /// nVisti, LLC (`1179`)
+    @_alwaysEmitIntoClient
+    static var nvisti: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1179)
+    }
+
+    /// DyOcean (`1180`)
+    @_alwaysEmitIntoClient
+    static var dyocean: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1180)
+    }
+
+    /// Uhlmann & Zacher GmbH (`1181`)
+    @_alwaysEmitIntoClient
+    static var uhlmannZacher: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1181)
+    }
+
+    /// AND!XOR LLC (`1182`)
+    @_alwaysEmitIntoClient
+    static var andXor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1182)
+    }
+
+    /// Popper Pay AB (`1183`)
+    @_alwaysEmitIntoClient
+    static var popperPay: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1183)
+    }
+
+    /// Vypin, LLC (`1184`)
+    @_alwaysEmitIntoClient
+    static var vypin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1184)
+    }
+
+    /// PNI Sensor Corporation (`1185`)
+    @_alwaysEmitIntoClient
+    static var pniSensor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1185)
+    }
+
+    /// ovrEngineered, LLC (`1186`)
+    @_alwaysEmitIntoClient
+    static var ovrengineered: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1186)
+    }
+
+    /// GT-tronics HK Ltd (`1187`)
+    @_alwaysEmitIntoClient
+    static var gtTronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1187)
+    }
+
+    /// Herbert Waldmann GmbH & Co. KG (`1188`)
+    @_alwaysEmitIntoClient
+    static var herbertWaldmann: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1188)
+    }
+
+    /// Guangzhou FiiO Electronics Technology Co.,Ltd (`1189`)
+    @_alwaysEmitIntoClient
+    static var guangzhouFiioElectronicsTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1189)
+    }
+
+    /// Vinetech Co., Ltd (`1190`)
+    @_alwaysEmitIntoClient
+    static var vinetech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1190)
+    }
+
+    /// Dallas Logic Corporation (`1191`)
+    @_alwaysEmitIntoClient
+    static var dallasLogic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1191)
+    }
+
+    /// BioTex, Inc. (`1192`)
+    @_alwaysEmitIntoClient
+    static var biotex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1192)
+    }
+
+    /// DISCOVERY SOUND TECHNOLOGY, LLC (`1193`)
+    @_alwaysEmitIntoClient
+    static var discoverySoundTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1193)
+    }
+
+    /// LINKIO SAS (`1194`)
+    @_alwaysEmitIntoClient
+    static var linkios: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1194)
+    }
+
+    /// Harbortronics, Inc. (`1195`)
+    @_alwaysEmitIntoClient
+    static var harbortronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1195)
+    }
+
+    /// Undagrid B.V. (`1196`)
+    @_alwaysEmitIntoClient
+    static var undagrid: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1196)
+    }
+
+    /// Shure Inc (`1197`)
+    @_alwaysEmitIntoClient
+    static var shure: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1197)
+    }
+
+    /// ERM Electronic Systems LTD (`1198`)
+    @_alwaysEmitIntoClient
+    static var ermElectronicSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1198)
+    }
+
+    /// BIOROWER Handelsagentur GmbH (`1199`)
+    @_alwaysEmitIntoClient
+    static var biorowerHandelsagentur: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1199)
+    }
+
+    /// Weba Sport und Med. Artikel GmbH (`1200`)
+    @_alwaysEmitIntoClient
+    static var webaSportUndMedArtikel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1200)
+    }
+
+    /// Kartographers Technologies Pvt. Ltd. (`1201`)
+    @_alwaysEmitIntoClient
+    static var kartographersTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1201)
+    }
+
+    /// The Shadow on the Moon (`1202`)
+    @_alwaysEmitIntoClient
+    static var shadowOnMoon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1202)
+    }
+
+    /// mobike (Hong Kong) Limited (`1203`)
+    @_alwaysEmitIntoClient
+    static var mobikeHongKong: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1203)
+    }
+
+    /// Inuheat Group AB (`1204`)
+    @_alwaysEmitIntoClient
+    static var inuheatGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1204)
+    }
+
+    /// Swiftronix AB (`1205`)
+    @_alwaysEmitIntoClient
+    static var swiftronix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1205)
+    }
+
+    /// Diagnoptics Technologies (`1206`)
+    @_alwaysEmitIntoClient
+    static var diagnopticsTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1206)
+    }
+
+    /// Analog Devices, Inc. (`1207`)
+    @_alwaysEmitIntoClient
+    static var analogDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1207)
+    }
+
+    /// Soraa Inc. (`1208`)
+    @_alwaysEmitIntoClient
+    static var soraa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1208)
+    }
+
+    /// CSR Building Products Limited (`1209`)
+    @_alwaysEmitIntoClient
+    static var csrBuildingProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1209)
+    }
+
+    /// Crestron Electronics, Inc. (`1210`)
+    @_alwaysEmitIntoClient
+    static var crestronElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1210)
+    }
+
+    /// Neatebox Ltd (`1211`)
+    @_alwaysEmitIntoClient
+    static var neatebox: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1211)
+    }
+
+    /// Draegerwerk AG & Co. KGaA (`1212`)
+    @_alwaysEmitIntoClient
+    static var draegerwerk: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1212)
+    }
+
+    /// AlbynMedical (`1213`)
+    @_alwaysEmitIntoClient
+    static var albynmedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1213)
+    }
+
+    /// Averos FZCO (`1214`)
+    @_alwaysEmitIntoClient
+    static var averos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1214)
+    }
+
+    /// VIT Initiative, LLC (`1215`)
+    @_alwaysEmitIntoClient
+    static var vitInitiative: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1215)
+    }
+
+    /// Statsports International (`1216`)
+    @_alwaysEmitIntoClient
+    static var statsportsInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1216)
+    }
+
+    /// Sospitas, s.r.o. (`1217`)
+    @_alwaysEmitIntoClient
+    static var sospitas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1217)
+    }
+
+    /// Dmet Products Corp. (`1218`)
+    @_alwaysEmitIntoClient
+    static var dmetProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1218)
+    }
+
+    /// Mantracourt Electronics Limited (`1219`)
+    @_alwaysEmitIntoClient
+    static var mantracourtElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1219)
+    }
+
+    /// TeAM Hutchins AB (`1220`)
+    @_alwaysEmitIntoClient
+    static var teamHutchins: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1220)
+    }
+
+    /// Seibert Williams Glass, LLC (`1221`)
+    @_alwaysEmitIntoClient
+    static var seibertWilliamsGlass: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1221)
+    }
+
+    /// Insta GmbH (`1222`)
+    @_alwaysEmitIntoClient
+    static var insta: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1222)
+    }
+
+    /// Svantek Sp. z o.o. (`1223`)
+    @_alwaysEmitIntoClient
+    static var svantek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1223)
+    }
+
+    /// Shanghai Flyco Electrical Appliance Co., Ltd. (`1224`)
+    @_alwaysEmitIntoClient
+    static var shanghaiFlycoElectricalAppliance: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1224)
+    }
+
+    /// Thornwave Labs Inc (`1225`)
+    @_alwaysEmitIntoClient
+    static var thornwaveLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1225)
+    }
+
+    /// Steiner-Optik GmbH (`1226`)
+    @_alwaysEmitIntoClient
+    static var steinerOptik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1226)
+    }
+
+    /// Novo Nordisk A/S (`1227`)
+    @_alwaysEmitIntoClient
+    static var novoNordisk: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1227)
+    }
+
+    /// Enflux Inc. (`1228`)
+    @_alwaysEmitIntoClient
+    static var enflux: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1228)
+    }
+
+    /// Safetech Products LLC (`1229`)
+    @_alwaysEmitIntoClient
+    static var safetechProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1229)
+    }
+
+    /// GOOOLED S.R.L. (`1230`)
+    @_alwaysEmitIntoClient
+    static var goooled: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1230)
+    }
+
+    /// DOM Sicherheitstechnik GmbH & Co. KG (`1231`)
+    @_alwaysEmitIntoClient
+    static var domSicherheitstechnik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1231)
+    }
+
+    /// Olympus Corporation (`1232`)
+    @_alwaysEmitIntoClient
+    static var olympus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1232)
+    }
+
+    /// KTS GmbH (`1233`)
+    @_alwaysEmitIntoClient
+    static var kts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1233)
+    }
+
+    /// Anloq Technologies Inc. (`1234`)
+    @_alwaysEmitIntoClient
+    static var anloqTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1234)
+    }
+
+    /// Queercon, Inc (`1235`)
+    @_alwaysEmitIntoClient
+    static var queercon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1235)
+    }
+
+    /// 5th Element Ltd (`1236`)
+    @_alwaysEmitIntoClient
+    static var company5ThElement: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1236)
+    }
+
+    /// Gooee Limited (`1237`)
+    @_alwaysEmitIntoClient
+    static var gooee: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1237)
+    }
+
+    /// LUGLOC LLC (`1238`)
+    @_alwaysEmitIntoClient
+    static var lugloc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1238)
+    }
+
+    /// Blincam, Inc. (`1239`)
+    @_alwaysEmitIntoClient
+    static var blincam: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1239)
+    }
+
+    /// FUJIFILM Corporation (`1240`)
+    @_alwaysEmitIntoClient
+    static var fujifilm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1240)
+    }
+
+    /// RM Acquisition LLC (`1241`)
+    @_alwaysEmitIntoClient
+    static var rmAcquisition: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1241)
+    }
+
+    /// Franceschi Marina snc (`1242`)
+    @_alwaysEmitIntoClient
+    static var franceschiMarinaSnc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1242)
+    }
+
+    /// Engineered Audio, LLC. (`1243`)
+    @_alwaysEmitIntoClient
+    static var engineeredAudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1243)
+    }
+
+    /// IOTTIVE (OPC) PRIVATE LIMITED (`1244`)
+    @_alwaysEmitIntoClient
+    static var iottiveOpc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1244)
+    }
+
+    /// 4MOD Technology (`1245`)
+    @_alwaysEmitIntoClient
+    static var company4ModTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1245)
+    }
+
+    /// Lutron Electronics Co., Inc. (`1246`)
+    @_alwaysEmitIntoClient
+    static var lutronElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1246)
+    }
+
+    /// Emerson Electric Co. (`1247`)
+    @_alwaysEmitIntoClient
+    static var emersonElectric: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1247)
+    }
+
+    /// Guardtec, Inc. (`1248`)
+    @_alwaysEmitIntoClient
+    static var guardtec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1248)
+    }
+
+    /// REACTEC LIMITED (`1249`)
+    @_alwaysEmitIntoClient
+    static var reactec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1249)
+    }
+
+    /// EllieGrid (`1250`)
+    @_alwaysEmitIntoClient
+    static var elliegrid: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1250)
+    }
+
+    /// Under Armour (`1251`)
+    @_alwaysEmitIntoClient
+    static var underArmour: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1251)
+    }
+
+    /// Woodenshark (`1252`)
+    @_alwaysEmitIntoClient
+    static var woodenshark: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1252)
+    }
+
+    /// Avack Oy (`1253`)
+    @_alwaysEmitIntoClient
+    static var avack: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1253)
+    }
+
+    /// Smart Solution Technology, Inc. (`1254`)
+    @_alwaysEmitIntoClient
+    static var smartSolutionTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1254)
+    }
+
+    /// REHABTRONICS INC. (`1255`)
+    @_alwaysEmitIntoClient
+    static var rehabtronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1255)
+    }
+
+    /// STABILO International (`1256`)
+    @_alwaysEmitIntoClient
+    static var stabiloInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1256)
+    }
+
+    /// Busch Jaeger Elektro GmbH (`1257`)
+    @_alwaysEmitIntoClient
+    static var buschJaegerElektro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1257)
+    }
+
+    /// Pacific Bioscience Laboratories, Inc (`1258`)
+    @_alwaysEmitIntoClient
+    static var pacificBioscienceLaboratories: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1258)
+    }
+
+    /// Bird Home Automation GmbH (`1259`)
+    @_alwaysEmitIntoClient
+    static var birdHomeAutomation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1259)
+    }
+
+    /// Motorola Solutions (`1260`)
+    @_alwaysEmitIntoClient
+    static var motorolaSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1260)
+    }
+
+    /// R9 Technology, Inc. (`1261`)
+    @_alwaysEmitIntoClient
+    static var r9Technology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1261)
+    }
+
+    /// Auxivia (`1262`)
+    @_alwaysEmitIntoClient
+    static var auxivia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1262)
+    }
+
+    /// DaisyWorks, Inc (`1263`)
+    @_alwaysEmitIntoClient
+    static var daisyworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1263)
+    }
+
+    /// Kosi Limited (`1264`)
+    @_alwaysEmitIntoClient
+    static var kosi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1264)
+    }
+
+    /// Theben AG (`1265`)
+    @_alwaysEmitIntoClient
+    static var theben: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1265)
+    }
+
+    /// InDreamer Techsol Private Limited (`1266`)
+    @_alwaysEmitIntoClient
+    static var indreamerTechsol: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1266)
+    }
+
+    /// Cerevast Medical (`1267`)
+    @_alwaysEmitIntoClient
+    static var cerevastMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1267)
+    }
+
+    /// ZanCompute Inc. (`1268`)
+    @_alwaysEmitIntoClient
+    static var zancompute: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1268)
+    }
+
+    /// Pirelli Tyre S.P.A. (`1269`)
+    @_alwaysEmitIntoClient
+    static var pirelliTyre: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1269)
+    }
+
+    /// McLear Limited (`1270`)
+    @_alwaysEmitIntoClient
+    static var mclear: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1270)
+    }
+
+    /// Shenzhen Goodix Technology Co., Ltd (`1271`)
+    @_alwaysEmitIntoClient
+    static var shenzhenGoodixTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1271)
+    }
+
+    /// Convergence Systems Limited (`1272`)
+    @_alwaysEmitIntoClient
+    static var convergenceSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1272)
+    }
+
+    /// Interactio (`1273`)
+    @_alwaysEmitIntoClient
+    static var interactio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1273)
+    }
+
+    /// Androtec GmbH (`1274`)
+    @_alwaysEmitIntoClient
+    static var androtec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1274)
+    }
+
+    /// Benchmark Drives GmbH & Co. KG (`1275`)
+    @_alwaysEmitIntoClient
+    static var benchmarkDrives: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1275)
+    }
+
+    /// SwingLync L. L. C. (`1276`)
+    @_alwaysEmitIntoClient
+    static var swinglyncLLC: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1276)
+    }
+
+    /// Tapkey GmbH (`1277`)
+    @_alwaysEmitIntoClient
+    static var tapkey: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1277)
+    }
+
+    /// Woosim Systems Inc. (`1278`)
+    @_alwaysEmitIntoClient
+    static var woosimSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1278)
+    }
+
+    /// Microsemi Corporation (`1279`)
+    @_alwaysEmitIntoClient
+    static var microsemi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1279)
+    }
+
+    /// Wiliot LTD. (`1280`)
+    @_alwaysEmitIntoClient
+    static var wiliot: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1280)
+    }
+
+    /// Polaris IND (`1281`)
+    @_alwaysEmitIntoClient
+    static var polarisInd: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1281)
+    }
+
+    /// Specifi-Kali LLC (`1282`)
+    @_alwaysEmitIntoClient
+    static var specifiKali: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1282)
+    }
+
+    /// Locoroll, Inc (`1283`)
+    @_alwaysEmitIntoClient
+    static var locoroll: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1283)
+    }
+
+    /// PHYPLUS Inc (`1284`)
+    @_alwaysEmitIntoClient
+    static var phyplus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1284)
+    }
+
+    /// InPlay, Inc. (`1285`)
+    @_alwaysEmitIntoClient
+    static var inplay: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1285)
+    }
+
+    /// Hager (`1286`)
+    @_alwaysEmitIntoClient
+    static var hager: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1286)
+    }
+
+    /// Yellowcog (`1287`)
+    @_alwaysEmitIntoClient
+    static var yellowcog: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1287)
+    }
+
+    /// Axes System sp. z o. o. (`1288`)
+    @_alwaysEmitIntoClient
+    static var axesSystemSpZOO: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1288)
+    }
+
+    /// Garage Smart, Inc. (`1289`)
+    @_alwaysEmitIntoClient
+    static var garageSmart: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1289)
+    }
+
+    /// Shake-on B.V. (`1290`)
+    @_alwaysEmitIntoClient
+    static var shakeOn: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1290)
+    }
+
+    /// Vibrissa Inc. (`1291`)
+    @_alwaysEmitIntoClient
+    static var vibrissa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1291)
+    }
+
+    /// OSRAM GmbH (`1292`)
+    @_alwaysEmitIntoClient
+    static var osram: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1292)
+    }
+
+    /// TRSystems GmbH (`1293`)
+    @_alwaysEmitIntoClient
+    static var trsystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1293)
+    }
+
+    /// Yichip Microelectronics (Hangzhou) Co.,Ltd. (`1294`)
+    @_alwaysEmitIntoClient
+    static var yichipMicroelectronicsHangzhou: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1294)
+    }
+
+    /// Foundation Engineering LLC (`1295`)
+    @_alwaysEmitIntoClient
+    static var foundationEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1295)
+    }
+
+    /// UNI-ELECTRONICS, INC. (`1296`)
+    @_alwaysEmitIntoClient
+    static var uniElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1296)
+    }
+
+    /// Brookfield Equinox LLC (`1297`)
+    @_alwaysEmitIntoClient
+    static var brookfieldEquinox: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1297)
+    }
+
+    /// Soprod SA (`1298`)
+    @_alwaysEmitIntoClient
+    static var soprod: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1298)
+    }
+
+    /// 9974091 Canada Inc. (`1299`)
+    @_alwaysEmitIntoClient
+    static var company9974091Canada: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1299)
+    }
+
+    /// FIBRO GmbH (`1300`)
+    @_alwaysEmitIntoClient
+    static var fibro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1300)
+    }
+
+    /// RB Controls Co., Ltd. (`1301`)
+    @_alwaysEmitIntoClient
+    static var rbControls: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1301)
+    }
+
+    /// Footmarks (`1302`)
+    @_alwaysEmitIntoClient
+    static var footmarks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1302)
+    }
+
+    /// Amtronic Sverige AB (`1303`)
+    @_alwaysEmitIntoClient
+    static var amtronicSverige: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1303)
+    }
+
+    /// MAMORIO.inc (`1304`)
+    @_alwaysEmitIntoClient
+    static var mamorioInc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1304)
+    }
+
+    /// Tyto Life LLC (`1305`)
+    @_alwaysEmitIntoClient
+    static var tytoLife: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1305)
+    }
+
+    /// Leica Camera AG (`1306`)
+    @_alwaysEmitIntoClient
+    static var leicaCamera: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1306)
+    }
+
+    /// Angee Technologies Ltd. (`1307`)
+    @_alwaysEmitIntoClient
+    static var angeeTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1307)
+    }
+
+    /// EDPS (`1308`)
+    @_alwaysEmitIntoClient
+    static var edps: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1308)
+    }
+
+    /// OFF Line Co., Ltd. (`1309`)
+    @_alwaysEmitIntoClient
+    static var offLine: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1309)
+    }
+
+    /// Detect Blue Limited (`1310`)
+    @_alwaysEmitIntoClient
+    static var detectBlue: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1310)
+    }
+
+    /// Setec Pty Ltd (`1311`)
+    @_alwaysEmitIntoClient
+    static var setec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1311)
+    }
+
+    /// Target Corporation (`1312`)
+    @_alwaysEmitIntoClient
+    static var target: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1312)
+    }
+
+    /// IAI Corporation (`1313`)
+    @_alwaysEmitIntoClient
+    static var iai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1313)
+    }
+
+    /// NS Tech, Inc. (`1314`)
+    @_alwaysEmitIntoClient
+    static var nsTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1314)
+    }
+
+    /// MTG Co., Ltd. (`1315`)
+    @_alwaysEmitIntoClient
+    static var mtg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1315)
+    }
+
+    /// Hangzhou iMagic Technology Co., Ltd (`1316`)
+    @_alwaysEmitIntoClient
+    static var hangzhouImagicTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1316)
+    }
+
+    /// HONGKONG NANO IC TECHNOLOGIES  CO., LIMITED (`1317`)
+    @_alwaysEmitIntoClient
+    static var hongkongNanoIcTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1317)
+    }
+
+    /// Honeywell International Inc. (`1318`)
+    @_alwaysEmitIntoClient
+    static var honeywellInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1318)
+    }
+
+    /// Albrecht JUNG (`1319`)
+    @_alwaysEmitIntoClient
+    static var albrechtJung: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1319)
+    }
+
+    /// Lunera Lighting Inc. (`1320`)
+    @_alwaysEmitIntoClient
+    static var luneraLighting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1320)
+    }
+
+    /// Lumen UAB (`1321`)
+    @_alwaysEmitIntoClient
+    static var lumenUab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1321)
+    }
+
+    /// Keynes Controls Ltd (`1322`)
+    @_alwaysEmitIntoClient
+    static var keynesControls: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1322)
+    }
+
+    /// Novartis AG (`1323`)
+    @_alwaysEmitIntoClient
+    static var novartis: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1323)
+    }
+
+    /// Geosatis SA (`1324`)
+    @_alwaysEmitIntoClient
+    static var geosatis: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1324)
+    }
+
+    /// EXFO, Inc. (`1325`)
+    @_alwaysEmitIntoClient
+    static var exfo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1325)
+    }
+
+    /// LEDVANCE GmbH (`1326`)
+    @_alwaysEmitIntoClient
+    static var ledvance: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1326)
+    }
+
+    /// Center ID Corp. (`1327`)
+    @_alwaysEmitIntoClient
+    static var centerId: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1327)
+    }
+
+    /// Adolene, Inc. (`1328`)
+    @_alwaysEmitIntoClient
+    static var adolene: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1328)
+    }
+
+    /// D&M Holdings Inc. (`1329`)
+    @_alwaysEmitIntoClient
+    static var dMHoldings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1329)
+    }
+
+    /// CRESCO Wireless, Inc. (`1330`)
+    @_alwaysEmitIntoClient
+    static var crescoWireless: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1330)
+    }
+
+    /// Nura Operations Pty Ltd (`1331`)
+    @_alwaysEmitIntoClient
+    static var nuraOperations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1331)
+    }
+
+    /// Frontiergadget, Inc. (`1332`)
+    @_alwaysEmitIntoClient
+    static var frontiergadget: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1332)
+    }
+
+    /// Smart Component Technologies Limited (`1333`)
+    @_alwaysEmitIntoClient
+    static var smartComponentTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1333)
+    }
+
+    /// ZTR Control Systems LLC (`1334`)
+    @_alwaysEmitIntoClient
+    static var ztrControlSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1334)
+    }
+
+    /// MetaLogics Corporation (`1335`)
+    @_alwaysEmitIntoClient
+    static var metalogics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1335)
+    }
+
+    /// Medela AG (`1336`)
+    @_alwaysEmitIntoClient
+    static var medela2: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1336)
+    }
+
+    /// OPPLE Lighting Co., Ltd (`1337`)
+    @_alwaysEmitIntoClient
+    static var oppleLighting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1337)
+    }
+
+    /// Savitech Corp., (`1338`)
+    @_alwaysEmitIntoClient
+    static var savitech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1338)
+    }
+
+    /// prodigy (`1339`)
+    @_alwaysEmitIntoClient
+    static var prodigy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1339)
+    }
+
+    /// Screenovate Technologies Ltd (`1340`)
+    @_alwaysEmitIntoClient
+    static var screenovateTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1340)
+    }
+
+    /// TESA SA (`1341`)
+    @_alwaysEmitIntoClient
+    static var tesa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1341)
+    }
+
+    /// CLIM8 LIMITED (`1342`)
+    @_alwaysEmitIntoClient
+    static var clim8: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1342)
+    }
+
+    /// Silergy Corp (`1343`)
+    @_alwaysEmitIntoClient
+    static var silergy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1343)
+    }
+
+    /// SilverPlus, Inc (`1344`)
+    @_alwaysEmitIntoClient
+    static var silverplus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1344)
+    }
+
+    /// Sharknet srl (`1345`)
+    @_alwaysEmitIntoClient
+    static var sharknet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1345)
+    }
+
+    /// Mist Systems, Inc. (`1346`)
+    @_alwaysEmitIntoClient
+    static var mistSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1346)
+    }
+
+    /// MIWA LOCK CO.,Ltd (`1347`)
+    @_alwaysEmitIntoClient
+    static var miwaLock: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1347)
+    }
+
+    /// OrthoSensor, Inc. (`1348`)
+    @_alwaysEmitIntoClient
+    static var orthosensor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1348)
+    }
+
+    /// Candy Hoover Group s.r.l (`1349`)
+    @_alwaysEmitIntoClient
+    static var candyHooverGroupSRL: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1349)
+    }
+
+    /// Apexar Technologies S.A. (`1350`)
+    @_alwaysEmitIntoClient
+    static var apexarTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1350)
+    }
+
+    /// LOGICDATA Electronic & Software Entwicklungs GmbH (`1351`)
+    @_alwaysEmitIntoClient
+    static var logicdataElectronicSoftwareEntwicklungs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1351)
+    }
+
+    /// Knick Elektronische Messgeraete GmbH & Co. KG (`1352`)
+    @_alwaysEmitIntoClient
+    static var knickElektronischeMessgeraete: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1352)
+    }
+
+    /// Smart Technologies and Investment Limited (`1353`)
+    @_alwaysEmitIntoClient
+    static var smartTechnologiesAndInvestment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1353)
+    }
+
+    /// Linough Inc. (`1354`)
+    @_alwaysEmitIntoClient
+    static var linough: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1354)
+    }
+
+    /// Advanced Electronic Designs, Inc. (`1355`)
+    @_alwaysEmitIntoClient
+    static var advancedElectronicDesigns: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1355)
+    }
+
+    /// Carefree Scott Fetzer Co Inc (`1356`)
+    @_alwaysEmitIntoClient
+    static var carefreeScottFetzerCo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1356)
+    }
+
+    /// Sensome (`1357`)
+    @_alwaysEmitIntoClient
+    static var sensome: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1357)
+    }
+
+    /// FORTRONIK storitve d.o.o. (`1358`)
+    @_alwaysEmitIntoClient
+    static var fortronikStoritve: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1358)
+    }
+
+    /// Sinnoz (`1359`)
+    @_alwaysEmitIntoClient
+    static var sinnoz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1359)
+    }
+
+    /// Versa Networks, Inc. (`1360`)
+    @_alwaysEmitIntoClient
+    static var versaNetworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1360)
+    }
+
+    /// Sylero (`1361`)
+    @_alwaysEmitIntoClient
+    static var sylero: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1361)
+    }
+
+    /// Avempace SARL (`1362`)
+    @_alwaysEmitIntoClient
+    static var avempacerl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1362)
+    }
+
+    /// Nintendo Co., Ltd. (`1363`)
+    @_alwaysEmitIntoClient
+    static var nintendo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1363)
+    }
+
+    /// National Instruments (`1364`)
+    @_alwaysEmitIntoClient
+    static var nationalInstruments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1364)
+    }
+
+    /// KROHNE Messtechnik GmbH (`1365`)
+    @_alwaysEmitIntoClient
+    static var krohneMesstechnik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1365)
+    }
+
+    /// Otodynamics Ltd (`1366`)
+    @_alwaysEmitIntoClient
+    static var otodynamics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1366)
+    }
+
+    /// Arwin Technology Limited (`1367`)
+    @_alwaysEmitIntoClient
+    static var arwinTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1367)
+    }
+
+    /// benegear, inc. (`1368`)
+    @_alwaysEmitIntoClient
+    static var benegear: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1368)
+    }
+
+    /// Newcon Optik (`1369`)
+    @_alwaysEmitIntoClient
+    static var newconOptik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1369)
+    }
+
+    /// CANDY HOUSE, Inc. (`1370`)
+    @_alwaysEmitIntoClient
+    static var candyHouse: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1370)
+    }
+
+    /// FRANKLIN TECHNOLOGY INC (`1371`)
+    @_alwaysEmitIntoClient
+    static var franklinTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1371)
+    }
+
+    /// Lely (`1372`)
+    @_alwaysEmitIntoClient
+    static var lely: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1372)
+    }
+
+    /// Valve Corporation (`1373`)
+    @_alwaysEmitIntoClient
+    static var valve: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1373)
+    }
+
+    /// Hekatron Vertriebs GmbH (`1374`)
+    @_alwaysEmitIntoClient
+    static var hekatronVertriebs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1374)
+    }
+
+    /// PROTECH S.A.S. DI GIRARDI ANDREA & C. (`1375`)
+    @_alwaysEmitIntoClient
+    static var protechDiGirardiAndreaC: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1375)
+    }
+
+    /// Sarita CareTech APS (`1376`)
+    @_alwaysEmitIntoClient
+    static var saritaCaretech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1376)
+    }
+
+    /// Finder S.p.A. (`1377`)
+    @_alwaysEmitIntoClient
+    static var finder: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1377)
+    }
+
+    /// Thalmic Labs Inc. (`1378`)
+    @_alwaysEmitIntoClient
+    static var thalmicLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1378)
+    }
+
+    /// Steinel Vertrieb GmbH (`1379`)
+    @_alwaysEmitIntoClient
+    static var steinelVertrieb: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1379)
+    }
+
+    /// Beghelli Spa (`1380`)
+    @_alwaysEmitIntoClient
+    static var beghelliSpa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1380)
+    }
+
+    /// Beijing Smartspace Technologies Inc. (`1381`)
+    @_alwaysEmitIntoClient
+    static var beijingSmartspaceTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1381)
+    }
+
+    /// CORE TRANSPORT TECHNOLOGIES NZ LIMITED (`1382`)
+    @_alwaysEmitIntoClient
+    static var coreTransportTechnologiesNz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1382)
+    }
+
+    /// Xiamen Everesports Goods Co., Ltd (`1383`)
+    @_alwaysEmitIntoClient
+    static var xiamenEveresportsGoods: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1383)
+    }
+
+    /// Bodyport Inc. (`1384`)
+    @_alwaysEmitIntoClient
+    static var bodyport: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1384)
+    }
+
+    /// Audionics System, INC. (`1385`)
+    @_alwaysEmitIntoClient
+    static var audionicsSystem: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1385)
+    }
+
+    /// Flipnavi Co.,Ltd. (`1386`)
+    @_alwaysEmitIntoClient
+    static var flipnavi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1386)
+    }
+
+    /// Rion Co., Ltd. (`1387`)
+    @_alwaysEmitIntoClient
+    static var rion: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1387)
+    }
+
+    /// Long Range Systems, LLC (`1388`)
+    @_alwaysEmitIntoClient
+    static var longRangeSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1388)
+    }
+
+    /// Redmond Industrial Group LLC (`1389`)
+    @_alwaysEmitIntoClient
+    static var redmondIndustrialGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1389)
+    }
+
+    /// VIZPIN INC. (`1390`)
+    @_alwaysEmitIntoClient
+    static var vizpin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1390)
+    }
+
+    /// BikeFinder AS (`1391`)
+    @_alwaysEmitIntoClient
+    static var bikefinder: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1391)
+    }
+
+    /// Consumer Sleep Solutions LLC (`1392`)
+    @_alwaysEmitIntoClient
+    static var consumerSleepSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1392)
+    }
+
+    /// PSIKICK, INC. (`1393`)
+    @_alwaysEmitIntoClient
+    static var psikick: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1393)
+    }
+
+    /// AntTail.com (`1394`)
+    @_alwaysEmitIntoClient
+    static var anttailCom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1394)
+    }
+
+    /// Lighting Science Group Corp. (`1395`)
+    @_alwaysEmitIntoClient
+    static var lightingScienceGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1395)
+    }
+
+    /// AFFORDABLE ELECTRONICS INC (`1396`)
+    @_alwaysEmitIntoClient
+    static var affordableElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1396)
+    }
+
+    /// Integral Memroy Plc (`1397`)
+    @_alwaysEmitIntoClient
+    static var integralMemroyPlc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1397)
+    }
+
+    /// Globalstar, Inc. (`1398`)
+    @_alwaysEmitIntoClient
+    static var globalstar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1398)
+    }
+
+    /// True Wearables, Inc. (`1399`)
+    @_alwaysEmitIntoClient
+    static var trueWearables: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1399)
+    }
+
+    /// Wellington Drive Technologies Ltd (`1400`)
+    @_alwaysEmitIntoClient
+    static var wellingtonDriveTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1400)
+    }
+
+    /// Ensemble Tech Private Limited (`1401`)
+    @_alwaysEmitIntoClient
+    static var ensembleTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1401)
+    }
+
+    /// OMNI Remotes (`1402`)
+    @_alwaysEmitIntoClient
+    static var omniRemotes: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1402)
+    }
+
+    /// Duracell U.S. Operations Inc. (`1403`)
+    @_alwaysEmitIntoClient
+    static var duracellUSOperations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1403)
+    }
+
+    /// Toor Technologies LLC (`1404`)
+    @_alwaysEmitIntoClient
+    static var toorTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1404)
+    }
+
+    /// Instinct Performance (`1405`)
+    @_alwaysEmitIntoClient
+    static var instinctPerformance: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1405)
+    }
+
+    /// Beco, Inc (`1406`)
+    @_alwaysEmitIntoClient
+    static var beco: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1406)
+    }
+
+    /// Scuf Gaming International, LLC (`1407`)
+    @_alwaysEmitIntoClient
+    static var scufGamingInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1407)
+    }
+
+    /// ARANZ Medical Limited (`1408`)
+    @_alwaysEmitIntoClient
+    static var aranzMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1408)
+    }
+
+    /// LYS TECHNOLOGIES LTD (`1409`)
+    @_alwaysEmitIntoClient
+    static var lysTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1409)
+    }
+
+    /// Breakwall Analytics, LLC (`1410`)
+    @_alwaysEmitIntoClient
+    static var breakwallAnalytics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1410)
+    }
+
+    /// Code Blue Communications (`1411`)
+    @_alwaysEmitIntoClient
+    static var codeBlueCommunications: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1411)
+    }
+
+    /// Gira Giersiepen GmbH & Co. KG (`1412`)
+    @_alwaysEmitIntoClient
+    static var giraGiersiepen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1412)
+    }
+
+    /// Hearing Lab Technology (`1413`)
+    @_alwaysEmitIntoClient
+    static var hearingLabTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1413)
+    }
+
+    /// LEGRAND (`1414`)
+    @_alwaysEmitIntoClient
+    static var legrand: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1414)
+    }
+
+    /// Derichs GmbH (`1415`)
+    @_alwaysEmitIntoClient
+    static var derichs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1415)
+    }
+
+    /// ALT-TEKNIK LLC (`1416`)
+    @_alwaysEmitIntoClient
+    static var altTeknik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1416)
+    }
+
+    /// Star Technologies (`1417`)
+    @_alwaysEmitIntoClient
+    static var starTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1417)
+    }
+
+    /// START TODAY CO.,LTD. (`1418`)
+    @_alwaysEmitIntoClient
+    static var startToday: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1418)
+    }
+
+    /// Maxim Integrated Products (`1419`)
+    @_alwaysEmitIntoClient
+    static var maximIntegratedProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1419)
+    }
+
+    /// Fracarro Radioindustrie SRL (`1420`)
+    @_alwaysEmitIntoClient
+    static var fracarroRadioindustrie: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1420)
+    }
+
+    /// Jungheinrich Aktiengesellschaft (`1421`)
+    @_alwaysEmitIntoClient
+    static var jungheinrichAktiengesellschaft: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1421)
+    }
+
+    /// Meta Platforms Technologies, LLC (`1422`)
+    @_alwaysEmitIntoClient
+    static var metaPlatformsTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1422)
+    }
+
+    /// HENDON SEMICONDUCTORS PTY LTD (`1423`)
+    @_alwaysEmitIntoClient
+    static var hendonSemiconductors: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1423)
+    }
+
+    /// Pur3 Ltd (`1424`)
+    @_alwaysEmitIntoClient
+    static var pur3: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1424)
+    }
+
+    /// Viasat Group S.p.A. (`1425`)
+    @_alwaysEmitIntoClient
+    static var viasatGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1425)
+    }
+
+    /// IZITHERM (`1426`)
+    @_alwaysEmitIntoClient
+    static var izitherm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1426)
+    }
+
+    /// Spaulding Clinical Research (`1427`)
+    @_alwaysEmitIntoClient
+    static var spauldingClinicalResearch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1427)
+    }
+
+    /// Kohler Company (`1428`)
+    @_alwaysEmitIntoClient
+    static var kohler: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1428)
+    }
+
+    /// Inor Process AB (`1429`)
+    @_alwaysEmitIntoClient
+    static var inorProcess: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1429)
+    }
+
+    /// My Smart Blinds (`1430`)
+    @_alwaysEmitIntoClient
+    static var mySmartBlinds: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1430)
+    }
+
+    /// RadioPulse Inc (`1431`)
+    @_alwaysEmitIntoClient
+    static var radiopulse: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1431)
+    }
+
+    /// rapitag GmbH (`1432`)
+    @_alwaysEmitIntoClient
+    static var rapitag: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1432)
+    }
+
+    /// Lazlo326, LLC. (`1433`)
+    @_alwaysEmitIntoClient
+    static var lazlo326: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1433)
+    }
+
+    /// Teledyne Lecroy, Inc. (`1434`)
+    @_alwaysEmitIntoClient
+    static var teledyneLecroy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1434)
+    }
+
+    /// Dataflow Systems Limited (`1435`)
+    @_alwaysEmitIntoClient
+    static var dataflowSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1435)
+    }
+
+    /// Macrogiga Electronics (`1436`)
+    @_alwaysEmitIntoClient
+    static var macrogigaElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1436)
+    }
+
+    /// Tandem Diabetes Care (`1437`)
+    @_alwaysEmitIntoClient
+    static var tandemDiabetesCare: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1437)
+    }
+
+    /// Polycom, Inc. (`1438`)
+    @_alwaysEmitIntoClient
+    static var polycom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1438)
+    }
+
+    /// Fisher & Paykel Healthcare (`1439`)
+    @_alwaysEmitIntoClient
+    static var fisherPaykelHealthcare: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1439)
+    }
+
+    /// Dream Devices Technologies Oy (`1440`)
+    @_alwaysEmitIntoClient
+    static var dreamDevicesTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1440)
+    }
+
+    /// Shanghai Xiaoyi Technology Co.,Ltd. (`1441`)
+    @_alwaysEmitIntoClient
+    static var shanghaiXiaoyiTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1441)
+    }
+
+    /// ADHERIUM(NZ) LIMITED (`1442`)
+    @_alwaysEmitIntoClient
+    static var adheriumNz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1442)
+    }
+
+    /// Axiomware Systems Incorporated (`1443`)
+    @_alwaysEmitIntoClient
+    static var axiomwareSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1443)
+    }
+
+    /// O. E. M. Controls, Inc. (`1444`)
+    @_alwaysEmitIntoClient
+    static var oEMControls: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1444)
+    }
+
+    /// Kiiroo BV (`1445`)
+    @_alwaysEmitIntoClient
+    static var kiiroo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1445)
+    }
+
+    /// Telecon Mobile Limited (`1446`)
+    @_alwaysEmitIntoClient
+    static var teleconMobile: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1446)
+    }
+
+    /// Sonos Inc (`1447`)
+    @_alwaysEmitIntoClient
+    static var sonos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1447)
+    }
+
+    /// Tom Allebrandi Consulting (`1448`)
+    @_alwaysEmitIntoClient
+    static var tomAllebrandiConsulting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1448)
+    }
+
+    /// Monidor (`1449`)
+    @_alwaysEmitIntoClient
+    static var monidor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1449)
+    }
+
+    /// Tramex Limited (`1450`)
+    @_alwaysEmitIntoClient
+    static var tramex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1450)
+    }
+
+    /// Nofence AS (`1451`)
+    @_alwaysEmitIntoClient
+    static var nofence: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1451)
+    }
+
+    /// GoerTek Dynaudio Co., Ltd. (`1452`)
+    @_alwaysEmitIntoClient
+    static var goertekDynaudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1452)
+    }
+
+    /// INIA (`1453`)
+    @_alwaysEmitIntoClient
+    static var inia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1453)
+    }
+
+    /// CARMATE MFG.CO.,LTD (`1454`)
+    @_alwaysEmitIntoClient
+    static var carmateMfg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1454)
+    }
+
+    /// OV LOOP, INC. (`1455`)
+    @_alwaysEmitIntoClient
+    static var ovLoop: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1455)
+    }
+
+    /// NewTec GmbH (`1456`)
+    @_alwaysEmitIntoClient
+    static var newtec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1456)
+    }
+
+    /// Medallion Instrumentation Systems (`1457`)
+    @_alwaysEmitIntoClient
+    static var medallionInstrumentationSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1457)
+    }
+
+    /// CAREL INDUSTRIES S.P.A. (`1458`)
+    @_alwaysEmitIntoClient
+    static var carelIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1458)
+    }
+
+    /// Parabit Systems, Inc. (`1459`)
+    @_alwaysEmitIntoClient
+    static var parabitSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1459)
+    }
+
+    /// White Horse Scientific ltd (`1460`)
+    @_alwaysEmitIntoClient
+    static var whiteHorseScientific: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1460)
+    }
+
+    /// verisilicon (`1461`)
+    @_alwaysEmitIntoClient
+    static var verisilicon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1461)
+    }
+
+    /// Elecs Industry Co.,Ltd. (`1462`)
+    @_alwaysEmitIntoClient
+    static var elecsIndustry: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1462)
+    }
+
+    /// Beijing Pinecone Electronics Co.,Ltd. (`1463`)
+    @_alwaysEmitIntoClient
+    static var beijingPineconeElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1463)
+    }
+
+    /// Ambystoma Labs Inc. (`1464`)
+    @_alwaysEmitIntoClient
+    static var ambystomaLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1464)
+    }
+
+    /// Suzhou Pairlink Network Technology (`1465`)
+    @_alwaysEmitIntoClient
+    static var suzhouPairlinkNetworkTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1465)
+    }
+
+    /// igloohome (`1466`)
+    @_alwaysEmitIntoClient
+    static var igloohome: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1466)
+    }
+
+    /// Oxford Metrics plc (`1467`)
+    @_alwaysEmitIntoClient
+    static var oxfordMetricsPlc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1467)
+    }
+
+    /// Leviton Mfg. Co., Inc. (`1468`)
+    @_alwaysEmitIntoClient
+    static var levitonMfg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1468)
+    }
+
+    /// ULC Robotics Inc. (`1469`)
+    @_alwaysEmitIntoClient
+    static var ulcRobotics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1469)
+    }
+
+    /// RFID Global by Softwork SrL (`1470`)
+    @_alwaysEmitIntoClient
+    static var rfidGlobalBySoftwork: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1470)
+    }
+
+    /// Real-World-Systems Corporation (`1471`)
+    @_alwaysEmitIntoClient
+    static var realWorldSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1471)
+    }
+
+    /// Nalu Medical, Inc. (`1472`)
+    @_alwaysEmitIntoClient
+    static var naluMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1472)
+    }
+
+    /// P.I.Engineering (`1473`)
+    @_alwaysEmitIntoClient
+    static var pIEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1473)
+    }
+
+    /// Grote Industries (`1474`)
+    @_alwaysEmitIntoClient
+    static var groteIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1474)
+    }
+
+    /// Runtime, Inc. (`1475`)
+    @_alwaysEmitIntoClient
+    static var runtime: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1475)
+    }
+
+    /// Codecoup sp. z o.o. sp. k. (`1476`)
+    @_alwaysEmitIntoClient
+    static var codecoup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1476)
+    }
+
+    /// SELVE GmbH & Co. KG (`1477`)
+    @_alwaysEmitIntoClient
+    static var selve: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1477)
+    }
+
+    /// Smart Animal Training Systems, LLC (`1478`)
+    @_alwaysEmitIntoClient
+    static var smartAnimalTrainingSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1478)
+    }
+
+    /// Lippert Components, INC (`1479`)
+    @_alwaysEmitIntoClient
+    static var lippertComponents: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1479)
+    }
+
+    /// SOMFY SAS (`1480`)
+    @_alwaysEmitIntoClient
+    static var somfys: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1480)
+    }
+
+    /// TBS Electronics B.V. (`1481`)
+    @_alwaysEmitIntoClient
+    static var tbsElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1481)
+    }
+
+    /// MHL Custom Inc (`1482`)
+    @_alwaysEmitIntoClient
+    static var mhlCustom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1482)
+    }
+
+    /// LucentWear LLC (`1483`)
+    @_alwaysEmitIntoClient
+    static var lucentwear: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1483)
+    }
+
+    /// WATTS ELECTRONICS (`1484`)
+    @_alwaysEmitIntoClient
+    static var wattsElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1484)
+    }
+
+    /// RJ Brands LLC (`1485`)
+    @_alwaysEmitIntoClient
+    static var rjBrands: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1485)
+    }
+
+    /// V-ZUG Ltd (`1486`)
+    @_alwaysEmitIntoClient
+    static var vZug: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1486)
+    }
+
+    /// Biowatch SA (`1487`)
+    @_alwaysEmitIntoClient
+    static var biowatch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1487)
+    }
+
+    /// Anova Applied Electronics (`1488`)
+    @_alwaysEmitIntoClient
+    static var anovaAppliedElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1488)
+    }
+
+    /// Lindab AB (`1489`)
+    @_alwaysEmitIntoClient
+    static var lindab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1489)
+    }
+
+    /// frogblue TECHNOLOGY GmbH (`1490`)
+    @_alwaysEmitIntoClient
+    static var frogblueTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1490)
+    }
+
+    /// Acurable Limited (`1491`)
+    @_alwaysEmitIntoClient
+    static var acurable: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1491)
+    }
+
+    /// LAMPLIGHT Co., Ltd. (`1492`)
+    @_alwaysEmitIntoClient
+    static var lamplight: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1492)
+    }
+
+    /// TEGAM, Inc. (`1493`)
+    @_alwaysEmitIntoClient
+    static var tegam: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1493)
+    }
+
+    /// Zhuhai Jieli technology Co.,Ltd (`1494`)
+    @_alwaysEmitIntoClient
+    static var zhuhaiJieliTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1494)
+    }
+
+    /// modum.io AG (`1495`)
+    @_alwaysEmitIntoClient
+    static var modumIo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1495)
+    }
+
+    /// Farm Jenny LLC (`1496`)
+    @_alwaysEmitIntoClient
+    static var farmJenny: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1496)
+    }
+
+    /// Toyo Electronics Corporation (`1497`)
+    @_alwaysEmitIntoClient
+    static var toyoElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1497)
+    }
+
+    /// Applied Neural Research Corp (`1498`)
+    @_alwaysEmitIntoClient
+    static var appliedNeuralResearch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1498)
+    }
+
+    /// Avid Identification Systems, Inc. (`1499`)
+    @_alwaysEmitIntoClient
+    static var avidIdentificationSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1499)
+    }
+
+    /// Petronics Inc. (`1500`)
+    @_alwaysEmitIntoClient
+    static var petronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1500)
+    }
+
+    /// essentim GmbH (`1501`)
+    @_alwaysEmitIntoClient
+    static var essentim: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1501)
+    }
+
+    /// QT Medical INC. (`1502`)
+    @_alwaysEmitIntoClient
+    static var qtMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1502)
+    }
+
+    /// VIRTUALCLINIC.DIRECT LIMITED (`1503`)
+    @_alwaysEmitIntoClient
+    static var virtualclinicDirect: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1503)
+    }
+
+    /// Viper Design LLC (`1504`)
+    @_alwaysEmitIntoClient
+    static var viperDesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1504)
+    }
+
+    /// Human, Incorporated (`1505`)
+    @_alwaysEmitIntoClient
+    static var human: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1505)
+    }
+
+    /// stAPPtronics GmbH (`1506`)
+    @_alwaysEmitIntoClient
+    static var stapptronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1506)
+    }
+
+    /// Elemental Machines, Inc. (`1507`)
+    @_alwaysEmitIntoClient
+    static var elementalMachines: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1507)
+    }
+
+    /// Taiyo Yuden Co., Ltd (`1508`)
+    @_alwaysEmitIntoClient
+    static var taiyoYuden: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1508)
+    }
+
+    /// INEO ENERGY& SYSTEMS (`1509`)
+    @_alwaysEmitIntoClient
+    static var ineoEnergySystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1509)
+    }
+
+    /// Motion Instruments Inc. (`1510`)
+    @_alwaysEmitIntoClient
+    static var motionInstruments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1510)
+    }
+
+    /// PressurePro (`1511`)
+    @_alwaysEmitIntoClient
+    static var pressurepro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1511)
+    }
+
+    /// COWBOY (`1512`)
+    @_alwaysEmitIntoClient
+    static var cowboy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1512)
+    }
+
+    /// iconmobile GmbH (`1513`)
+    @_alwaysEmitIntoClient
+    static var iconmobile: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1513)
+    }
+
+    /// ACS-Control-System GmbH (`1514`)
+    @_alwaysEmitIntoClient
+    static var acsControlSystem: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1514)
+    }
+
+    /// Bayerische Motoren Werke AG (`1515`)
+    @_alwaysEmitIntoClient
+    static var bayerischeMotorenWerke: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1515)
+    }
+
+    /// Gycom Svenska AB (`1516`)
+    @_alwaysEmitIntoClient
+    static var gycomSvenska: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1516)
+    }
+
+    /// Fuji Xerox Co., Ltd (`1517`)
+    @_alwaysEmitIntoClient
+    static var fujiXerox: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1517)
+    }
+
+    /// Wristcam Inc. (`1518`)
+    @_alwaysEmitIntoClient
+    static var wristcam: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1518)
+    }
+
+    /// SIKOM AS (`1519`)
+    @_alwaysEmitIntoClient
+    static var sikom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1519)
+    }
+
+    /// beken (`1520`)
+    @_alwaysEmitIntoClient
+    static var beken: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1520)
+    }
+
+    /// The Linux Foundation (`1521`)
+    @_alwaysEmitIntoClient
+    static var linuxFoundation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1521)
+    }
+
+    /// Try and E CO.,LTD. (`1522`)
+    @_alwaysEmitIntoClient
+    static var tryAndE: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1522)
+    }
+
+    /// SeeScan (`1523`)
+    @_alwaysEmitIntoClient
+    static var seescan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1523)
+    }
+
+    /// Clearity, LLC (`1524`)
+    @_alwaysEmitIntoClient
+    static var clearity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1524)
+    }
+
+    /// GS TAG (`1525`)
+    @_alwaysEmitIntoClient
+    static var gsTag: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1525)
+    }
+
+    /// DPTechnics (`1526`)
+    @_alwaysEmitIntoClient
+    static var dptechnics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1526)
+    }
+
+    /// TRACMO, INC. (`1527`)
+    @_alwaysEmitIntoClient
+    static var tracmo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1527)
+    }
+
+    /// Anki Inc. (`1528`)
+    @_alwaysEmitIntoClient
+    static var anki: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1528)
+    }
+
+    /// Hagleitner Hygiene International GmbH (`1529`)
+    @_alwaysEmitIntoClient
+    static var hagleitnerHygieneInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1529)
+    }
+
+    /// Konami Sports Life Co., Ltd. (`1530`)
+    @_alwaysEmitIntoClient
+    static var konamiSportsLife: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1530)
+    }
+
+    /// Arblet Inc. (`1531`)
+    @_alwaysEmitIntoClient
+    static var arblet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1531)
+    }
+
+    /// Masbando GmbH (`1532`)
+    @_alwaysEmitIntoClient
+    static var masbando: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1532)
+    }
+
+    /// Innoseis (`1533`)
+    @_alwaysEmitIntoClient
+    static var innoseis: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1533)
+    }
+
+    /// Niko nv (`1534`)
+    @_alwaysEmitIntoClient
+    static var nikoNv: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1534)
+    }
+
+    /// Wellnomics Ltd (`1535`)
+    @_alwaysEmitIntoClient
+    static var wellnomics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1535)
+    }
+
+    /// iRobot Corporation (`1536`)
+    @_alwaysEmitIntoClient
+    static var irobot: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1536)
+    }
+
+    /// Schrader Electronics (`1537`)
+    @_alwaysEmitIntoClient
+    static var schraderElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1537)
+    }
+
+    /// Geberit International AG (`1538`)
+    @_alwaysEmitIntoClient
+    static var geberitInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1538)
+    }
+
+    /// Fourth Evolution Inc (`1539`)
+    @_alwaysEmitIntoClient
+    static var fourthEvolution: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1539)
+    }
+
+    /// Cell2Jack LLC (`1540`)
+    @_alwaysEmitIntoClient
+    static var cell2Jack: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1540)
+    }
+
+    /// FMW electronic Futterer u. Maier-Wolf OHG (`1541`)
+    @_alwaysEmitIntoClient
+    static var fmwElectronicFuttererUMaierWolfOhg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1541)
+    }
+
+    /// John Deere (`1542`)
+    @_alwaysEmitIntoClient
+    static var johnDeere: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1542)
+    }
+
+    /// Rookery Technology Ltd (`1543`)
+    @_alwaysEmitIntoClient
+    static var rookeryTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1543)
+    }
+
+    /// KeySafe-Cloud (`1544`)
+    @_alwaysEmitIntoClient
+    static var keysafeCloud: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1544)
+    }
+
+    /// BUCHI Labortechnik AG (`1545`)
+    @_alwaysEmitIntoClient
+    static var buchiLabortechnik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1545)
+    }
+
+    /// IQAir AG (`1546`)
+    @_alwaysEmitIntoClient
+    static var iqair: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1546)
+    }
+
+    /// Triax Technologies Inc (`1547`)
+    @_alwaysEmitIntoClient
+    static var triaxTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1547)
+    }
+
+    /// Vuzix Corporation (`1548`)
+    @_alwaysEmitIntoClient
+    static var vuzix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1548)
+    }
+
+    /// TDK Corporation (`1549`)
+    @_alwaysEmitIntoClient
+    static var tdk: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1549)
+    }
+
+    /// Blueair AB (`1550`)
+    @_alwaysEmitIntoClient
+    static var blueair: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1550)
+    }
+
+    /// Signify Netherlands B.V. (`1551`)
+    @_alwaysEmitIntoClient
+    static var signifyNetherlands: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1551)
+    }
+
+    /// ADH GUARDIAN USA LLC (`1552`)
+    @_alwaysEmitIntoClient
+    static var adhGuardian: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1552)
+    }
+
+    /// Beurer GmbH (`1553`)
+    @_alwaysEmitIntoClient
+    static var beurer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1553)
+    }
+
+    /// Playfinity AS (`1554`)
+    @_alwaysEmitIntoClient
+    static var playfinity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1554)
+    }
+
+    /// Hans Dinslage GmbH (`1555`)
+    @_alwaysEmitIntoClient
+    static var hansDinslage: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1555)
+    }
+
+    /// OnAsset Intelligence, Inc. (`1556`)
+    @_alwaysEmitIntoClient
+    static var onassetIntelligence: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1556)
+    }
+
+    /// INTER ACTION Corporation (`1557`)
+    @_alwaysEmitIntoClient
+    static var interAction: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1557)
+    }
+
+    /// OS42 UG (haftungsbeschraenkt) (`1558`)
+    @_alwaysEmitIntoClient
+    static var os42UgHaftungsbeschraenkt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1558)
+    }
+
+    /// WIZCONNECTED COMPANY LIMITED (`1559`)
+    @_alwaysEmitIntoClient
+    static var wizconnected: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1559)
+    }
+
+    /// Audio-Technica Corporation (`1560`)
+    @_alwaysEmitIntoClient
+    static var audioTechnica: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1560)
+    }
+
+    /// Six Guys Labs, s.r.o. (`1561`)
+    @_alwaysEmitIntoClient
+    static var sixGuysLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1561)
+    }
+
+    /// R.W. Beckett Corporation (`1562`)
+    @_alwaysEmitIntoClient
+    static var rWBeckett: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1562)
+    }
+
+    /// silex technology, inc. (`1563`)
+    @_alwaysEmitIntoClient
+    static var silexTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1563)
+    }
+
+    /// Univations Limited (`1564`)
+    @_alwaysEmitIntoClient
+    static var univations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1564)
+    }
+
+    /// SENS Innovation ApS (`1565`)
+    @_alwaysEmitIntoClient
+    static var sensInnovation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1565)
+    }
+
+    /// Diamond Kinetics, Inc. (`1566`)
+    @_alwaysEmitIntoClient
+    static var diamondKinetics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1566)
+    }
+
+    /// Phrame Inc. (`1567`)
+    @_alwaysEmitIntoClient
+    static var phrame: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1567)
+    }
+
+    /// Forciot Oy (`1568`)
+    @_alwaysEmitIntoClient
+    static var forciot: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1568)
+    }
+
+    /// Noordung d.o.o. (`1569`)
+    @_alwaysEmitIntoClient
+    static var noordung: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1569)
+    }
+
+    /// Beam Labs, LLC (`1570`)
+    @_alwaysEmitIntoClient
+    static var beamLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1570)
+    }
+
+    /// Philadelphia Scientific (U.K.) Limited (`1571`)
+    @_alwaysEmitIntoClient
+    static var philadelphiaScientificUK: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1571)
+    }
+
+    /// Biovotion AG (`1572`)
+    @_alwaysEmitIntoClient
+    static var biovotion: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1572)
+    }
+
+    /// Square Panda, Inc. (`1573`)
+    @_alwaysEmitIntoClient
+    static var squarePanda: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1573)
+    }
+
+    /// Amplifico (`1574`)
+    @_alwaysEmitIntoClient
+    static var amplifico: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1574)
+    }
+
+    /// WEG S.A. (`1575`)
+    @_alwaysEmitIntoClient
+    static var weg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1575)
+    }
+
+    /// Ensto Oy (`1576`)
+    @_alwaysEmitIntoClient
+    static var ensto: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1576)
+    }
+
+    /// PHONEPE PVT LTD (`1577`)
+    @_alwaysEmitIntoClient
+    static var phonepePvt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1577)
+    }
+
+    /// Lunatico Astronomia SL (`1578`)
+    @_alwaysEmitIntoClient
+    static var lunaticoAstronomia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1578)
+    }
+
+    /// MinebeaMitsumi Inc. (`1579`)
+    @_alwaysEmitIntoClient
+    static var minebeamitsumi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1579)
+    }
+
+    /// ASPion GmbH (`1580`)
+    @_alwaysEmitIntoClient
+    static var aspion: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1580)
+    }
+
+    /// Vossloh-Schwabe Deutschland GmbH (`1581`)
+    @_alwaysEmitIntoClient
+    static var vosslohSchwabeDeutschland: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1581)
+    }
+
+    /// Procept (`1582`)
+    @_alwaysEmitIntoClient
+    static var procept: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1582)
+    }
+
+    /// ONKYO Corporation (`1583`)
+    @_alwaysEmitIntoClient
+    static var onkyo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1583)
+    }
+
+    /// Asthrea D.O.O. (`1584`)
+    @_alwaysEmitIntoClient
+    static var asthrea: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1584)
+    }
+
+    /// Fortiori Design LLC (`1585`)
+    @_alwaysEmitIntoClient
+    static var fortioriDesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1585)
+    }
+
+    /// Hugo Muller GmbH & Co KG (`1586`)
+    @_alwaysEmitIntoClient
+    static var hugoMuller: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1586)
+    }
+
+    /// Wangi Lai PLT (`1587`)
+    @_alwaysEmitIntoClient
+    static var wangiLaiPlt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1587)
+    }
+
+    /// Fanstel Corp (`1588`)
+    @_alwaysEmitIntoClient
+    static var fanstel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1588)
+    }
+
+    /// Crookwood (`1589`)
+    @_alwaysEmitIntoClient
+    static var crookwood: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1589)
+    }
+
+    /// ELECTRONICA INTEGRAL DE SONIDO S.A. (`1590`)
+    @_alwaysEmitIntoClient
+    static var electronicaIntegralDeSonido: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1590)
+    }
+
+    /// GiP Innovation Tools GmbH (`1591`)
+    @_alwaysEmitIntoClient
+    static var gipInnovationTools: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1591)
+    }
+
+    /// LX SOLUTIONS PTY LIMITED (`1592`)
+    @_alwaysEmitIntoClient
+    static var lxSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1592)
+    }
+
+    /// Shenzhen Minew Technologies Co., Ltd. (`1593`)
+    @_alwaysEmitIntoClient
+    static var shenzhenMinewTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1593)
+    }
+
+    /// Prolojik Limited (`1594`)
+    @_alwaysEmitIntoClient
+    static var prolojik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1594)
+    }
+
+    /// Kromek Group Plc (`1595`)
+    @_alwaysEmitIntoClient
+    static var kromekGroupPlc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1595)
+    }
+
+    /// Contec Medical Systems Co., Ltd. (`1596`)
+    @_alwaysEmitIntoClient
+    static var contecMedicalSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1596)
+    }
+
+    /// Xradio Technology Co.,Ltd. (`1597`)
+    @_alwaysEmitIntoClient
+    static var xradioTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1597)
+    }
+
+    /// The Indoor Lab, LLC (`1598`)
+    @_alwaysEmitIntoClient
+    static var indoorLab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1598)
+    }
+
+    /// LDL TECHNOLOGY (`1599`)
+    @_alwaysEmitIntoClient
+    static var ldlTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1599)
+    }
+
+    /// Dish Network LLC (`1600`)
+    @_alwaysEmitIntoClient
+    static var dishNetwork: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1600)
+    }
+
+    /// Revenue Collection Systems FRANCE SAS (`1601`)
+    @_alwaysEmitIntoClient
+    static var revenueCollectionSystemsFrances: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1601)
+    }
+
+    /// Bluetrum Technology Co.,Ltd (`1602`)
+    @_alwaysEmitIntoClient
+    static var bluetrumTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1602)
+    }
+
+    /// makita corporation (`1603`)
+    @_alwaysEmitIntoClient
+    static var makita: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1603)
+    }
+
+    /// Apogee Instruments (`1604`)
+    @_alwaysEmitIntoClient
+    static var apogeeInstruments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1604)
+    }
+
+    /// BM3 (`1605`)
+    @_alwaysEmitIntoClient
+    static var bm3: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1605)
+    }
+
+    /// SGV Group Holding GmbH & Co. KG (`1606`)
+    @_alwaysEmitIntoClient
+    static var sgvGroupHolding: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1606)
+    }
+
+    /// MED-EL (`1607`)
+    @_alwaysEmitIntoClient
+    static var medEl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1607)
+    }
+
+    /// Ultune Technologies (`1608`)
+    @_alwaysEmitIntoClient
+    static var ultuneTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1608)
+    }
+
+    /// Ryeex Technology Co.,Ltd. (`1609`)
+    @_alwaysEmitIntoClient
+    static var ryeexTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1609)
+    }
+
+    /// Open Research Institute, Inc. (`1610`)
+    @_alwaysEmitIntoClient
+    static var openResearchInstitute: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1610)
+    }
+
+    /// Scale-Tec, Ltd (`1611`)
+    @_alwaysEmitIntoClient
+    static var scaleTec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1611)
+    }
+
+    /// Zumtobel Group AG (`1612`)
+    @_alwaysEmitIntoClient
+    static var zumtobelGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1612)
+    }
+
+    /// iLOQ Oy (`1613`)
+    @_alwaysEmitIntoClient
+    static var iloq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1613)
+    }
+
+    /// KRUXWorks Technologies Private Limited (`1614`)
+    @_alwaysEmitIntoClient
+    static var kruxworksTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1614)
+    }
+
+    /// Digital Matter Pty Ltd (`1615`)
+    @_alwaysEmitIntoClient
+    static var digitalMatter: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1615)
+    }
+
+    /// Coravin, Inc. (`1616`)
+    @_alwaysEmitIntoClient
+    static var coravin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1616)
+    }
+
+    /// Stasis Labs, Inc. (`1617`)
+    @_alwaysEmitIntoClient
+    static var stasisLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1617)
+    }
+
+    /// ITZ Innovations- und Technologiezentrum GmbH (`1618`)
+    @_alwaysEmitIntoClient
+    static var itzInnovationsUndTechnologiezentrum: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1618)
+    }
+
+    /// Meggitt SA (`1619`)
+    @_alwaysEmitIntoClient
+    static var meggitt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1619)
+    }
+
+    /// Ledlenser GmbH & Co. KG (`1620`)
+    @_alwaysEmitIntoClient
+    static var ledlenser: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1620)
+    }
+
+    /// Renishaw PLC (`1621`)
+    @_alwaysEmitIntoClient
+    static var renishawPlc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1621)
+    }
+
+    /// ZhuHai AdvanPro Technology Company Limited (`1622`)
+    @_alwaysEmitIntoClient
+    static var zhuhaiAdvanproTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1622)
+    }
+
+    /// Meshtronix Limited (`1623`)
+    @_alwaysEmitIntoClient
+    static var meshtronix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1623)
+    }
+
+    /// Payex Norge AS (`1624`)
+    @_alwaysEmitIntoClient
+    static var payexNorge: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1624)
+    }
+
+    /// UnSeen Technologies Oy (`1625`)
+    @_alwaysEmitIntoClient
+    static var unseenTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1625)
+    }
+
+    /// Zound Industries International AB (`1626`)
+    @_alwaysEmitIntoClient
+    static var zoundIndustriesInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1626)
+    }
+
+    /// Sesam Solutions BV (`1627`)
+    @_alwaysEmitIntoClient
+    static var sesamSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1627)
+    }
+
+    /// PixArt Imaging Inc. (`1628`)
+    @_alwaysEmitIntoClient
+    static var pixartImaging: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1628)
+    }
+
+    /// Panduit Corp. (`1629`)
+    @_alwaysEmitIntoClient
+    static var panduit: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1629)
+    }
+
+    /// Alo AB (`1630`)
+    @_alwaysEmitIntoClient
+    static var alo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1630)
+    }
+
+    /// Ricoh Company Ltd (`1631`)
+    @_alwaysEmitIntoClient
+    static var ricoh: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1631)
+    }
+
+    /// RTC Industries, Inc. (`1632`)
+    @_alwaysEmitIntoClient
+    static var rtcIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1632)
+    }
+
+    /// Mode Lighting Limited (`1633`)
+    @_alwaysEmitIntoClient
+    static var modeLighting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1633)
+    }
+
+    /// Particle Industries, Inc. (`1634`)
+    @_alwaysEmitIntoClient
+    static var particleIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1634)
+    }
+
+    /// Advanced Telemetry Systems, Inc. (`1635`)
+    @_alwaysEmitIntoClient
+    static var advancedTelemetrySystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1635)
+    }
+
+    /// RHA TECHNOLOGIES LTD (`1636`)
+    @_alwaysEmitIntoClient
+    static var rhaTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1636)
+    }
+
+    /// Pure International Limited (`1637`)
+    @_alwaysEmitIntoClient
+    static var pureInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1637)
+    }
+
+    /// WTO Werkzeug-Einrichtungen GmbH (`1638`)
+    @_alwaysEmitIntoClient
+    static var wtoWerkzeugEinrichtungen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1638)
+    }
+
+    /// Spark Technology Labs Inc. (`1639`)
+    @_alwaysEmitIntoClient
+    static var sparkTechnologyLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1639)
+    }
+
+    /// Bleb Technology srl (`1640`)
+    @_alwaysEmitIntoClient
+    static var blebTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1640)
+    }
+
+    /// Livanova USA, Inc. (`1641`)
+    @_alwaysEmitIntoClient
+    static var livanova: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1641)
+    }
+
+    /// Brady Worldwide Inc. (`1642`)
+    @_alwaysEmitIntoClient
+    static var bradyWorldwide: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1642)
+    }
+
+    /// DewertOkin GmbH (`1643`)
+    @_alwaysEmitIntoClient
+    static var dewertokin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1643)
+    }
+
+    /// Ztove ApS (`1644`)
+    @_alwaysEmitIntoClient
+    static var ztove: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1644)
+    }
+
+    /// Venso EcoSolutions AB (`1645`)
+    @_alwaysEmitIntoClient
+    static var vensoEcosolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1645)
+    }
+
+    /// Eurotronik Kranj d.o.o. (`1646`)
+    @_alwaysEmitIntoClient
+    static var eurotronikKranj: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1646)
+    }
+
+    /// Hug Technology Ltd (`1647`)
+    @_alwaysEmitIntoClient
+    static var hugTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1647)
+    }
+
+    /// Gema Switzerland GmbH (`1648`)
+    @_alwaysEmitIntoClient
+    static var gemaSwitzerland: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1648)
+    }
+
+    /// Buzz Products Ltd. (`1649`)
+    @_alwaysEmitIntoClient
+    static var buzzProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1649)
+    }
+
+    /// Kopi (`1650`)
+    @_alwaysEmitIntoClient
+    static var kopi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1650)
+    }
+
+    /// Innova Ideas Limited (`1651`)
+    @_alwaysEmitIntoClient
+    static var innovaIdeas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1651)
+    }
+
+    /// BeSpoon (`1652`)
+    @_alwaysEmitIntoClient
+    static var bespoon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1652)
+    }
+
+    /// Deco Enterprises, Inc. (`1653`)
+    @_alwaysEmitIntoClient
+    static var decoEnterprises: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1653)
+    }
+
+    /// Expai Solutions Private Limited (`1654`)
+    @_alwaysEmitIntoClient
+    static var expaiSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1654)
+    }
+
+    /// Innovation First, Inc. (`1655`)
+    @_alwaysEmitIntoClient
+    static var innovationFirst: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1655)
+    }
+
+    /// SABIK Offshore GmbH (`1656`)
+    @_alwaysEmitIntoClient
+    static var sabikOffshore: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1656)
+    }
+
+    /// 4iiii Innovations Inc. (`1657`)
+    @_alwaysEmitIntoClient
+    static var company4IiiiInnovations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1657)
+    }
+
+    /// The Energy Conservatory, Inc. (`1658`)
+    @_alwaysEmitIntoClient
+    static var energyConservatory: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1658)
+    }
+
+    /// I.FARM, INC. (`1659`)
+    @_alwaysEmitIntoClient
+    static var iFarm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1659)
+    }
+
+    /// Tile, Inc. (`1660`)
+    @_alwaysEmitIntoClient
+    static var tile: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1660)
+    }
+
+    /// Form Athletica Inc. (`1661`)
+    @_alwaysEmitIntoClient
+    static var formAthletica: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1661)
+    }
+
+    /// MbientLab Inc (`1662`)
+    @_alwaysEmitIntoClient
+    static var mbientlab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1662)
+    }
+
+    /// NETGRID S.N.C. DI BISSOLI MATTEO, CAMPOREALE SIMONE, TOGNETTI FEDERICO (`1663`)
+    @_alwaysEmitIntoClient
+    static var netgridSNCDiBissoliMatteoCamporealeSimoneTognettiFederico: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1663)
+    }
+
+    /// Mannkind Corporation (`1664`)
+    @_alwaysEmitIntoClient
+    static var mannkind: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1664)
+    }
+
+    /// Trade FIDES a.s. (`1665`)
+    @_alwaysEmitIntoClient
+    static var tradeFides: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1665)
+    }
+
+    /// Photron Limited (`1666`)
+    @_alwaysEmitIntoClient
+    static var photron: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1666)
+    }
+
+    /// Eltako GmbH (`1667`)
+    @_alwaysEmitIntoClient
+    static var eltako: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1667)
+    }
+
+    /// Dermalapps, LLC (`1668`)
+    @_alwaysEmitIntoClient
+    static var dermalapps: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1668)
+    }
+
+    /// Greenwald Industries (`1669`)
+    @_alwaysEmitIntoClient
+    static var greenwaldIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1669)
+    }
+
+    /// inQs Co., Ltd. (`1670`)
+    @_alwaysEmitIntoClient
+    static var inqs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1670)
+    }
+
+    /// Cherry GmbH (`1671`)
+    @_alwaysEmitIntoClient
+    static var cherry: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1671)
+    }
+
+    /// Amsted Digital Solutions Inc. (`1672`)
+    @_alwaysEmitIntoClient
+    static var amstedDigitalSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1672)
+    }
+
+    /// Tacx b.v. (`1673`)
+    @_alwaysEmitIntoClient
+    static var tacx: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1673)
+    }
+
+    /// Raytac Corporation (`1674`)
+    @_alwaysEmitIntoClient
+    static var raytac: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1674)
+    }
+
+    /// Jiangsu Teranovo Tech Co., Ltd. (`1675`)
+    @_alwaysEmitIntoClient
+    static var jiangsuTeranovoTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1675)
+    }
+
+    /// Changzhou Sound Dragon Electronics and Acoustics Co., Ltd (`1676`)
+    @_alwaysEmitIntoClient
+    static var changzhouSoundDragonElectronicsAndAcoustics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1676)
+    }
+
+    /// JetBeep Inc. (`1677`)
+    @_alwaysEmitIntoClient
+    static var jetbeep: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1677)
+    }
+
+    /// Razer Inc. (`1678`)
+    @_alwaysEmitIntoClient
+    static var razer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1678)
+    }
+
+    /// JRM Group Limited (`1679`)
+    @_alwaysEmitIntoClient
+    static var jrmGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1679)
+    }
+
+    /// Eccrine Systems, Inc. (`1680`)
+    @_alwaysEmitIntoClient
+    static var eccrineSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1680)
+    }
+
+    /// Curie Point AB (`1681`)
+    @_alwaysEmitIntoClient
+    static var curiePoint: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1681)
+    }
+
+    /// Georg Fischer AG (`1682`)
+    @_alwaysEmitIntoClient
+    static var georgFischer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1682)
+    }
+
+    /// Hach - Danaher (`1683`)
+    @_alwaysEmitIntoClient
+    static var hachDanaher: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1683)
+    }
+
+    /// T&A Laboratories LLC (`1684`)
+    @_alwaysEmitIntoClient
+    static var tALaboratories: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1684)
+    }
+
+    /// Koki Holdings Co., Ltd. (`1685`)
+    @_alwaysEmitIntoClient
+    static var kokiHoldings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1685)
+    }
+
+    /// Gunakar Private Limited (`1686`)
+    @_alwaysEmitIntoClient
+    static var gunakar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1686)
+    }
+
+    /// Stemco Products Inc (`1687`)
+    @_alwaysEmitIntoClient
+    static var stemcoProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1687)
+    }
+
+    /// Wood IT Security, LLC (`1688`)
+    @_alwaysEmitIntoClient
+    static var woodItSecurity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1688)
+    }
+
+    /// RandomLab SAS (`1689`)
+    @_alwaysEmitIntoClient
+    static var randomlabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1689)
+    }
+
+    /// Adero, Inc. (`1690`)
+    @_alwaysEmitIntoClient
+    static var adero: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1690)
+    }
+
+    /// Dragonchip Limited (`1691`)
+    @_alwaysEmitIntoClient
+    static var dragonchip: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1691)
+    }
+
+    /// Noomi AB (`1692`)
+    @_alwaysEmitIntoClient
+    static var noomi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1692)
+    }
+
+    /// Vakaros LLC (`1693`)
+    @_alwaysEmitIntoClient
+    static var vakaros: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1693)
+    }
+
+    /// Delta Electronics, Inc. (`1694`)
+    @_alwaysEmitIntoClient
+    static var deltaElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1694)
+    }
+
+    /// FlowMotion Technologies AS (`1695`)
+    @_alwaysEmitIntoClient
+    static var flowmotionTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1695)
+    }
+
+    /// OBIQ Location Technology Inc. (`1696`)
+    @_alwaysEmitIntoClient
+    static var obiqLocationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1696)
+    }
+
+    /// Cardo Systems, Ltd (`1697`)
+    @_alwaysEmitIntoClient
+    static var cardoSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1697)
+    }
+
+    /// Globalworx GmbH (`1698`)
+    @_alwaysEmitIntoClient
+    static var globalworx: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1698)
+    }
+
+    /// Nymbus, LLC (`1699`)
+    @_alwaysEmitIntoClient
+    static var nymbus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1699)
+    }
+
+    /// LIMNO Co. Ltd. (`1700`)
+    @_alwaysEmitIntoClient
+    static var limno: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1700)
+    }
+
+    /// TEKZITEL PTY LTD (`1701`)
+    @_alwaysEmitIntoClient
+    static var tekzitel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1701)
+    }
+
+    /// Roambee Corporation (`1702`)
+    @_alwaysEmitIntoClient
+    static var roambee: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1702)
+    }
+
+    /// Chipsea Technologies (ShenZhen) Corp. (`1703`)
+    @_alwaysEmitIntoClient
+    static var chipseaTechnologiesShenzhen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1703)
+    }
+
+    /// GD Midea Air-Conditioning Equipment Co., Ltd. (`1704`)
+    @_alwaysEmitIntoClient
+    static var gdMideaAirConditioningEquipment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1704)
+    }
+
+    /// Soundmax Electronics Limited (`1705`)
+    @_alwaysEmitIntoClient
+    static var soundmaxElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1705)
+    }
+
+    /// Produal Oy (`1706`)
+    @_alwaysEmitIntoClient
+    static var produal: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1706)
+    }
+
+    /// HMS Industrial Networks AB (`1707`)
+    @_alwaysEmitIntoClient
+    static var hmsIndustrialNetworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1707)
+    }
+
+    /// Ingchips Technology Co., Ltd. (`1708`)
+    @_alwaysEmitIntoClient
+    static var ingchipsTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1708)
+    }
+
+    /// InnovaSea Systems Inc. (`1709`)
+    @_alwaysEmitIntoClient
+    static var innovaseaSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1709)
+    }
+
+    /// SenseQ Inc. (`1710`)
+    @_alwaysEmitIntoClient
+    static var senseq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1710)
+    }
+
+    /// Shoof Technologies (`1711`)
+    @_alwaysEmitIntoClient
+    static var shoofTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1711)
+    }
+
+    /// BRK Brands, Inc. (`1712`)
+    @_alwaysEmitIntoClient
+    static var brkBrands: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1712)
+    }
+
+    /// SimpliSafe, Inc. (`1713`)
+    @_alwaysEmitIntoClient
+    static var simplisafe: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1713)
+    }
+
+    /// Tussock Innovation 2013 Limited (`1714`)
+    @_alwaysEmitIntoClient
+    static var tussockInnovation2013: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1714)
+    }
+
+    /// The Hablab ApS (`1715`)
+    @_alwaysEmitIntoClient
+    static var hablab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1715)
+    }
+
+    /// Sencilion Oy (`1716`)
+    @_alwaysEmitIntoClient
+    static var sencilion: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1716)
+    }
+
+    /// Wabilogic Ltd. (`1717`)
+    @_alwaysEmitIntoClient
+    static var wabilogic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1717)
+    }
+
+    /// Sociometric Solutions, Inc. (`1718`)
+    @_alwaysEmitIntoClient
+    static var sociometricSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1718)
+    }
+
+    /// iCOGNIZE GmbH (`1719`)
+    @_alwaysEmitIntoClient
+    static var icognize: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1719)
+    }
+
+    /// ShadeCraft, Inc (`1720`)
+    @_alwaysEmitIntoClient
+    static var shadecraft: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1720)
+    }
+
+    /// Beflex Inc. (`1721`)
+    @_alwaysEmitIntoClient
+    static var beflex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1721)
+    }
+
+    /// Beaconzone Ltd (`1722`)
+    @_alwaysEmitIntoClient
+    static var beaconzone: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1722)
+    }
+
+    /// Leaftronix Analogic Solutions Private Limited (`1723`)
+    @_alwaysEmitIntoClient
+    static var leaftronixAnalogicSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1723)
+    }
+
+    /// TWS Srl (`1724`)
+    @_alwaysEmitIntoClient
+    static var tws: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1724)
+    }
+
+    /// ABB Oy (`1725`)
+    @_alwaysEmitIntoClient
+    static var abb: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1725)
+    }
+
+    /// HitSeed Oy (`1726`)
+    @_alwaysEmitIntoClient
+    static var hitseed: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1726)
+    }
+
+    /// Delcom Products Inc. (`1727`)
+    @_alwaysEmitIntoClient
+    static var delcomProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1727)
+    }
+
+    /// CAME S.p.A. (`1728`)
+    @_alwaysEmitIntoClient
+    static var came: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1728)
+    }
+
+    /// Alarm.com Holdings, Inc (`1729`)
+    @_alwaysEmitIntoClient
+    static var alarmComHoldings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1729)
+    }
+
+    /// Measurlogic Inc. (`1730`)
+    @_alwaysEmitIntoClient
+    static var measurlogic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1730)
+    }
+
+    /// King I Electronics.Co.,Ltd (`1731`)
+    @_alwaysEmitIntoClient
+    static var kingIElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1731)
+    }
+
+    /// Dream Labs GmbH (`1732`)
+    @_alwaysEmitIntoClient
+    static var dreamLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1732)
+    }
+
+    /// Urban Compass, Inc (`1733`)
+    @_alwaysEmitIntoClient
+    static var urbanCompass: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1733)
+    }
+
+    /// Simm Tronic Limited (`1734`)
+    @_alwaysEmitIntoClient
+    static var simmTronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1734)
+    }
+
+    /// Somatix Inc (`1735`)
+    @_alwaysEmitIntoClient
+    static var somatix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1735)
+    }
+
+    /// Storz & Bickel GmbH & Co. KG (`1736`)
+    @_alwaysEmitIntoClient
+    static var storzBickel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1736)
+    }
+
+    /// MYLAPS B.V. (`1737`)
+    @_alwaysEmitIntoClient
+    static var mylaps: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1737)
+    }
+
+    /// Shenzhen Zhongguang Infotech Technology Development Co., Ltd (`1738`)
+    @_alwaysEmitIntoClient
+    static var shenzhenZhongguangInfotechTechnologyDevelopment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1738)
+    }
+
+    /// Dyeware, LLC (`1739`)
+    @_alwaysEmitIntoClient
+    static var dyeware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1739)
+    }
+
+    /// Dongguan SmartAction Technology Co.,Ltd. (`1740`)
+    @_alwaysEmitIntoClient
+    static var dongguanSmartactionTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1740)
+    }
+
+    /// DIG Corporation (`1741`)
+    @_alwaysEmitIntoClient
+    static var dig: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1741)
+    }
+
+    /// FIOR & GENTZ (`1742`)
+    @_alwaysEmitIntoClient
+    static var fiorGentz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1742)
+    }
+
+    /// Belparts N.V. (`1743`)
+    @_alwaysEmitIntoClient
+    static var belparts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1743)
+    }
+
+    /// Etekcity Corporation (`1744`)
+    @_alwaysEmitIntoClient
+    static var etekcity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1744)
+    }
+
+    /// Meyer Sound Laboratories, Incorporated (`1745`)
+    @_alwaysEmitIntoClient
+    static var meyerSoundLaboratories: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1745)
+    }
+
+    /// CeoTronics AG (`1746`)
+    @_alwaysEmitIntoClient
+    static var ceotronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1746)
+    }
+
+    /// TriTeq Lock and Security, LLC (`1747`)
+    @_alwaysEmitIntoClient
+    static var triteqLockAndSecurity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1747)
+    }
+
+    /// DYNAKODE TECHNOLOGY PRIVATE LIMITED (`1748`)
+    @_alwaysEmitIntoClient
+    static var dynakodeTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1748)
+    }
+
+    /// Sensirion AG (`1749`)
+    @_alwaysEmitIntoClient
+    static var sensirion: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1749)
+    }
+
+    /// JCT Healthcare Pty Ltd (`1750`)
+    @_alwaysEmitIntoClient
+    static var jctHealthcare: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1750)
+    }
+
+    /// FUBA Automotive Electronics GmbH (`1751`)
+    @_alwaysEmitIntoClient
+    static var fubaAutomotiveElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1751)
+    }
+
+    /// AW Company (`1752`)
+    @_alwaysEmitIntoClient
+    static var aw: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1752)
+    }
+
+    /// Shanghai Mountain View Silicon Co.,Ltd. (`1753`)
+    @_alwaysEmitIntoClient
+    static var shanghaiMountainViewSilicon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1753)
+    }
+
+    /// Zliide Technologies ApS (`1754`)
+    @_alwaysEmitIntoClient
+    static var zliideTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1754)
+    }
+
+    /// Automatic Labs, Inc. (`1755`)
+    @_alwaysEmitIntoClient
+    static var automaticLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1755)
+    }
+
+    /// Industrial Network Controls, LLC (`1756`)
+    @_alwaysEmitIntoClient
+    static var industrialNetworkControls: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1756)
+    }
+
+    /// Intellithings Ltd. (`1757`)
+    @_alwaysEmitIntoClient
+    static var intellithings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1757)
+    }
+
+    /// Navcast, Inc. (`1758`)
+    @_alwaysEmitIntoClient
+    static var navcast: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1758)
+    }
+
+    /// HLI Solutions Inc. (`1759`)
+    @_alwaysEmitIntoClient
+    static var hliSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1759)
+    }
+
+    /// Avaya Inc. (`1760`)
+    @_alwaysEmitIntoClient
+    static var avaya: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1760)
+    }
+
+    /// Milestone AV Technologies LLC (`1761`)
+    @_alwaysEmitIntoClient
+    static var milestoneAvTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1761)
+    }
+
+    /// Alango Technologies Ltd (`1762`)
+    @_alwaysEmitIntoClient
+    static var alangoTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1762)
+    }
+
+    /// Spinlock Ltd (`1763`)
+    @_alwaysEmitIntoClient
+    static var spinlock: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1763)
+    }
+
+    /// Aluna (`1764`)
+    @_alwaysEmitIntoClient
+    static var aluna: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1764)
+    }
+
+    /// OPTEX CO.,LTD. (`1765`)
+    @_alwaysEmitIntoClient
+    static var optex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1765)
+    }
+
+    /// NIHON DENGYO KOUSAKU (`1766`)
+    @_alwaysEmitIntoClient
+    static var nihonDengyoKousaku: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1766)
+    }
+
+    /// VELUX A/S (`1767`)
+    @_alwaysEmitIntoClient
+    static var velux: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1767)
+    }
+
+    /// Almendo Technologies GmbH (`1768`)
+    @_alwaysEmitIntoClient
+    static var almendoTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1768)
+    }
+
+    /// Zmartfun Electronics, Inc. (`1769`)
+    @_alwaysEmitIntoClient
+    static var zmartfunElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1769)
+    }
+
+    /// SafeLine Sweden AB (`1770`)
+    @_alwaysEmitIntoClient
+    static var safelineSweden: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1770)
+    }
+
+    /// Houston Radar LLC (`1771`)
+    @_alwaysEmitIntoClient
+    static var houstonRadar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1771)
+    }
+
+    /// Sigur (`1772`)
+    @_alwaysEmitIntoClient
+    static var sigur: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1772)
+    }
+
+    /// J Neades Ltd (`1773`)
+    @_alwaysEmitIntoClient
+    static var jNeades: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1773)
+    }
+
+    /// Avantis Systems Limited (`1774`)
+    @_alwaysEmitIntoClient
+    static var avantisSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1774)
+    }
+
+    /// ALCARE Co., Ltd. (`1775`)
+    @_alwaysEmitIntoClient
+    static var alcare: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1775)
+    }
+
+    /// Chargy Technologies, SL (`1776`)
+    @_alwaysEmitIntoClient
+    static var chargyTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1776)
+    }
+
+    /// Shibutani Co., Ltd. (`1777`)
+    @_alwaysEmitIntoClient
+    static var shibutani: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1777)
+    }
+
+    /// Trapper Data AB (`1778`)
+    @_alwaysEmitIntoClient
+    static var trapperData: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1778)
+    }
+
+    /// Alfred International Inc. (`1779`)
+    @_alwaysEmitIntoClient
+    static var alfredInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1779)
+    }
+
+    /// Touché Technology Ltd (`1780`)
+    @_alwaysEmitIntoClient
+    static var toucheTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1780)
+    }
+
+    /// Vigil Technologies Inc. (`1781`)
+    @_alwaysEmitIntoClient
+    static var vigilTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1781)
+    }
+
+    /// Vitulo Plus BV (`1782`)
+    @_alwaysEmitIntoClient
+    static var vituloPlus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1782)
+    }
+
+    /// WILKA Schliesstechnik GmbH (`1783`)
+    @_alwaysEmitIntoClient
+    static var wilkaSchliesstechnik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1783)
+    }
+
+    /// BodyPlus Technology Co.,Ltd (`1784`)
+    @_alwaysEmitIntoClient
+    static var bodyplusTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1784)
+    }
+
+    /// happybrush GmbH (`1785`)
+    @_alwaysEmitIntoClient
+    static var happybrush: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1785)
+    }
+
+    /// Enequi AB (`1786`)
+    @_alwaysEmitIntoClient
+    static var enequi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1786)
+    }
+
+    /// Sartorius AG (`1787`)
+    @_alwaysEmitIntoClient
+    static var sartorius: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1787)
+    }
+
+    /// Tom Communication Industrial Co.,Ltd. (`1788`)
+    @_alwaysEmitIntoClient
+    static var tomCommunicationIndustrial: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1788)
+    }
+
+    /// ESS Embedded System Solutions Inc. (`1789`)
+    @_alwaysEmitIntoClient
+    static var essEmbeddedSystemSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1789)
+    }
+
+    /// Mahr GmbH (`1790`)
+    @_alwaysEmitIntoClient
+    static var mahr: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1790)
+    }
+
+    /// Redpine Signals Inc (`1791`)
+    @_alwaysEmitIntoClient
+    static var redpineSignals: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1791)
+    }
+
+    /// TraqFreq LLC (`1792`)
+    @_alwaysEmitIntoClient
+    static var traqfreq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1792)
+    }
+
+    /// PAFERS TECH (`1793`)
+    @_alwaysEmitIntoClient
+    static var pafersTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1793)
+    }
+
+    /// Akciju sabiedriba "SAF TEHNIKA" (`1794`)
+    @_alwaysEmitIntoClient
+    static var akcijuSabiedribafTehnika: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1794)
+    }
+
+    /// Beijing Jingdong Century Trading Co., Ltd. (`1795`)
+    @_alwaysEmitIntoClient
+    static var beijingJingdongCenturyTrading: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1795)
+    }
+
+    /// JBX Designs Inc. (`1796`)
+    @_alwaysEmitIntoClient
+    static var jbxDesigns: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1796)
+    }
+
+    /// AB Electrolux (`1797`)
+    @_alwaysEmitIntoClient
+    static var abElectrolux: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1797)
+    }
+
+    /// Wernher von Braun Center for ASdvanced Research (`1798`)
+    @_alwaysEmitIntoClient
+    static var wernherVonBraunCenterFordvancedResearch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1798)
+    }
+
+    /// Essity Hygiene and Health Aktiebolag (`1799`)
+    @_alwaysEmitIntoClient
+    static var essityHygieneAndHealthAktiebolag: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1799)
+    }
+
+    /// Be Interactive Co., Ltd (`1800`)
+    @_alwaysEmitIntoClient
+    static var beInteractive: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1800)
+    }
+
+    /// Carewear Corp. (`1801`)
+    @_alwaysEmitIntoClient
+    static var carewear: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1801)
+    }
+
+    /// Huf Hülsbeck & Fürst GmbH & Co. KG (`1802`)
+    @_alwaysEmitIntoClient
+    static var hufHulsbeckFurst: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1802)
+    }
+
+    /// Element Products, Inc. (`1803`)
+    @_alwaysEmitIntoClient
+    static var elementProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1803)
+    }
+
+    /// Beijing Winner Microelectronics Co.,Ltd (`1804`)
+    @_alwaysEmitIntoClient
+    static var beijingWinnerMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1804)
+    }
+
+    /// SmartSnugg Pty Ltd (`1805`)
+    @_alwaysEmitIntoClient
+    static var smartsnugg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1805)
+    }
+
+    /// FiveCo Sarl (`1806`)
+    @_alwaysEmitIntoClient
+    static var fivecoSarl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1806)
+    }
+
+    /// California Things Inc. (`1807`)
+    @_alwaysEmitIntoClient
+    static var californiaThings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1807)
+    }
+
+    /// Audiodo AB (`1808`)
+    @_alwaysEmitIntoClient
+    static var audiodo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1808)
+    }
+
+    /// ABAX AS (`1809`)
+    @_alwaysEmitIntoClient
+    static var abax: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1809)
+    }
+
+    /// Bull Group Company Limited (`1810`)
+    @_alwaysEmitIntoClient
+    static var bullGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1810)
+    }
+
+    /// Respiri Limited (`1811`)
+    @_alwaysEmitIntoClient
+    static var respiri: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1811)
+    }
+
+    /// MindPeace Safety LLC (`1812`)
+    @_alwaysEmitIntoClient
+    static var mindpeaceSafety: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1812)
+    }
+
+    /// MBARC LABS Inc (`1813`)
+    @_alwaysEmitIntoClient
+    static var mbarcLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1813)
+    }
+
+    /// Altonics (`1814`)
+    @_alwaysEmitIntoClient
+    static var altonics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1814)
+    }
+
+    /// iQsquare BV (`1815`)
+    @_alwaysEmitIntoClient
+    static var iqsquare: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1815)
+    }
+
+    /// IDIBAIX enginneering (`1816`)
+    @_alwaysEmitIntoClient
+    static var idibaixEnginneering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1816)
+    }
+
+    /// COREIOT PTY LTD (`1817`)
+    @_alwaysEmitIntoClient
+    static var coreiot: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1817)
+    }
+
+    /// REVSMART WEARABLE HK CO LTD (`1818`)
+    @_alwaysEmitIntoClient
+    static var revsmartWearableCo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1818)
+    }
+
+    /// Precor (`1819`)
+    @_alwaysEmitIntoClient
+    static var precor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1819)
+    }
+
+    /// F5 Sports, Inc (`1820`)
+    @_alwaysEmitIntoClient
+    static var f5Sports: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1820)
+    }
+
+    /// exoTIC Systems (`1821`)
+    @_alwaysEmitIntoClient
+    static var exoticSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1821)
+    }
+
+    /// DONGGUAN HELE ELECTRONICS CO., LTD (`1822`)
+    @_alwaysEmitIntoClient
+    static var dongguanHeleElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1822)
+    }
+
+    /// Dongguan Liesheng Electronic Co.Ltd (`1823`)
+    @_alwaysEmitIntoClient
+    static var dongguanLieshengElectronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1823)
+    }
+
+    /// Oculeve, Inc. (`1824`)
+    @_alwaysEmitIntoClient
+    static var oculeve: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1824)
+    }
+
+    /// Clover Network, Inc. (`1825`)
+    @_alwaysEmitIntoClient
+    static var cloverNetwork: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1825)
+    }
+
+    /// Xiamen Eholder Electronics Co.Ltd (`1826`)
+    @_alwaysEmitIntoClient
+    static var xiamenEholderElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1826)
+    }
+
+    /// Ford Motor Company (`1827`)
+    @_alwaysEmitIntoClient
+    static var fordMotor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1827)
+    }
+
+    /// Guangzhou SuperSound Information Technology Co.,Ltd (`1828`)
+    @_alwaysEmitIntoClient
+    static var guangzhouSupersoundInformationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1828)
+    }
+
+    /// Tedee Sp. z o.o. (`1829`)
+    @_alwaysEmitIntoClient
+    static var tedee: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1829)
+    }
+
+    /// PHC Corporation (`1830`)
+    @_alwaysEmitIntoClient
+    static var phc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1830)
+    }
+
+    /// STALKIT AS (`1831`)
+    @_alwaysEmitIntoClient
+    static var stalkit: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1831)
+    }
+
+    /// Eli Lilly and Company (`1832`)
+    @_alwaysEmitIntoClient
+    static var eliLillyAndcompany: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1832)
+    }
+
+    /// SwaraLink Technologies (`1833`)
+    @_alwaysEmitIntoClient
+    static var swaralinkTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1833)
+    }
+
+    /// JMR embedded systems GmbH (`1834`)
+    @_alwaysEmitIntoClient
+    static var jmrEmbeddedSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1834)
+    }
+
+    /// Bitkey Inc. (`1835`)
+    @_alwaysEmitIntoClient
+    static var bitkey: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1835)
+    }
+
+    /// GWA Hygiene GmbH (`1836`)
+    @_alwaysEmitIntoClient
+    static var gwaHygiene: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1836)
+    }
+
+    /// Safera Oy (`1837`)
+    @_alwaysEmitIntoClient
+    static var safera: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1837)
+    }
+
+    /// Open Platform Systems LLC (`1838`)
+    @_alwaysEmitIntoClient
+    static var openPlatformSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1838)
+    }
+
+    /// OnePlus Electronics (Shenzhen) Co., Ltd. (`1839`)
+    @_alwaysEmitIntoClient
+    static var oneplusElectronicsShenzhen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1839)
+    }
+
+    /// Wildlife Acoustics, Inc. (`1840`)
+    @_alwaysEmitIntoClient
+    static var wildlifeAcoustics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1840)
+    }
+
+    /// ABLIC Inc. (`1841`)
+    @_alwaysEmitIntoClient
+    static var ablic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1841)
+    }
+
+    /// Dairy Tech, LLC (`1842`)
+    @_alwaysEmitIntoClient
+    static var dairyTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1842)
+    }
+
+    /// Iguanavation, Inc. (`1843`)
+    @_alwaysEmitIntoClient
+    static var iguanavation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1843)
+    }
+
+    /// DiUS Computing Pty Ltd (`1844`)
+    @_alwaysEmitIntoClient
+    static var diusComputing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1844)
+    }
+
+    /// UpRight Technologies LTD (`1845`)
+    @_alwaysEmitIntoClient
+    static var uprightTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1845)
+    }
+
+    /// Luna XIO, Inc. (`1846`)
+    @_alwaysEmitIntoClient
+    static var lunaXio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1846)
+    }
+
+    /// LLC Navitek (`1847`)
+    @_alwaysEmitIntoClient
+    static var llcNavitek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1847)
+    }
+
+    /// Glass Security Pte Ltd (`1848`)
+    @_alwaysEmitIntoClient
+    static var glassSecurityPte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1848)
+    }
+
+    /// Jiangsu Qinheng Co., Ltd. (`1849`)
+    @_alwaysEmitIntoClient
+    static var jiangsuQinheng: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1849)
+    }
+
+    /// Chandler Systems Inc. (`1850`)
+    @_alwaysEmitIntoClient
+    static var chandlerSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1850)
+    }
+
+    /// Fantini Cosmi s.p.a. (`1851`)
+    @_alwaysEmitIntoClient
+    static var fantiniCosmi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1851)
+    }
+
+    /// Acubit ApS (`1852`)
+    @_alwaysEmitIntoClient
+    static var acubit: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1852)
+    }
+
+    /// Beijing Hao Heng Tian Tech Co., Ltd. (`1853`)
+    @_alwaysEmitIntoClient
+    static var beijingHaoHengTianTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1853)
+    }
+
+    /// Bluepack S.R.L. (`1854`)
+    @_alwaysEmitIntoClient
+    static var bluepack: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1854)
+    }
+
+    /// Beijing Unisoc Technologies Co., Ltd. (`1855`)
+    @_alwaysEmitIntoClient
+    static var beijingUnisocTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1855)
+    }
+
+    /// HITIQ LIMITED (`1856`)
+    @_alwaysEmitIntoClient
+    static var hitiq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1856)
+    }
+
+    /// MAC SRL (`1857`)
+    @_alwaysEmitIntoClient
+    static var mac: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1857)
+    }
+
+    /// DML LLC (`1858`)
+    @_alwaysEmitIntoClient
+    static var dml: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1858)
+    }
+
+    /// Sanofi (`1859`)
+    @_alwaysEmitIntoClient
+    static var sanofi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1859)
+    }
+
+    /// SOCOMEC (`1860`)
+    @_alwaysEmitIntoClient
+    static var socomec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1860)
+    }
+
+    /// WIZNOVA, Inc. (`1861`)
+    @_alwaysEmitIntoClient
+    static var wiznova: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1861)
+    }
+
+    /// Seitec Elektronik GmbH (`1862`)
+    @_alwaysEmitIntoClient
+    static var seitecElektronik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1862)
+    }
+
+    /// OR Technologies Pty Ltd (`1863`)
+    @_alwaysEmitIntoClient
+    static var orTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1863)
+    }
+
+    /// GuangZhou KuGou Computer Technology Co.Ltd (`1864`)
+    @_alwaysEmitIntoClient
+    static var guangzhouKugouComputerTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1864)
+    }
+
+    /// DIAODIAO (Beijing) Technology Co., Ltd. (`1865`)
+    @_alwaysEmitIntoClient
+    static var diaodiaoBeijingTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1865)
+    }
+
+    /// Illusory Studios LLC (`1866`)
+    @_alwaysEmitIntoClient
+    static var illusoryStudios: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1866)
+    }
+
+    /// Sarvavid Software Solutions LLP (`1867`)
+    @_alwaysEmitIntoClient
+    static var sarvavidSoftwareSolutionsLlp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1867)
+    }
+
+    /// iopool s.a. (`1868`)
+    @_alwaysEmitIntoClient
+    static var iopool: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1868)
+    }
+
+    /// Amtech Systems, LLC (`1869`)
+    @_alwaysEmitIntoClient
+    static var amtechSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1869)
+    }
+
+    /// EAGLE DETECTION SA (`1870`)
+    @_alwaysEmitIntoClient
+    static var eagleDetection: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1870)
+    }
+
+    /// MEDIATECH S.R.L. (`1871`)
+    @_alwaysEmitIntoClient
+    static var mediatech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1871)
+    }
+
+    /// Hamilton Professional Services of Canada Incorporated (`1872`)
+    @_alwaysEmitIntoClient
+    static var hamiltonProfessionalServicesOfCanada: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1872)
+    }
+
+    /// Changsha JEMO IC Design Co.,Ltd (`1873`)
+    @_alwaysEmitIntoClient
+    static var changshaJemoIcDesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1873)
+    }
+
+    /// Elatec GmbH (`1874`)
+    @_alwaysEmitIntoClient
+    static var elatec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1874)
+    }
+
+    /// JLG Industries, Inc. (`1875`)
+    @_alwaysEmitIntoClient
+    static var jlgIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1875)
+    }
+
+    /// Michael Parkin (`1876`)
+    @_alwaysEmitIntoClient
+    static var michaelParkin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1876)
+    }
+
+    /// Brother Industries, Ltd (`1877`)
+    @_alwaysEmitIntoClient
+    static var brotherIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1877)
+    }
+
+    /// Lumens For Less, Inc (`1878`)
+    @_alwaysEmitIntoClient
+    static var lumensForLess: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1878)
+    }
+
+    /// ELA Innovation (`1879`)
+    @_alwaysEmitIntoClient
+    static var elaInnovation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1879)
+    }
+
+    /// umanSense AB (`1880`)
+    @_alwaysEmitIntoClient
+    static var umansense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1880)
+    }
+
+    /// Shanghai InGeek Cyber Security Co., Ltd. (`1881`)
+    @_alwaysEmitIntoClient
+    static var shanghaiIngeekCyberSecurity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1881)
+    }
+
+    /// HARMAN CO.,LTD. (`1882`)
+    @_alwaysEmitIntoClient
+    static var harman: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1882)
+    }
+
+    /// Smart Sensor Devices AB (`1883`)
+    @_alwaysEmitIntoClient
+    static var smartSensorDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1883)
+    }
+
+    /// Antitronics Inc. (`1884`)
+    @_alwaysEmitIntoClient
+    static var antitronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1884)
+    }
+
+    /// RHOMBUS SYSTEMS, INC. (`1885`)
+    @_alwaysEmitIntoClient
+    static var rhombusSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1885)
+    }
+
+    /// Katerra Inc. (`1886`)
+    @_alwaysEmitIntoClient
+    static var katerra: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1886)
+    }
+
+    /// Remote Solution Co., LTD. (`1887`)
+    @_alwaysEmitIntoClient
+    static var remoteSolution: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1887)
+    }
+
+    /// Vimar SpA (`1888`)
+    @_alwaysEmitIntoClient
+    static var vimarSpa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1888)
+    }
+
+    /// Mantis Tech LLC (`1889`)
+    @_alwaysEmitIntoClient
+    static var mantisTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1889)
+    }
+
+    /// TerOpta Ltd (`1890`)
+    @_alwaysEmitIntoClient
+    static var teropta: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1890)
+    }
+
+    /// PIKOLIN S.L. (`1891`)
+    @_alwaysEmitIntoClient
+    static var pikolin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1891)
+    }
+
+    /// WWZN Information Technology Company Limited (`1892`)
+    @_alwaysEmitIntoClient
+    static var wwznInformationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1892)
+    }
+
+    /// Voxx International (`1893`)
+    @_alwaysEmitIntoClient
+    static var voxxInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1893)
+    }
+
+    /// ART AND PROGRAM, INC. (`1894`)
+    @_alwaysEmitIntoClient
+    static var artAndProgram: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1894)
+    }
+
+    /// NITTO DENKO ASIA TECHNICAL CENTRE PTE. LTD. (`1895`)
+    @_alwaysEmitIntoClient
+    static var nittoDenkoiaTechnicalCentrePte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1895)
+    }
+
+    /// Peloton Interactive Inc. (`1896`)
+    @_alwaysEmitIntoClient
+    static var pelotonInteractive: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1896)
+    }
+
+    /// Force Impact Technologies (`1897`)
+    @_alwaysEmitIntoClient
+    static var forceImpactTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1897)
+    }
+
+    /// Dmac Mobile Developments, LLC (`1898`)
+    @_alwaysEmitIntoClient
+    static var dmacMobileDevelopments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1898)
+    }
+
+    /// Engineered Medical Technologies (`1899`)
+    @_alwaysEmitIntoClient
+    static var engineeredMedicalTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1899)
+    }
+
+    /// Noodle Technology inc (`1900`)
+    @_alwaysEmitIntoClient
+    static var noodleTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1900)
+    }
+
+    /// Graesslin GmbH (`1901`)
+    @_alwaysEmitIntoClient
+    static var graesslin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1901)
+    }
+
+    /// WuQi technologies, Inc. (`1902`)
+    @_alwaysEmitIntoClient
+    static var wuqiTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1902)
+    }
+
+    /// Successful Endeavours Pty Ltd (`1903`)
+    @_alwaysEmitIntoClient
+    static var successfulEndeavours: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1903)
+    }
+
+    /// InnoCon Medical ApS (`1904`)
+    @_alwaysEmitIntoClient
+    static var innoconMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1904)
+    }
+
+    /// Corvex Connected Safety (`1905`)
+    @_alwaysEmitIntoClient
+    static var corvexConnectedSafety: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1905)
+    }
+
+    /// Thirdwayv Inc. (`1906`)
+    @_alwaysEmitIntoClient
+    static var thirdwayv: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1906)
+    }
+
+    /// Echoflex Solutions Inc. (`1907`)
+    @_alwaysEmitIntoClient
+    static var echoflexSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1907)
+    }
+
+    /// C-MAX Asia Limited (`1908`)
+    @_alwaysEmitIntoClient
+    static var cMaxAsia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1908)
+    }
+
+    /// 4eBusiness GmbH (`1909`)
+    @_alwaysEmitIntoClient
+    static var company4Ebusiness: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1909)
+    }
+
+    /// Cyber Transport Control GmbH (`1910`)
+    @_alwaysEmitIntoClient
+    static var cyberTransportControl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1910)
+    }
+
+    /// Cue (`1911`)
+    @_alwaysEmitIntoClient
+    static var cue: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1911)
+    }
+
+    /// KOAMTAC INC. (`1912`)
+    @_alwaysEmitIntoClient
+    static var koamtac: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1912)
+    }
+
+    /// Loopshore Oy (`1913`)
+    @_alwaysEmitIntoClient
+    static var loopshore: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1913)
+    }
+
+    /// Niruha Systems Private Limited (`1914`)
+    @_alwaysEmitIntoClient
+    static var niruhaSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1914)
+    }
+
+    /// AmaterZ, Inc. (`1915`)
+    @_alwaysEmitIntoClient
+    static var amaterz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1915)
+    }
+
+    /// radius co., ltd. (`1916`)
+    @_alwaysEmitIntoClient
+    static var radius: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1916)
+    }
+
+    /// Sensority, s.r.o. (`1917`)
+    @_alwaysEmitIntoClient
+    static var sensority: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1917)
+    }
+
+    /// Sparkage Inc. (`1918`)
+    @_alwaysEmitIntoClient
+    static var sparkage: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1918)
+    }
+
+    /// Glenview Software Corporation (`1919`)
+    @_alwaysEmitIntoClient
+    static var glenviewSoftware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1919)
+    }
+
+    /// Finch Technologies Ltd. (`1920`)
+    @_alwaysEmitIntoClient
+    static var finchTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1920)
+    }
+
+    /// Qingping Technology (Beijing) Co., Ltd. (`1921`)
+    @_alwaysEmitIntoClient
+    static var qingpingTechnologyBeijing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1921)
+    }
+
+    /// DeviceDrive AS (`1922`)
+    @_alwaysEmitIntoClient
+    static var devicedrive: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1922)
+    }
+
+    /// ESEMBER LIMITED LIABILITY COMPANY (`1923`)
+    @_alwaysEmitIntoClient
+    static var esemberLiability: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1923)
+    }
+
+    /// audifon GmbH & Co. KG (`1924`)
+    @_alwaysEmitIntoClient
+    static var audifon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1924)
+    }
+
+    /// O2 Micro, Inc. (`1925`)
+    @_alwaysEmitIntoClient
+    static var o2Micro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1925)
+    }
+
+    /// HLP Controls Pty Limited (`1926`)
+    @_alwaysEmitIntoClient
+    static var hlpControls: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1926)
+    }
+
+    /// Pangaea Solution (`1927`)
+    @_alwaysEmitIntoClient
+    static var pangaeaSolution: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1927)
+    }
+
+    /// BubblyNet, LLC (`1928`)
+    @_alwaysEmitIntoClient
+    static var bubblynet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1928)
+    }
+
+    /// PCB Piezotronics, Inc. (`1929`)
+    @_alwaysEmitIntoClient
+    static var pcbPiezotronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1929)
+    }
+
+    /// The Wildflower Foundation (`1930`)
+    @_alwaysEmitIntoClient
+    static var wildflowerFoundation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1930)
+    }
+
+    /// Optikam Tech Inc. (`1931`)
+    @_alwaysEmitIntoClient
+    static var optikamTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1931)
+    }
+
+    /// MINIBREW HOLDING B.V (`1932`)
+    @_alwaysEmitIntoClient
+    static var minibrewHoldingBV: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1932)
+    }
+
+    /// Cybex GmbH (`1933`)
+    @_alwaysEmitIntoClient
+    static var cybex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1933)
+    }
+
+    /// FUJIMIC NIIGATA, INC. (`1934`)
+    @_alwaysEmitIntoClient
+    static var fujimicNiigata: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1934)
+    }
+
+    /// Hanna Instruments, Inc. (`1935`)
+    @_alwaysEmitIntoClient
+    static var hannaInstruments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1935)
+    }
+
+    /// KOMPAN A/S (`1936`)
+    @_alwaysEmitIntoClient
+    static var kompan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1936)
+    }
+
+    /// Scosche Industries, Inc. (`1937`)
+    @_alwaysEmitIntoClient
+    static var scoscheIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1937)
+    }
+
+    /// Cricut, Inc. (`1938`)
+    @_alwaysEmitIntoClient
+    static var cricut: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1938)
+    }
+
+    /// AEV spol. s r.o. (`1939`)
+    @_alwaysEmitIntoClient
+    static var aevSpolSRO: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1939)
+    }
+
+    /// The Coca-Cola Company (`1940`)
+    @_alwaysEmitIntoClient
+    static var cocaCola: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1940)
+    }
+
+    /// GASTEC CORPORATION (`1941`)
+    @_alwaysEmitIntoClient
+    static var gastec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1941)
+    }
+
+    /// StarLeaf Ltd (`1942`)
+    @_alwaysEmitIntoClient
+    static var starleaf: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1942)
+    }
+
+    /// Water-i.d. GmbH (`1943`)
+    @_alwaysEmitIntoClient
+    static var waterID: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1943)
+    }
+
+    /// HoloKit, Inc. (`1944`)
+    @_alwaysEmitIntoClient
+    static var holokit: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1944)
+    }
+
+    /// PlantChoir Inc. (`1945`)
+    @_alwaysEmitIntoClient
+    static var plantchoir: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1945)
+    }
+
+    /// GuangDong Oppo Mobile Telecommunications Corp., Ltd. (`1946`)
+    @_alwaysEmitIntoClient
+    static var guangdongOppoMobileTelecommunications: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1946)
+    }
+
+    /// CST ELECTRONICS (PROPRIETARY) LIMITED (`1947`)
+    @_alwaysEmitIntoClient
+    static var cstElectronicsProprietary: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1947)
+    }
+
+    /// Sky UK Limited (`1948`)
+    @_alwaysEmitIntoClient
+    static var skyUk: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1948)
+    }
+
+    /// Digibale Pty Ltd (`1949`)
+    @_alwaysEmitIntoClient
+    static var digibale: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1949)
+    }
+
+    /// Smartloxx GmbH (`1950`)
+    @_alwaysEmitIntoClient
+    static var smartloxx: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1950)
+    }
+
+    /// Pune Scientific LLP (`1951`)
+    @_alwaysEmitIntoClient
+    static var puneScientificLlp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1951)
+    }
+
+    /// Regent Beleuchtungskorper AG (`1952`)
+    @_alwaysEmitIntoClient
+    static var regentBeleuchtungskorper: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1952)
+    }
+
+    /// Apollo Neuroscience, Inc. (`1953`)
+    @_alwaysEmitIntoClient
+    static var apolloNeuroscience: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1953)
+    }
+
+    /// Roku, Inc. (`1954`)
+    @_alwaysEmitIntoClient
+    static var roku: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1954)
+    }
+
+    /// Comcast Cable (`1955`)
+    @_alwaysEmitIntoClient
+    static var comcastCable: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1955)
+    }
+
+    /// Xiamen Mage Information Technology Co., Ltd. (`1956`)
+    @_alwaysEmitIntoClient
+    static var xiamenMageInformationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1956)
+    }
+
+    /// RAB Lighting, Inc. (`1957`)
+    @_alwaysEmitIntoClient
+    static var rabLighting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1957)
+    }
+
+    /// Musen Connect, Inc. (`1958`)
+    @_alwaysEmitIntoClient
+    static var musenConnect: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1958)
+    }
+
+    /// Zume, Inc. (`1959`)
+    @_alwaysEmitIntoClient
+    static var zume: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1959)
+    }
+
+    /// conbee GmbH (`1960`)
+    @_alwaysEmitIntoClient
+    static var conbee: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1960)
+    }
+
+    /// Bruel & Kjaer Sound & Vibration (`1961`)
+    @_alwaysEmitIntoClient
+    static var bruelKjaerSoundVibration: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1961)
+    }
+
+    /// The Kroger Co. (`1962`)
+    @_alwaysEmitIntoClient
+    static var kroger: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1962)
+    }
+
+    /// Granite River Solutions, Inc. (`1963`)
+    @_alwaysEmitIntoClient
+    static var graniteRiverSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1963)
+    }
+
+    /// LoupeDeck Oy (`1964`)
+    @_alwaysEmitIntoClient
+    static var loupedeck: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1964)
+    }
+
+    /// New H3C Technologies Co.,Ltd (`1965`)
+    @_alwaysEmitIntoClient
+    static var newH3CTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1965)
+    }
+
+    /// Aurea Solucoes Tecnologicas Ltda. (`1966`)
+    @_alwaysEmitIntoClient
+    static var aureaSolucoesTecnologicas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1966)
+    }
+
+    /// Hong Kong Bouffalo Lab Limited (`1967`)
+    @_alwaysEmitIntoClient
+    static var hongKongBouffaloLab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1967)
+    }
+
+    /// GV Concepts Inc. (`1968`)
+    @_alwaysEmitIntoClient
+    static var gvConcepts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1968)
+    }
+
+    /// Thomas Dynamics, LLC (`1969`)
+    @_alwaysEmitIntoClient
+    static var thomasDynamics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1969)
+    }
+
+    /// Moeco IOT Inc. (`1970`)
+    @_alwaysEmitIntoClient
+    static var moecoIot: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1970)
+    }
+
+    /// 2N TELEKOMUNIKACE a.s. (`1971`)
+    @_alwaysEmitIntoClient
+    static var company2NTelekomunikace: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1971)
+    }
+
+    /// Hormann KG Antriebstechnik (`1972`)
+    @_alwaysEmitIntoClient
+    static var hormannKgAntriebstechnik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1972)
+    }
+
+    /// CRONO CHIP, S.L. (`1973`)
+    @_alwaysEmitIntoClient
+    static var cronoChip: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1973)
+    }
+
+    /// Soundbrenner Limited (`1974`)
+    @_alwaysEmitIntoClient
+    static var soundbrenner: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1974)
+    }
+
+    /// ETABLISSEMENTS GEORGES RENAULT (`1975`)
+    @_alwaysEmitIntoClient
+    static var etablissementsGeorgesRenault: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1975)
+    }
+
+    /// iSwip (`1976`)
+    @_alwaysEmitIntoClient
+    static var iswip: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1976)
+    }
+
+    /// Epona Biotec Limited (`1977`)
+    @_alwaysEmitIntoClient
+    static var eponaBiotec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1977)
+    }
+
+    /// Battery-Biz Inc. (`1978`)
+    @_alwaysEmitIntoClient
+    static var batteryBiz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1978)
+    }
+
+    /// EPIC S.R.L. (`1979`)
+    @_alwaysEmitIntoClient
+    static var epic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1979)
+    }
+
+    /// KD CIRCUITS LLC (`1980`)
+    @_alwaysEmitIntoClient
+    static var kdCircuits: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1980)
+    }
+
+    /// Genedrive Diagnostics Ltd (`1981`)
+    @_alwaysEmitIntoClient
+    static var genedriveDiagnostics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1981)
+    }
+
+    /// Axentia Technologies AB (`1982`)
+    @_alwaysEmitIntoClient
+    static var axentiaTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1982)
+    }
+
+    /// REGULA Ltd. (`1983`)
+    @_alwaysEmitIntoClient
+    static var regula: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1983)
+    }
+
+    /// Biral AG (`1984`)
+    @_alwaysEmitIntoClient
+    static var biral: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1984)
+    }
+
+    /// A.W. Chesterton Company (`1985`)
+    @_alwaysEmitIntoClient
+    static var aWChesterton: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1985)
+    }
+
+    /// Radinn AB (`1986`)
+    @_alwaysEmitIntoClient
+    static var radinn: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1986)
+    }
+
+    /// CIMTechniques, Inc. (`1987`)
+    @_alwaysEmitIntoClient
+    static var cimtechniques: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1987)
+    }
+
+    /// Johnson Health Tech NA (`1988`)
+    @_alwaysEmitIntoClient
+    static var johnsonHealthTechNa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1988)
+    }
+
+    /// June Life, Inc. (`1989`)
+    @_alwaysEmitIntoClient
+    static var juneLife: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1989)
+    }
+
+    /// Bluenetics GmbH (`1990`)
+    @_alwaysEmitIntoClient
+    static var bluenetics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1990)
+    }
+
+    /// iaconicDesign Inc. (`1991`)
+    @_alwaysEmitIntoClient
+    static var iaconicdesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1991)
+    }
+
+    /// WRLDS Creations AB (`1992`)
+    @_alwaysEmitIntoClient
+    static var wrldsCreations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1992)
+    }
+
+    /// Skullcandy, Inc. (`1993`)
+    @_alwaysEmitIntoClient
+    static var skullcandy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1993)
+    }
+
+    /// Modul-System HH AB (`1994`)
+    @_alwaysEmitIntoClient
+    static var modulSystemHh: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1994)
+    }
+
+    /// West Pharmaceutical Services, Inc. (`1995`)
+    @_alwaysEmitIntoClient
+    static var westPharmaceuticalServices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1995)
+    }
+
+    /// Barnacle Systems Inc. (`1996`)
+    @_alwaysEmitIntoClient
+    static var barnacleSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1996)
+    }
+
+    /// Smart Wave Technologies Canada Inc (`1997`)
+    @_alwaysEmitIntoClient
+    static var smartWaveTechnologiesCanada: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1997)
+    }
+
+    /// Shanghai Top-Chip Microelectronics Tech. Co., LTD (`1998`)
+    @_alwaysEmitIntoClient
+    static var shanghaiTopChipMicroelectronicsTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1998)
+    }
+
+    /// NeoSensory, Inc. (`1999`)
+    @_alwaysEmitIntoClient
+    static var neosensory: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 1999)
+    }
+
+    /// Hangzhou Tuya Information  Technology Co., Ltd (`2000`)
+    @_alwaysEmitIntoClient
+    static var hangzhouTuyaInformationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2000)
+    }
+
+    /// Shanghai Panchip Microelectronics Co., Ltd (`2001`)
+    @_alwaysEmitIntoClient
+    static var shanghaiPanchipMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2001)
+    }
+
+    /// React Accessibility Limited (`2002`)
+    @_alwaysEmitIntoClient
+    static var reactAccessibility: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2002)
+    }
+
+    /// LIVNEX Co.,Ltd. (`2003`)
+    @_alwaysEmitIntoClient
+    static var livnex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2003)
+    }
+
+    /// Kano Computing Limited (`2004`)
+    @_alwaysEmitIntoClient
+    static var kanoComputing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2004)
+    }
+
+    /// hoots classic GmbH (`2005`)
+    @_alwaysEmitIntoClient
+    static var hootsClassic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2005)
+    }
+
+    /// ecobee Inc. (`2006`)
+    @_alwaysEmitIntoClient
+    static var ecobee: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2006)
+    }
+
+    /// Nanjing Qinheng Microelectronics Co., Ltd (`2007`)
+    @_alwaysEmitIntoClient
+    static var nanjingQinhengMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2007)
+    }
+
+    /// SOLUTIONS AMBRA INC. (`2008`)
+    @_alwaysEmitIntoClient
+    static var solutionsAmbra: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2008)
+    }
+
+    /// Micro-Design, Inc. (`2009`)
+    @_alwaysEmitIntoClient
+    static var microDesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2009)
+    }
+
+    /// STARLITE Co., Ltd. (`2010`)
+    @_alwaysEmitIntoClient
+    static var starlite: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2010)
+    }
+
+    /// Remedee Labs (`2011`)
+    @_alwaysEmitIntoClient
+    static var remedeeLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2011)
+    }
+
+    /// ThingOS GmbH & Co KG (`2012`)
+    @_alwaysEmitIntoClient
+    static var thingos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2012)
+    }
+
+    /// Linear Circuits (`2013`)
+    @_alwaysEmitIntoClient
+    static var linearCircuits: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2013)
+    }
+
+    /// Unlimited Engineering SL (`2014`)
+    @_alwaysEmitIntoClient
+    static var unlimitedEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2014)
+    }
+
+    /// Snap-on Incorporated (`2015`)
+    @_alwaysEmitIntoClient
+    static var snapOn: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2015)
+    }
+
+    /// Edifier International Limited (`2016`)
+    @_alwaysEmitIntoClient
+    static var edifierInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2016)
+    }
+
+    /// Lucie Labs (`2017`)
+    @_alwaysEmitIntoClient
+    static var lucieLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2017)
+    }
+
+    /// Alfred Kaercher SE & Co. KG (`2018`)
+    @_alwaysEmitIntoClient
+    static var alfredKaercherSeKg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2018)
+    }
+
+    /// Airoha Technology Corp. (`2019`)
+    @_alwaysEmitIntoClient
+    static var airohaTechnology2: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2019)
+    }
+
+    /// Geeksme S.L. (`2020`)
+    @_alwaysEmitIntoClient
+    static var geeksme: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2020)
+    }
+
+    /// Minut, Inc. (`2021`)
+    @_alwaysEmitIntoClient
+    static var minut: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2021)
+    }
+
+    /// Waybeyond Limited (`2022`)
+    @_alwaysEmitIntoClient
+    static var waybeyond: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2022)
+    }
+
+    /// Komfort IQ, Inc. (`2023`)
+    @_alwaysEmitIntoClient
+    static var komfortIq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2023)
+    }
+
+    /// Packetcraft, Inc. (`2024`)
+    @_alwaysEmitIntoClient
+    static var packetcraft: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2024)
+    }
+
+    /// Häfele GmbH & Co KG (`2025`)
+    @_alwaysEmitIntoClient
+    static var hafele: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2025)
+    }
+
+    /// ShapeLog, Inc. (`2026`)
+    @_alwaysEmitIntoClient
+    static var shapelog: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2026)
+    }
+
+    /// NOVABASE S.R.L. (`2027`)
+    @_alwaysEmitIntoClient
+    static var novabase: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2027)
+    }
+
+    /// Frecce LLC (`2028`)
+    @_alwaysEmitIntoClient
+    static var frecce: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2028)
+    }
+
+    /// Joule IQ, INC. (`2029`)
+    @_alwaysEmitIntoClient
+    static var jouleIq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2029)
+    }
+
+    /// KidzTek LLC (`2030`)
+    @_alwaysEmitIntoClient
+    static var kidztek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2030)
+    }
+
+    /// Aktiebolaget Sandvik Coromant (`2031`)
+    @_alwaysEmitIntoClient
+    static var aktiebolagetSandvikCoromant: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2031)
+    }
+
+    /// e-moola.com Pty Ltd (`2032`)
+    @_alwaysEmitIntoClient
+    static var eMoolaCom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2032)
+    }
+
+    /// Zimi Innovations Pty Ltd (`2033`)
+    @_alwaysEmitIntoClient
+    static var zimiInnovations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2033)
+    }
+
+    /// SERENE GROUP, INC (`2034`)
+    @_alwaysEmitIntoClient
+    static var sereneGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2034)
+    }
+
+    /// DIGISINE ENERGYTECH CO. LTD. (`2035`)
+    @_alwaysEmitIntoClient
+    static var digisineEnergytech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2035)
+    }
+
+    /// MEDIRLAB Orvosbiologiai Fejleszto Korlatolt Felelossegu Tarsasag (`2036`)
+    @_alwaysEmitIntoClient
+    static var medirlabOrvosbiologiaiFejlesztoKorlatoltFelelosseguTarsasag: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2036)
+    }
+
+    /// Byton North America Corporation (`2037`)
+    @_alwaysEmitIntoClient
+    static var bytonNorthAmerica: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2037)
+    }
+
+    /// Shenzhen TonliScience and Technology Development Co.,Ltd (`2038`)
+    @_alwaysEmitIntoClient
+    static var shenzhenTonliscienceAndTechnologyDevelopment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2038)
+    }
+
+    /// Cesar Systems Ltd. (`2039`)
+    @_alwaysEmitIntoClient
+    static var cesarSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2039)
+    }
+
+    /// quip NYC Inc. (`2040`)
+    @_alwaysEmitIntoClient
+    static var quipNyc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2040)
+    }
+
+    /// Direct Communication Solutions, Inc. (`2041`)
+    @_alwaysEmitIntoClient
+    static var directCommunicationSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2041)
+    }
+
+    /// Klipsch Group, Inc. (`2042`)
+    @_alwaysEmitIntoClient
+    static var klipschGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2042)
+    }
+
+    /// Access Co., Ltd (`2043`)
+    @_alwaysEmitIntoClient
+    static var access: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2043)
+    }
+
+    /// Renault SA (`2044`)
+    @_alwaysEmitIntoClient
+    static var renault: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2044)
+    }
+
+    /// JSK CO., LTD. (`2045`)
+    @_alwaysEmitIntoClient
+    static var jsk: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2045)
+    }
+
+    /// BIROTA (`2046`)
+    @_alwaysEmitIntoClient
+    static var birota: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2046)
+    }
+
+    /// maxon motor ltd. (`2047`)
+    @_alwaysEmitIntoClient
+    static var maxonMotor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2047)
+    }
+
+    /// Optek (`2048`)
+    @_alwaysEmitIntoClient
+    static var optek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2048)
+    }
+
+    /// CRONUS ELECTRONICS LTD (`2049`)
+    @_alwaysEmitIntoClient
+    static var cronusElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2049)
+    }
+
+    /// NantSound, Inc. (`2050`)
+    @_alwaysEmitIntoClient
+    static var nantsound: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2050)
+    }
+
+    /// Domintell s.a. (`2051`)
+    @_alwaysEmitIntoClient
+    static var domintell: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2051)
+    }
+
+    /// Andon Health Co.,Ltd (`2052`)
+    @_alwaysEmitIntoClient
+    static var andonHealth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2052)
+    }
+
+    /// Urbanminded Ltd (`2053`)
+    @_alwaysEmitIntoClient
+    static var urbanminded: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2053)
+    }
+
+    /// TYRI Sweden AB (`2054`)
+    @_alwaysEmitIntoClient
+    static var tyriSweden: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2054)
+    }
+
+    /// ECD Electronic Components GmbH Dresden (`2055`)
+    @_alwaysEmitIntoClient
+    static var ecdElectronicComponentsDresden: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2055)
+    }
+
+    /// SISTEMAS KERN, SOCIEDAD ANÓMINA (`2056`)
+    @_alwaysEmitIntoClient
+    static var sistemasKernSociedadAnomina: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2056)
+    }
+
+    /// Trulli Audio (`2057`)
+    @_alwaysEmitIntoClient
+    static var trulliAudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2057)
+    }
+
+    /// Altaneos (`2058`)
+    @_alwaysEmitIntoClient
+    static var altaneos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2058)
+    }
+
+    /// Nanoleaf Canada Limited (`2059`)
+    @_alwaysEmitIntoClient
+    static var nanoleafCanada: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2059)
+    }
+
+    /// Ingy B.V. (`2060`)
+    @_alwaysEmitIntoClient
+    static var ingy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2060)
+    }
+
+    /// Azbil Co. (`2061`)
+    @_alwaysEmitIntoClient
+    static var azbil: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2061)
+    }
+
+    /// TATTCOM LLC (`2062`)
+    @_alwaysEmitIntoClient
+    static var tattcom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2062)
+    }
+
+    /// Paradox Engineering SA (`2063`)
+    @_alwaysEmitIntoClient
+    static var paradoxEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2063)
+    }
+
+    /// LECO Corporation (`2064`)
+    @_alwaysEmitIntoClient
+    static var leco: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2064)
+    }
+
+    /// Becker Antriebe GmbH (`2065`)
+    @_alwaysEmitIntoClient
+    static var beckerAntriebe: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2065)
+    }
+
+    /// Mstream Technologies., Inc. (`2066`)
+    @_alwaysEmitIntoClient
+    static var mstreamTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2066)
+    }
+
+    /// Flextronics International USA Inc. (`2067`)
+    @_alwaysEmitIntoClient
+    static var flextronicsInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2067)
+    }
+
+    /// Ossur hf. (`2068`)
+    @_alwaysEmitIntoClient
+    static var ossurHf: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2068)
+    }
+
+    /// SKC Inc (`2069`)
+    @_alwaysEmitIntoClient
+    static var skc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2069)
+    }
+
+    /// SPICA SYSTEMS LLC (`2070`)
+    @_alwaysEmitIntoClient
+    static var spicaSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2070)
+    }
+
+    /// Wangs Alliance Corporation (`2071`)
+    @_alwaysEmitIntoClient
+    static var wangsAlliance: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2071)
+    }
+
+    /// tatwah SA (`2072`)
+    @_alwaysEmitIntoClient
+    static var tatwah: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2072)
+    }
+
+    /// Hunter Douglas Inc (`2073`)
+    @_alwaysEmitIntoClient
+    static var hunterDouglas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2073)
+    }
+
+    /// Shenzhen Conex (`2074`)
+    @_alwaysEmitIntoClient
+    static var shenzhenConex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2074)
+    }
+
+    /// DIM3 (`2075`)
+    @_alwaysEmitIntoClient
+    static var dim3: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2075)
+    }
+
+    /// Bobrick Washroom Equipment, Inc. (`2076`)
+    @_alwaysEmitIntoClient
+    static var bobrickWashroomEquipment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2076)
+    }
+
+    /// Potrykus Holdings and Development LLC (`2077`)
+    @_alwaysEmitIntoClient
+    static var potrykusHoldingsAndDevelopment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2077)
+    }
+
+    /// iNFORM Technology GmbH (`2078`)
+    @_alwaysEmitIntoClient
+    static var informTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2078)
+    }
+
+    /// eSenseLab LTD (`2079`)
+    @_alwaysEmitIntoClient
+    static var esenselab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2079)
+    }
+
+    /// Brilliant Home Technology, Inc. (`2080`)
+    @_alwaysEmitIntoClient
+    static var brilliantHomeTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2080)
+    }
+
+    /// INOVA Geophysical, Inc. (`2081`)
+    @_alwaysEmitIntoClient
+    static var inovaGeophysical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2081)
+    }
+
+    /// adafruit industries (`2082`)
+    @_alwaysEmitIntoClient
+    static var adafruitIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2082)
+    }
+
+    /// Nexite Ltd (`2083`)
+    @_alwaysEmitIntoClient
+    static var nexite: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2083)
+    }
+
+    /// 8Power Limited (`2084`)
+    @_alwaysEmitIntoClient
+    static var company8Power: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2084)
+    }
+
+    /// CME PTE. LTD. (`2085`)
+    @_alwaysEmitIntoClient
+    static var cmePte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2085)
+    }
+
+    /// Hyundai Motor Company (`2086`)
+    @_alwaysEmitIntoClient
+    static var hyundaiMotor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2086)
+    }
+
+    /// Kickmaker (`2087`)
+    @_alwaysEmitIntoClient
+    static var kickmaker: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2087)
+    }
+
+    /// Shanghai Suisheng Information Technology Co., Ltd. (`2088`)
+    @_alwaysEmitIntoClient
+    static var shanghaiSuishengInformationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2088)
+    }
+
+    /// HEXAGON METROLOGY DIVISION ROMER (`2089`)
+    @_alwaysEmitIntoClient
+    static var hexagonMetrologyDivisionRomer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2089)
+    }
+
+    /// Mitutoyo Corporation (`2090`)
+    @_alwaysEmitIntoClient
+    static var mitutoyo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2090)
+    }
+
+    /// shenzhen fitcare electronics Co.,Ltd (`2091`)
+    @_alwaysEmitIntoClient
+    static var shenzhenFitcareElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2091)
+    }
+
+    /// INGICS TECHNOLOGY CO., LTD. (`2092`)
+    @_alwaysEmitIntoClient
+    static var ingicsTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2092)
+    }
+
+    /// INCUS PERFORMANCE LTD. (`2093`)
+    @_alwaysEmitIntoClient
+    static var incusPerformance: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2093)
+    }
+
+    /// ABB S.p.A. (`2094`)
+    @_alwaysEmitIntoClient
+    static var abb2: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2094)
+    }
+
+    /// Blippit AB (`2095`)
+    @_alwaysEmitIntoClient
+    static var blippit: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2095)
+    }
+
+    /// Core Health and Fitness LLC (`2096`)
+    @_alwaysEmitIntoClient
+    static var coreHealthAndFitness: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2096)
+    }
+
+    /// Foxble, LLC (`2097`)
+    @_alwaysEmitIntoClient
+    static var foxble: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2097)
+    }
+
+    /// Intermotive,Inc. (`2098`)
+    @_alwaysEmitIntoClient
+    static var intermotive: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2098)
+    }
+
+    /// Conneqtech B.V. (`2099`)
+    @_alwaysEmitIntoClient
+    static var conneqtech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2099)
+    }
+
+    /// RIKEN KEIKI CO., LTD., (`2100`)
+    @_alwaysEmitIntoClient
+    static var rikenKeiki: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2100)
+    }
+
+    /// Canopy Growth Corporation (`2101`)
+    @_alwaysEmitIntoClient
+    static var canopyGrowth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2101)
+    }
+
+    /// Bitwards Oy (`2102`)
+    @_alwaysEmitIntoClient
+    static var bitwards: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2102)
+    }
+
+    /// vivo Mobile Communication Co., Ltd. (`2103`)
+    @_alwaysEmitIntoClient
+    static var vivoMobileCommunication: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2103)
+    }
+
+    /// Etymotic Research, Inc. (`2104`)
+    @_alwaysEmitIntoClient
+    static var etymoticResearch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2104)
+    }
+
+    /// A puissance 3 (`2105`)
+    @_alwaysEmitIntoClient
+    static var aPuissance3: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2105)
+    }
+
+    /// BPW Bergische Achsen Kommanditgesellschaft (`2106`)
+    @_alwaysEmitIntoClient
+    static var bpwBergischeAchsenKommanditgesellschaft: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2106)
+    }
+
+    /// Piaggio Fast Forward (`2107`)
+    @_alwaysEmitIntoClient
+    static var piaggioFastForward: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2107)
+    }
+
+    /// BeerTech LTD (`2108`)
+    @_alwaysEmitIntoClient
+    static var beertech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2108)
+    }
+
+    /// Tokenize, Inc. (`2109`)
+    @_alwaysEmitIntoClient
+    static var tokenize: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2109)
+    }
+
+    /// Zorachka LTD (`2110`)
+    @_alwaysEmitIntoClient
+    static var zorachka: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2110)
+    }
+
+    /// D-Link Corp. (`2111`)
+    @_alwaysEmitIntoClient
+    static var dLink: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2111)
+    }
+
+    /// Down Range Systems LLC (`2112`)
+    @_alwaysEmitIntoClient
+    static var downRangeSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2112)
+    }
+
+    /// General Luminaire (Shanghai) Co., Ltd. (`2113`)
+    @_alwaysEmitIntoClient
+    static var generalLuminaireShanghai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2113)
+    }
+
+    /// Tangshan HongJia electronic technology co., LTD. (`2114`)
+    @_alwaysEmitIntoClient
+    static var tangshanHongjiaElectronicTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2114)
+    }
+
+    /// FRAGRANCE DELIVERY TECHNOLOGIES LTD (`2115`)
+    @_alwaysEmitIntoClient
+    static var fragranceDeliveryTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2115)
+    }
+
+    /// Pepperl + Fuchs GmbH (`2116`)
+    @_alwaysEmitIntoClient
+    static var pepperlFuchs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2116)
+    }
+
+    /// Dometic Corporation (`2117`)
+    @_alwaysEmitIntoClient
+    static var dometic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2117)
+    }
+
+    /// USound GmbH (`2118`)
+    @_alwaysEmitIntoClient
+    static var usound: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2118)
+    }
+
+    /// DNANUDGE LIMITED (`2119`)
+    @_alwaysEmitIntoClient
+    static var dnanudge: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2119)
+    }
+
+    /// JUJU JOINTS CANADA CORP. (`2120`)
+    @_alwaysEmitIntoClient
+    static var jujuJointsCanada: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2120)
+    }
+
+    /// Dopple Technologies B.V. (`2121`)
+    @_alwaysEmitIntoClient
+    static var doppleTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2121)
+    }
+
+    /// ARCOM (`2122`)
+    @_alwaysEmitIntoClient
+    static var arcom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2122)
+    }
+
+    /// Biotechware SRL (`2123`)
+    @_alwaysEmitIntoClient
+    static var biotechware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2123)
+    }
+
+    /// ORSO Inc. (`2124`)
+    @_alwaysEmitIntoClient
+    static var orso: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2124)
+    }
+
+    /// SafePort (`2125`)
+    @_alwaysEmitIntoClient
+    static var safeport: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2125)
+    }
+
+    /// Carol Cole Company (`2126`)
+    @_alwaysEmitIntoClient
+    static var carolCole: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2126)
+    }
+
+    /// Embedded Fitness B.V. (`2127`)
+    @_alwaysEmitIntoClient
+    static var embeddedFitness: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2127)
+    }
+
+    /// Yealink (Xiamen) Network Technology Co.,LTD (`2128`)
+    @_alwaysEmitIntoClient
+    static var yealinkXiamenNetworkTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2128)
+    }
+
+    /// Subeca, Inc. (`2129`)
+    @_alwaysEmitIntoClient
+    static var subeca: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2129)
+    }
+
+    /// Cognosos, Inc. (`2130`)
+    @_alwaysEmitIntoClient
+    static var cognosos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2130)
+    }
+
+    /// Pektron Group Limited (`2131`)
+    @_alwaysEmitIntoClient
+    static var pektronGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2131)
+    }
+
+    /// Tap Sound System (`2132`)
+    @_alwaysEmitIntoClient
+    static var tapSoundSystem: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2132)
+    }
+
+    /// Helios Sports, Inc. (`2133`)
+    @_alwaysEmitIntoClient
+    static var heliosSports: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2133)
+    }
+
+    /// Canopy Growth Corporation (`2134`)
+    @_alwaysEmitIntoClient
+    static var canopyGrowth2: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2134)
+    }
+
+    /// Parsyl Inc (`2135`)
+    @_alwaysEmitIntoClient
+    static var parsyl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2135)
+    }
+
+    /// SOUNDBOKS (`2136`)
+    @_alwaysEmitIntoClient
+    static var soundboks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2136)
+    }
+
+    /// BlueUp (`2137`)
+    @_alwaysEmitIntoClient
+    static var blueup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2137)
+    }
+
+    /// DAKATECH (`2138`)
+    @_alwaysEmitIntoClient
+    static var dakatech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2138)
+    }
+
+    /// Nisshinbo Micro Devices Inc. (`2139`)
+    @_alwaysEmitIntoClient
+    static var nisshinboMicroDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2139)
+    }
+
+    /// ACOS CO.,LTD. (`2140`)
+    @_alwaysEmitIntoClient
+    static var acos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2140)
+    }
+
+    /// Guilin Zhishen Information Technology Co.,Ltd. (`2141`)
+    @_alwaysEmitIntoClient
+    static var guilinZhishenInformationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2141)
+    }
+
+    /// Krog Systems LLC (`2142`)
+    @_alwaysEmitIntoClient
+    static var krogSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2142)
+    }
+
+    /// COMPEGPS TEAM,SOCIEDAD LIMITADA (`2143`)
+    @_alwaysEmitIntoClient
+    static var compegpsTeamSociedadLimitada: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2143)
+    }
+
+    /// Alflex Products B.V. (`2144`)
+    @_alwaysEmitIntoClient
+    static var alflexProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2144)
+    }
+
+    /// SmartSensor Labs Ltd (`2145`)
+    @_alwaysEmitIntoClient
+    static var smartsensorLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2145)
+    }
+
+    /// SmartDrive (`2146`)
+    @_alwaysEmitIntoClient
+    static var smartdrive: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2146)
+    }
+
+    /// Yo-tronics Technology Co., Ltd. (`2147`)
+    @_alwaysEmitIntoClient
+    static var yoTronicsTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2147)
+    }
+
+    /// Rafaelmicro (`2148`)
+    @_alwaysEmitIntoClient
+    static var rafaelmicro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2148)
+    }
+
+    /// Emergency Lighting Products Limited (`2149`)
+    @_alwaysEmitIntoClient
+    static var emergencyLightingProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2149)
+    }
+
+    /// LAONZ Co.,Ltd (`2150`)
+    @_alwaysEmitIntoClient
+    static var laonz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2150)
+    }
+
+    /// Western Digital Techologies, Inc. (`2151`)
+    @_alwaysEmitIntoClient
+    static var westernDigitalTechologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2151)
+    }
+
+    /// WIOsense GmbH & Co. KG (`2152`)
+    @_alwaysEmitIntoClient
+    static var wiosense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2152)
+    }
+
+    /// EVVA Sicherheitstechnologie GmbH (`2153`)
+    @_alwaysEmitIntoClient
+    static var evvaSicherheitstechnologie: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2153)
+    }
+
+    /// Odic Incorporated (`2154`)
+    @_alwaysEmitIntoClient
+    static var odic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2154)
+    }
+
+    /// Pacific Track, LLC (`2155`)
+    @_alwaysEmitIntoClient
+    static var pacificTrack: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2155)
+    }
+
+    /// Revvo Technologies, Inc. (`2156`)
+    @_alwaysEmitIntoClient
+    static var revvoTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2156)
+    }
+
+    /// Biometrika d.o.o. (`2157`)
+    @_alwaysEmitIntoClient
+    static var biometrika: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2157)
+    }
+
+    /// Vorwerk Elektrowerke GmbH & Co. KG (`2158`)
+    @_alwaysEmitIntoClient
+    static var vorwerkElektrowerke: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2158)
+    }
+
+    /// Trackunit A/S (`2159`)
+    @_alwaysEmitIntoClient
+    static var trackunit: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2159)
+    }
+
+    /// Wyze Labs, Inc (`2160`)
+    @_alwaysEmitIntoClient
+    static var wyzeLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2160)
+    }
+
+    /// Dension Elektronikai Kft. (`2161`)
+    @_alwaysEmitIntoClient
+    static var densionElektronikai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2161)
+    }
+
+    /// 11 Health & Technologies Limited (`2162`)
+    @_alwaysEmitIntoClient
+    static var company11HealthTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2162)
+    }
+
+    /// Innophase Incorporated (`2163`)
+    @_alwaysEmitIntoClient
+    static var innophase: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2163)
+    }
+
+    /// Treegreen Limited (`2164`)
+    @_alwaysEmitIntoClient
+    static var treegreen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2164)
+    }
+
+    /// Berner International LLC (`2165`)
+    @_alwaysEmitIntoClient
+    static var bernerInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2165)
+    }
+
+    /// SmartResQ ApS (`2166`)
+    @_alwaysEmitIntoClient
+    static var smartresq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2166)
+    }
+
+    /// Tome, Inc. (`2167`)
+    @_alwaysEmitIntoClient
+    static var tome: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2167)
+    }
+
+    /// The Chamberlain Group, Inc. (`2168`)
+    @_alwaysEmitIntoClient
+    static var chamberlainGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2168)
+    }
+
+    /// MIZUNO Corporation (`2169`)
+    @_alwaysEmitIntoClient
+    static var mizuno: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2169)
+    }
+
+    /// ZRF, LLC (`2170`)
+    @_alwaysEmitIntoClient
+    static var zrf: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2170)
+    }
+
+    /// BYSTAMP (`2171`)
+    @_alwaysEmitIntoClient
+    static var bystamp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2171)
+    }
+
+    /// Crosscan GmbH (`2172`)
+    @_alwaysEmitIntoClient
+    static var crosscan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2172)
+    }
+
+    /// Konftel AB (`2173`)
+    @_alwaysEmitIntoClient
+    static var konftel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2173)
+    }
+
+    /// 1bar.net Limited (`2174`)
+    @_alwaysEmitIntoClient
+    static var company1BarNet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2174)
+    }
+
+    /// Phillips Connect Technologies LLC (`2175`)
+    @_alwaysEmitIntoClient
+    static var phillipsConnectTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2175)
+    }
+
+    /// imagiLabs AB (`2176`)
+    @_alwaysEmitIntoClient
+    static var imagilabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2176)
+    }
+
+    /// Optalert (`2177`)
+    @_alwaysEmitIntoClient
+    static var optalert: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2177)
+    }
+
+    /// PSYONIC, Inc. (`2178`)
+    @_alwaysEmitIntoClient
+    static var psyonic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2178)
+    }
+
+    /// Wintersteiger AG (`2179`)
+    @_alwaysEmitIntoClient
+    static var wintersteiger: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2179)
+    }
+
+    /// Controlid Industria, Comercio de Hardware e Servicos de Tecnologia Ltda (`2180`)
+    @_alwaysEmitIntoClient
+    static var controlidIndustriaComercioDeHardwareEServicosDeTecnologia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2180)
+    }
+
+    /// LEVOLOR INC (`2181`)
+    @_alwaysEmitIntoClient
+    static var levolor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2181)
+    }
+
+    /// Movella Technologies B.V. (`2182`)
+    @_alwaysEmitIntoClient
+    static var movellaTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2182)
+    }
+
+    /// Hydro-Gear Limited Partnership (`2183`)
+    @_alwaysEmitIntoClient
+    static var hydroGearPartnership: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2183)
+    }
+
+    /// EnPointe Fencing Pty Ltd (`2184`)
+    @_alwaysEmitIntoClient
+    static var enpointeFencing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2184)
+    }
+
+    /// XANTHIO (`2185`)
+    @_alwaysEmitIntoClient
+    static var xanthio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2185)
+    }
+
+    /// sclak s.r.l. (`2186`)
+    @_alwaysEmitIntoClient
+    static var sclak: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2186)
+    }
+
+    /// Tricorder Arraay Technologies LLC (`2187`)
+    @_alwaysEmitIntoClient
+    static var tricorderArraayTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2187)
+    }
+
+    /// GB Solution co.,Ltd (`2188`)
+    @_alwaysEmitIntoClient
+    static var gbSolution: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2188)
+    }
+
+    /// Soliton Systems K.K. (`2189`)
+    @_alwaysEmitIntoClient
+    static var solitonSystemsKK: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2189)
+    }
+
+    /// GIGA-TMS INC (`2190`)
+    @_alwaysEmitIntoClient
+    static var gigaTms: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2190)
+    }
+
+    /// Tait International Limited (`2191`)
+    @_alwaysEmitIntoClient
+    static var taitInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2191)
+    }
+
+    /// NICHIEI INTEC CO., LTD. (`2192`)
+    @_alwaysEmitIntoClient
+    static var nichieiIntec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2192)
+    }
+
+    /// SmartWireless GmbH & Co. KG (`2193`)
+    @_alwaysEmitIntoClient
+    static var smartwireless: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2193)
+    }
+
+    /// Ingenieurbuero Birnfeld UG (haftungsbeschraenkt) (`2194`)
+    @_alwaysEmitIntoClient
+    static var ingenieurbueroBirnfeldUgHaftungsbeschraenkt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2194)
+    }
+
+    /// Maytronics Ltd (`2195`)
+    @_alwaysEmitIntoClient
+    static var maytronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2195)
+    }
+
+    /// EPIFIT (`2196`)
+    @_alwaysEmitIntoClient
+    static var epifit: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2196)
+    }
+
+    /// Gimer medical (`2197`)
+    @_alwaysEmitIntoClient
+    static var gimerMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2197)
+    }
+
+    /// Nokian Renkaat Oyj (`2198`)
+    @_alwaysEmitIntoClient
+    static var nokianRenkaatj: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2198)
+    }
+
+    /// Current Lighting Solutions LLC (`2199`)
+    @_alwaysEmitIntoClient
+    static var currentLightingSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2199)
+    }
+
+    /// Sensibo, Inc. (`2200`)
+    @_alwaysEmitIntoClient
+    static var sensibo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2200)
+    }
+
+    /// SFS unimarket AG (`2201`)
+    @_alwaysEmitIntoClient
+    static var sfsUnimarket: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2201)
+    }
+
+    /// Private limited company "Teltonika" (`2202`)
+    @_alwaysEmitIntoClient
+    static var teltonika: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2202)
+    }
+
+    /// Saucon Technologies (`2203`)
+    @_alwaysEmitIntoClient
+    static var sauconTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2203)
+    }
+
+    /// Embedded Devices Co. Company (`2204`)
+    @_alwaysEmitIntoClient
+    static var embeddedDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2204)
+    }
+
+    /// J-J.A.D.E. Enterprise LLC (`2205`)
+    @_alwaysEmitIntoClient
+    static var jJADEEnterprise: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2205)
+    }
+
+    /// i-SENS, inc. (`2206`)
+    @_alwaysEmitIntoClient
+    static var iSens: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2206)
+    }
+
+    /// Witschi Electronic Ltd (`2207`)
+    @_alwaysEmitIntoClient
+    static var witschiElectronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2207)
+    }
+
+    /// Aclara Technologies LLC (`2208`)
+    @_alwaysEmitIntoClient
+    static var aclaraTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2208)
+    }
+
+    /// EXEO TECH CORPORATION (`2209`)
+    @_alwaysEmitIntoClient
+    static var exeoTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2209)
+    }
+
+    /// Epic Systems Co., Ltd. (`2210`)
+    @_alwaysEmitIntoClient
+    static var epicSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2210)
+    }
+
+    /// Hoffmann SE (`2211`)
+    @_alwaysEmitIntoClient
+    static var hoffmann: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2211)
+    }
+
+    /// Realme Chongqing Mobile Telecommunications Corp., Ltd. (`2212`)
+    @_alwaysEmitIntoClient
+    static var realmeChongqingMobileTelecommunications: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2212)
+    }
+
+    /// UMEHEAL Ltd (`2213`)
+    @_alwaysEmitIntoClient
+    static var umeheal: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2213)
+    }
+
+    /// Intelligenceworks Inc. (`2214`)
+    @_alwaysEmitIntoClient
+    static var intelligenceworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2214)
+    }
+
+    /// TGR 1.618 Limited (`2215`)
+    @_alwaysEmitIntoClient
+    static var tgr1618: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2215)
+    }
+
+    /// Shanghai Kfcube Inc (`2216`)
+    @_alwaysEmitIntoClient
+    static var shanghaiKfcube: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2216)
+    }
+
+    /// Fraunhofer IIS (`2217`)
+    @_alwaysEmitIntoClient
+    static var fraunhoferIis: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2217)
+    }
+
+    /// SZ DJI TECHNOLOGY CO.,LTD (`2218`)
+    @_alwaysEmitIntoClient
+    static var szDjiTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2218)
+    }
+
+    /// Coburn Technology, LLC (`2219`)
+    @_alwaysEmitIntoClient
+    static var coburnTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2219)
+    }
+
+    /// Topre Corporation (`2220`)
+    @_alwaysEmitIntoClient
+    static var topre: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2220)
+    }
+
+    /// Kayamatics Limited (`2221`)
+    @_alwaysEmitIntoClient
+    static var kayamatics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2221)
+    }
+
+    /// Moticon ReGo AG (`2222`)
+    @_alwaysEmitIntoClient
+    static var moticonRego: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2222)
+    }
+
+    /// Polidea Sp. z o.o. (`2223`)
+    @_alwaysEmitIntoClient
+    static var polidea: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2223)
+    }
+
+    /// Trivedi Advanced Technologies LLC (`2224`)
+    @_alwaysEmitIntoClient
+    static var trivediAdvancedTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2224)
+    }
+
+    /// CORE|vision BV (`2225`)
+    @_alwaysEmitIntoClient
+    static var coreVision: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2225)
+    }
+
+    /// PF SCHWEISSTECHNOLOGIE GMBH (`2226`)
+    @_alwaysEmitIntoClient
+    static var pfSchweisstechnologie: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2226)
+    }
+
+    /// IONIQ Skincare GmbH & Co. KG (`2227`)
+    @_alwaysEmitIntoClient
+    static var ioniqSkincare: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2227)
+    }
+
+    /// Sengled Co., Ltd. (`2228`)
+    @_alwaysEmitIntoClient
+    static var sengled: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2228)
+    }
+
+    /// TransferFi (`2229`)
+    @_alwaysEmitIntoClient
+    static var transferfi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2229)
+    }
+
+    /// Boehringer Ingelheim Vetmedica GmbH (`2230`)
+    @_alwaysEmitIntoClient
+    static var boehringerIngelheimVetmedica: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2230)
+    }
+
+    /// ABB Inc (`2231`)
+    @_alwaysEmitIntoClient
+    static var abb3: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2231)
+    }
+
+    /// Check Technology Solutions LLC (`2232`)
+    @_alwaysEmitIntoClient
+    static var checkTechnologySolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2232)
+    }
+
+    /// U-Shin Ltd. (`2233`)
+    @_alwaysEmitIntoClient
+    static var uShin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2233)
+    }
+
+    /// HYPER ICE, INC. (`2234`)
+    @_alwaysEmitIntoClient
+    static var hyperIce: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2234)
+    }
+
+    /// Tokai-rika co.,ltd. (`2235`)
+    @_alwaysEmitIntoClient
+    static var tokaiRika: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2235)
+    }
+
+    /// Prevayl Limited (`2236`)
+    @_alwaysEmitIntoClient
+    static var prevayl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2236)
+    }
+
+    /// bf1systems limited (`2237`)
+    @_alwaysEmitIntoClient
+    static var bf1Systems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2237)
+    }
+
+    /// ubisys technologies GmbH (`2238`)
+    @_alwaysEmitIntoClient
+    static var ubisysTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2238)
+    }
+
+    /// SIRC Co., Ltd. (`2239`)
+    @_alwaysEmitIntoClient
+    static var sirc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2239)
+    }
+
+    /// Accent Advanced Systems SLU (`2240`)
+    @_alwaysEmitIntoClient
+    static var accentAdvancedSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2240)
+    }
+
+    /// Rayden.Earth LTD (`2241`)
+    @_alwaysEmitIntoClient
+    static var raydenEarth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2241)
+    }
+
+    /// Lindinvent AB (`2242`)
+    @_alwaysEmitIntoClient
+    static var lindinvent: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2242)
+    }
+
+    /// CHIPOLO d.o.o. (`2243`)
+    @_alwaysEmitIntoClient
+    static var chipolo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2243)
+    }
+
+    /// CellAssist, LLC (`2244`)
+    @_alwaysEmitIntoClient
+    static var cellassist: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2244)
+    }
+
+    /// J. Wagner GmbH (`2245`)
+    @_alwaysEmitIntoClient
+    static var jWagner: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2245)
+    }
+
+    /// Integra Optics Inc (`2246`)
+    @_alwaysEmitIntoClient
+    static var integraOptics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2246)
+    }
+
+    /// Monadnock Systems Ltd. (`2247`)
+    @_alwaysEmitIntoClient
+    static var monadnockSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2247)
+    }
+
+    /// Liteboxer Technologies Inc. (`2248`)
+    @_alwaysEmitIntoClient
+    static var liteboxerTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2248)
+    }
+
+    /// Noventa AG (`2249`)
+    @_alwaysEmitIntoClient
+    static var noventa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2249)
+    }
+
+    /// Nubia Technology Co.,Ltd. (`2250`)
+    @_alwaysEmitIntoClient
+    static var nubiaTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2250)
+    }
+
+    /// JT INNOVATIONS LIMITED (`2251`)
+    @_alwaysEmitIntoClient
+    static var jtInnovations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2251)
+    }
+
+    /// TGM TECHNOLOGY CO., LTD. (`2252`)
+    @_alwaysEmitIntoClient
+    static var tgmTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2252)
+    }
+
+    /// ifly (`2253`)
+    @_alwaysEmitIntoClient
+    static var ifly: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2253)
+    }
+
+    /// ZIMI CORPORATION (`2254`)
+    @_alwaysEmitIntoClient
+    static var zimi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2254)
+    }
+
+    /// betternotstealmybike UG (with limited liability) (`2255`)
+    @_alwaysEmitIntoClient
+    static var betternotstealmybikeUgWithLiability: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2255)
+    }
+
+    /// ESTOM Infotech Kft. (`2256`)
+    @_alwaysEmitIntoClient
+    static var estomInfotech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2256)
+    }
+
+    /// Sensovium Inc. (`2257`)
+    @_alwaysEmitIntoClient
+    static var sensovium: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2257)
+    }
+
+    /// Virscient Limited (`2258`)
+    @_alwaysEmitIntoClient
+    static var virscient: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2258)
+    }
+
+    /// Novel Bits, LLC (`2259`)
+    @_alwaysEmitIntoClient
+    static var novelBits: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2259)
+    }
+
+    /// ADATA Technology Co., LTD. (`2260`)
+    @_alwaysEmitIntoClient
+    static var adataTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2260)
+    }
+
+    /// KEYes (`2261`)
+    @_alwaysEmitIntoClient
+    static var keyes: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2261)
+    }
+
+    /// Nome Oy (`2262`)
+    @_alwaysEmitIntoClient
+    static var nome: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2262)
+    }
+
+    /// Inovonics Corp (`2263`)
+    @_alwaysEmitIntoClient
+    static var inovonics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2263)
+    }
+
+    /// WARES (`2264`)
+    @_alwaysEmitIntoClient
+    static var wares: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2264)
+    }
+
+    /// Pointr Labs Limited (`2265`)
+    @_alwaysEmitIntoClient
+    static var pointrLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2265)
+    }
+
+    /// Miridia Technology Incorporated (`2266`)
+    @_alwaysEmitIntoClient
+    static var miridiaTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2266)
+    }
+
+    /// Tertium Technology (`2267`)
+    @_alwaysEmitIntoClient
+    static var tertiumTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2267)
+    }
+
+    /// SHENZHEN AUKEY E BUSINESS CO., LTD (`2268`)
+    @_alwaysEmitIntoClient
+    static var shenzhenAukeyEBusiness: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2268)
+    }
+
+    /// code-Q (`2269`)
+    @_alwaysEmitIntoClient
+    static var codeQ: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2269)
+    }
+
+    /// TE Connectivity Corporation (`2270`)
+    @_alwaysEmitIntoClient
+    static var teConnectivity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2270)
+    }
+
+    /// IRIS OHYAMA CO.,LTD. (`2271`)
+    @_alwaysEmitIntoClient
+    static var irisOhyama: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2271)
+    }
+
+    /// Philia Technology (`2272`)
+    @_alwaysEmitIntoClient
+    static var philiaTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2272)
+    }
+
+    /// KOZO KEIKAKU ENGINEERING Inc. (`2273`)
+    @_alwaysEmitIntoClient
+    static var kozoKeikakuEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2273)
+    }
+
+    /// Shenzhen Simo Technology co. LTD (`2274`)
+    @_alwaysEmitIntoClient
+    static var shenzhenSimoTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2274)
+    }
+
+    /// Republic Wireless, Inc. (`2275`)
+    @_alwaysEmitIntoClient
+    static var republicWireless: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2275)
+    }
+
+    /// Rashidov ltd (`2276`)
+    @_alwaysEmitIntoClient
+    static var rashidov: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2276)
+    }
+
+    /// Crowd Connected Ltd (`2277`)
+    @_alwaysEmitIntoClient
+    static var crowdConnected: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2277)
+    }
+
+    /// Eneso Tecnologia de Adaptacion S.L. (`2278`)
+    @_alwaysEmitIntoClient
+    static var enesoTecnologiaDeAdaptacion: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2278)
+    }
+
+    /// Barrot Technology Co.,Ltd. (`2279`)
+    @_alwaysEmitIntoClient
+    static var barrotTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2279)
+    }
+
+    /// Naonext (`2280`)
+    @_alwaysEmitIntoClient
+    static var naonext: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2280)
+    }
+
+    /// Taiwan Intelligent Home Corp. (`2281`)
+    @_alwaysEmitIntoClient
+    static var taiwanIntelligentHome: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2281)
+    }
+
+    /// COWBELL ENGINEERING CO.,LTD. (`2282`)
+    @_alwaysEmitIntoClient
+    static var cowbellEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2282)
+    }
+
+    /// Beijing Big Moment Technology Co., Ltd. (`2283`)
+    @_alwaysEmitIntoClient
+    static var beijingBigMomentTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2283)
+    }
+
+    /// Denso Corporation (`2284`)
+    @_alwaysEmitIntoClient
+    static var denso: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2284)
+    }
+
+    /// IMI Hydronic Engineering International SA (`2285`)
+    @_alwaysEmitIntoClient
+    static var imiHydronicEngineeringInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2285)
+    }
+
+    /// Askey Computer Corp. (`2286`)
+    @_alwaysEmitIntoClient
+    static var askeyComputer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2286)
+    }
+
+    /// Cumulus Digital Systems, Inc (`2287`)
+    @_alwaysEmitIntoClient
+    static var cumulusDigitalSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2287)
+    }
+
+    /// Joovv, Inc. (`2288`)
+    @_alwaysEmitIntoClient
+    static var joovv: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2288)
+    }
+
+    /// The L.S. Starrett Company (`2289`)
+    @_alwaysEmitIntoClient
+    static var lSStarrett: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2289)
+    }
+
+    /// Microoled (`2290`)
+    @_alwaysEmitIntoClient
+    static var microoled: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2290)
+    }
+
+    /// PSP - Pauli Services & Products GmbH (`2291`)
+    @_alwaysEmitIntoClient
+    static var pspPauliServicesProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2291)
+    }
+
+    /// Kodimo Technologies Company Limited (`2292`)
+    @_alwaysEmitIntoClient
+    static var kodimoTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2292)
+    }
+
+    /// Tymtix Technologies Private Limited (`2293`)
+    @_alwaysEmitIntoClient
+    static var tymtixTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2293)
+    }
+
+    /// Dermal Photonics Corporation (`2294`)
+    @_alwaysEmitIntoClient
+    static var dermalPhotonics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2294)
+    }
+
+    /// MTD Products Inc & Affiliates (`2295`)
+    @_alwaysEmitIntoClient
+    static var mtdProductsAffiliates: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2295)
+    }
+
+    /// instagrid GmbH (`2296`)
+    @_alwaysEmitIntoClient
+    static var instagrid: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2296)
+    }
+
+    /// Spacelabs Medical Inc. (`2297`)
+    @_alwaysEmitIntoClient
+    static var spacelabsMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2297)
+    }
+
+    /// Troo Corporation (`2298`)
+    @_alwaysEmitIntoClient
+    static var troo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2298)
+    }
+
+    /// Darkglass Electronics Oy (`2299`)
+    @_alwaysEmitIntoClient
+    static var darkglassElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2299)
+    }
+
+    /// Hill-Rom (`2300`)
+    @_alwaysEmitIntoClient
+    static var hillRom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2300)
+    }
+
+    /// BioIntelliSense, Inc. (`2301`)
+    @_alwaysEmitIntoClient
+    static var biointellisense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2301)
+    }
+
+    /// Ketronixs Sdn Bhd (`2302`)
+    @_alwaysEmitIntoClient
+    static var ketronixs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2302)
+    }
+
+    /// Plastimold Products, Inc (`2303`)
+    @_alwaysEmitIntoClient
+    static var plastimoldProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2303)
+    }
+
+    /// Beijing Zizai Technology Co., LTD. (`2304`)
+    @_alwaysEmitIntoClient
+    static var beijingZizaiTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2304)
+    }
+
+    /// Lucimed (`2305`)
+    @_alwaysEmitIntoClient
+    static var lucimed: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2305)
+    }
+
+    /// TSC Auto-ID Technology Co., Ltd. (`2306`)
+    @_alwaysEmitIntoClient
+    static var tscAutoIdTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2306)
+    }
+
+    /// DATAMARS, Inc. (`2307`)
+    @_alwaysEmitIntoClient
+    static var datamars: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2307)
+    }
+
+    /// SUNCORPORATION (`2308`)
+    @_alwaysEmitIntoClient
+    static var suncorporation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2308)
+    }
+
+    /// Yandex Services AG (`2309`)
+    @_alwaysEmitIntoClient
+    static var yandexServices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2309)
+    }
+
+    /// Scope Logistical Solutions (`2310`)
+    @_alwaysEmitIntoClient
+    static var scopeLogisticalSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2310)
+    }
+
+    /// User Hello, LLC (`2311`)
+    @_alwaysEmitIntoClient
+    static var userHello: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2311)
+    }
+
+    /// Pinpoint Innovations Limited (`2312`)
+    @_alwaysEmitIntoClient
+    static var pinpointInnovations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2312)
+    }
+
+    /// 70mai Co.,Ltd. (`2313`)
+    @_alwaysEmitIntoClient
+    static var company70Mai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2313)
+    }
+
+    /// Zhuhai Hoksi Technology CO.,LTD (`2314`)
+    @_alwaysEmitIntoClient
+    static var zhuhaiHoksiTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2314)
+    }
+
+    /// EMBR labs, INC (`2315`)
+    @_alwaysEmitIntoClient
+    static var embrLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2315)
+    }
+
+    /// Radiawave Technologies Co.,Ltd. (`2316`)
+    @_alwaysEmitIntoClient
+    static var radiawaveTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2316)
+    }
+
+    /// IOT Invent GmbH (`2317`)
+    @_alwaysEmitIntoClient
+    static var iotInvent: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2317)
+    }
+
+    /// OPTIMUSIOT TECH LLP (`2318`)
+    @_alwaysEmitIntoClient
+    static var optimusiotTechLlp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2318)
+    }
+
+    /// VC Inc. (`2319`)
+    @_alwaysEmitIntoClient
+    static var vc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2319)
+    }
+
+    /// ASR Microelectronics (Shanghai) Co., Ltd. (`2320`)
+    @_alwaysEmitIntoClient
+    static var asrMicroelectronicsShanghai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2320)
+    }
+
+    /// Douglas Lighting Controls Inc. (`2321`)
+    @_alwaysEmitIntoClient
+    static var douglasLightingControls: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2321)
+    }
+
+    /// Nerbio Medical Software Platforms Inc (`2322`)
+    @_alwaysEmitIntoClient
+    static var nerbioMedicalSoftwarePlatforms: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2322)
+    }
+
+    /// Braveheart Wireless, Inc. (`2323`)
+    @_alwaysEmitIntoClient
+    static var braveheartWireless: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2323)
+    }
+
+    /// INEO-SENSE (`2324`)
+    @_alwaysEmitIntoClient
+    static var ineoSense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2324)
+    }
+
+    /// Honda Motor Co., Ltd. (`2325`)
+    @_alwaysEmitIntoClient
+    static var hondaMotor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2325)
+    }
+
+    /// Ambient Sensors LLC (`2326`)
+    @_alwaysEmitIntoClient
+    static var ambientSensors: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2326)
+    }
+
+    /// ASR Microelectronics(ShenZhen)Co., Ltd. (`2327`)
+    @_alwaysEmitIntoClient
+    static var asrMicroelectronicsShenzhen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2327)
+    }
+
+    /// Technosphere Labs Pvt. Ltd. (`2328`)
+    @_alwaysEmitIntoClient
+    static var technosphereLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2328)
+    }
+
+    /// NO SMD LIMITED (`2329`)
+    @_alwaysEmitIntoClient
+    static var noSmd: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2329)
+    }
+
+    /// Albertronic BV (`2330`)
+    @_alwaysEmitIntoClient
+    static var albertronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2330)
+    }
+
+    /// Luminostics, Inc. (`2331`)
+    @_alwaysEmitIntoClient
+    static var luminostics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2331)
+    }
+
+    /// Oblamatik AG (`2332`)
+    @_alwaysEmitIntoClient
+    static var oblamatik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2332)
+    }
+
+    /// Innokind, Inc. (`2333`)
+    @_alwaysEmitIntoClient
+    static var innokind: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2333)
+    }
+
+    /// Melbot Studios, Sociedad Limitada (`2334`)
+    @_alwaysEmitIntoClient
+    static var melbotStudiosSociedadLimitada: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2334)
+    }
+
+    /// Myzee Technology (`2335`)
+    @_alwaysEmitIntoClient
+    static var myzeeTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2335)
+    }
+
+    /// Omnisense Limited (`2336`)
+    @_alwaysEmitIntoClient
+    static var omnisense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2336)
+    }
+
+    /// KAHA PTE. LTD. (`2337`)
+    @_alwaysEmitIntoClient
+    static var kahaPte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2337)
+    }
+
+    /// Shanghai MXCHIP Information Technology Co., Ltd. (`2338`)
+    @_alwaysEmitIntoClient
+    static var shanghaiMxchipInformationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2338)
+    }
+
+    /// JSB TECH PTE LTD (`2339`)
+    @_alwaysEmitIntoClient
+    static var jsbTechPte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2339)
+    }
+
+    /// Fundacion Tecnalia Research and Innovation (`2340`)
+    @_alwaysEmitIntoClient
+    static var fundacionTecnaliaResearchAndInnovation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2340)
+    }
+
+    /// Yukai Engineering Inc. (`2341`)
+    @_alwaysEmitIntoClient
+    static var yukaiEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2341)
+    }
+
+    /// Gooligum Technologies Pty Ltd (`2342`)
+    @_alwaysEmitIntoClient
+    static var gooligumTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2342)
+    }
+
+    /// ROOQ GmbH (`2343`)
+    @_alwaysEmitIntoClient
+    static var rooq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2343)
+    }
+
+    /// AiRISTA (`2344`)
+    @_alwaysEmitIntoClient
+    static var airista: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2344)
+    }
+
+    /// Qingdao Haier Technology Co., Ltd. (`2345`)
+    @_alwaysEmitIntoClient
+    static var qingdaoHaierTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2345)
+    }
+
+    /// Sappl Verwaltungs- und Betriebs GmbH (`2346`)
+    @_alwaysEmitIntoClient
+    static var sapplVerwaltungsUndBetriebs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2346)
+    }
+
+    /// TekHome (`2347`)
+    @_alwaysEmitIntoClient
+    static var tekhome: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2347)
+    }
+
+    /// PCI Private Limited (`2348`)
+    @_alwaysEmitIntoClient
+    static var pci: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2348)
+    }
+
+    /// Leggett & Platt, Incorporated (`2349`)
+    @_alwaysEmitIntoClient
+    static var leggettPlatt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2349)
+    }
+
+    /// PS GmbH (`2350`)
+    @_alwaysEmitIntoClient
+    static var ps: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2350)
+    }
+
+    /// C.O.B.O. SpA (`2351`)
+    @_alwaysEmitIntoClient
+    static var cOBOSpa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2351)
+    }
+
+    /// James Walker RotaBolt Limited (`2352`)
+    @_alwaysEmitIntoClient
+    static var jamesWalkerRotabolt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2352)
+    }
+
+    /// BREATHINGS Co., Ltd. (`2353`)
+    @_alwaysEmitIntoClient
+    static var breathings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2353)
+    }
+
+    /// BarVision, LLC (`2354`)
+    @_alwaysEmitIntoClient
+    static var barvision: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2354)
+    }
+
+    /// SRAM (`2355`)
+    @_alwaysEmitIntoClient
+    static var sram: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2355)
+    }
+
+    /// KiteSpring Inc. (`2356`)
+    @_alwaysEmitIntoClient
+    static var kitespring: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2356)
+    }
+
+    /// Reconnect, Inc. (`2357`)
+    @_alwaysEmitIntoClient
+    static var reconnect: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2357)
+    }
+
+    /// Elekon AG (`2358`)
+    @_alwaysEmitIntoClient
+    static var elekon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2358)
+    }
+
+    /// RealThingks GmbH (`2359`)
+    @_alwaysEmitIntoClient
+    static var realthingks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2359)
+    }
+
+    /// Henway Technologies, LTD. (`2360`)
+    @_alwaysEmitIntoClient
+    static var henwayTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2360)
+    }
+
+    /// ASTEM Co.,Ltd. (`2361`)
+    @_alwaysEmitIntoClient
+    static var astem: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2361)
+    }
+
+    /// LinkedSemi Microelectronics (Xiamen) Co., Ltd (`2362`)
+    @_alwaysEmitIntoClient
+    static var linkedsemiMicroelectronicsXiamen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2362)
+    }
+
+    /// ENSESO LLC (`2363`)
+    @_alwaysEmitIntoClient
+    static var enseso: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2363)
+    }
+
+    /// Xenoma Inc. (`2364`)
+    @_alwaysEmitIntoClient
+    static var xenoma: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2364)
+    }
+
+    /// Adolf Wuerth GmbH & Co KG (`2365`)
+    @_alwaysEmitIntoClient
+    static var adolfWuerth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2365)
+    }
+
+    /// Catalyft Labs, Inc. (`2366`)
+    @_alwaysEmitIntoClient
+    static var catalyftLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2366)
+    }
+
+    /// JEPICO Corporation (`2367`)
+    @_alwaysEmitIntoClient
+    static var jepico: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2367)
+    }
+
+    /// Hero Workout GmbH (`2368`)
+    @_alwaysEmitIntoClient
+    static var heroWorkout: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2368)
+    }
+
+    /// Rivian Automotive, LLC (`2369`)
+    @_alwaysEmitIntoClient
+    static var rivianAutomotive: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2369)
+    }
+
+    /// TRANSSION HOLDINGS LIMITED (`2370`)
+    @_alwaysEmitIntoClient
+    static var transsionHoldings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2370)
+    }
+
+    /// Agitron d.o.o. (`2372`)
+    @_alwaysEmitIntoClient
+    static var agitron: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2372)
+    }
+
+    /// Globe (Jiangsu) Co., Ltd (`2373`)
+    @_alwaysEmitIntoClient
+    static var globeJiangsu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2373)
+    }
+
+    /// AMC International Alfa Metalcraft Corporation AG (`2374`)
+    @_alwaysEmitIntoClient
+    static var amcInternationalAlfaMetalcraft: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2374)
+    }
+
+    /// First Light Technologies Ltd. (`2375`)
+    @_alwaysEmitIntoClient
+    static var firstLightTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2375)
+    }
+
+    /// Wearable Link Limited (`2376`)
+    @_alwaysEmitIntoClient
+    static var wearableLink: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2376)
+    }
+
+    /// Metronom Health Europe (`2377`)
+    @_alwaysEmitIntoClient
+    static var metronomHealthEurope: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2377)
+    }
+
+    /// Zwift, Inc. (`2378`)
+    @_alwaysEmitIntoClient
+    static var zwift: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2378)
+    }
+
+    /// Kindeva Drug Delivery L.P. (`2379`)
+    @_alwaysEmitIntoClient
+    static var kindevaDrugDeliveryLP: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2379)
+    }
+
+    /// GimmiSys GmbH (`2380`)
+    @_alwaysEmitIntoClient
+    static var gimmisys: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2380)
+    }
+
+    /// tkLABS INC. (`2381`)
+    @_alwaysEmitIntoClient
+    static var tklabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2381)
+    }
+
+    /// PassiveBolt, Inc. (`2382`)
+    @_alwaysEmitIntoClient
+    static var passivebolt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2382)
+    }
+
+    /// Limited Liability Company "Mikrotikls" (`2383`)
+    @_alwaysEmitIntoClient
+    static var mikrotikls: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2383)
+    }
+
+    /// Capetech (`2384`)
+    @_alwaysEmitIntoClient
+    static var capetech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2384)
+    }
+
+    /// PPRS (`2385`)
+    @_alwaysEmitIntoClient
+    static var pprs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2385)
+    }
+
+    /// Apptricity Corporation (`2386`)
+    @_alwaysEmitIntoClient
+    static var apptricity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2386)
+    }
+
+    /// LogiLube, LLC (`2387`)
+    @_alwaysEmitIntoClient
+    static var logilube: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2387)
+    }
+
+    /// Julbo (`2388`)
+    @_alwaysEmitIntoClient
+    static var julbo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2388)
+    }
+
+    /// Breville Group (`2389`)
+    @_alwaysEmitIntoClient
+    static var brevilleGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2389)
+    }
+
+    /// Kerlink (`2390`)
+    @_alwaysEmitIntoClient
+    static var kerlink: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2390)
+    }
+
+    /// Ohsung Electronics (`2391`)
+    @_alwaysEmitIntoClient
+    static var ohsungElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2391)
+    }
+
+    /// ZTE Corporation (`2392`)
+    @_alwaysEmitIntoClient
+    static var zte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2392)
+    }
+
+    /// HerdDogg, Inc (`2393`)
+    @_alwaysEmitIntoClient
+    static var herddogg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2393)
+    }
+
+    /// Selekt Bilgisayar, lletisim Urunleri lnsaat Sanayi ve Ticaret Limited Sirketi (`2394`)
+    @_alwaysEmitIntoClient
+    static var selektBilgisayarLletisimUrunleriLnsaatSanayiVeTicaretSirketi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2394)
+    }
+
+    /// Lismore Instruments Limited (`2395`)
+    @_alwaysEmitIntoClient
+    static var lismoreInstruments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2395)
+    }
+
+    /// LogiLube, LLC (`2396`)
+    @_alwaysEmitIntoClient
+    static var logilube2: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2396)
+    }
+
+    /// Electronic Theatre Controls (`2397`)
+    @_alwaysEmitIntoClient
+    static var electronicTheatreControls: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2397)
+    }
+
+    /// BioEchoNet inc. (`2398`)
+    @_alwaysEmitIntoClient
+    static var bioechonet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2398)
+    }
+
+    /// NUANCE HEARING LTD (`2399`)
+    @_alwaysEmitIntoClient
+    static var nuanceHearing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2399)
+    }
+
+    /// Sena Technologies Inc. (`2400`)
+    @_alwaysEmitIntoClient
+    static var senaTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2400)
+    }
+
+    /// Linkura AB (`2401`)
+    @_alwaysEmitIntoClient
+    static var linkura: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2401)
+    }
+
+    /// GL Solutions K.K. (`2402`)
+    @_alwaysEmitIntoClient
+    static var glSolutionsKK: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2402)
+    }
+
+    /// Moonbird BV (`2403`)
+    @_alwaysEmitIntoClient
+    static var moonbird: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2403)
+    }
+
+    /// Countrymate Technology Limited (`2404`)
+    @_alwaysEmitIntoClient
+    static var countrymateTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2404)
+    }
+
+    /// Asahi Kasei Corporation (`2405`)
+    @_alwaysEmitIntoClient
+    static var asahiKasei: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2405)
+    }
+
+    /// PointGuard, LLC (`2406`)
+    @_alwaysEmitIntoClient
+    static var pointguard: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2406)
+    }
+
+    /// Neo Materials and Consulting Inc. (`2407`)
+    @_alwaysEmitIntoClient
+    static var neoMaterialsAndConsulting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2407)
+    }
+
+    /// Actev Motors, Inc. (`2408`)
+    @_alwaysEmitIntoClient
+    static var actevMotors: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2408)
+    }
+
+    /// Woan Technology (Shenzhen) Co., Ltd. (`2409`)
+    @_alwaysEmitIntoClient
+    static var woanTechnologyShenzhen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2409)
+    }
+
+    /// dricos, Inc. (`2410`)
+    @_alwaysEmitIntoClient
+    static var dricos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2410)
+    }
+
+    /// Guide ID B.V. (`2411`)
+    @_alwaysEmitIntoClient
+    static var guideId: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2411)
+    }
+
+    /// 9374-7319 Quebec inc (`2412`)
+    @_alwaysEmitIntoClient
+    static var company93747319Quebec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2412)
+    }
+
+    /// Gunwerks, LLC (`2413`)
+    @_alwaysEmitIntoClient
+    static var gunwerks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2413)
+    }
+
+    /// Band Industries, inc. (`2414`)
+    @_alwaysEmitIntoClient
+    static var bandIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2414)
+    }
+
+    /// Lund Motion Products, Inc. (`2415`)
+    @_alwaysEmitIntoClient
+    static var lundMotionProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2415)
+    }
+
+    /// IBA Dosimetry GmbH (`2416`)
+    @_alwaysEmitIntoClient
+    static var ibaDosimetry: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2416)
+    }
+
+    /// GA (`2417`)
+    @_alwaysEmitIntoClient
+    static var ga: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2417)
+    }
+
+    /// Closed Joint Stock Company "Zavod Flometr" ("Zavod Flometr" CJSC) (`2418`)
+    @_alwaysEmitIntoClient
+    static var zavodFlometrZavodFlometrCjsc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2418)
+    }
+
+    /// Popit Oy (`2419`)
+    @_alwaysEmitIntoClient
+    static var popit: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2419)
+    }
+
+    /// ABEYE (`2420`)
+    @_alwaysEmitIntoClient
+    static var abeye: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2420)
+    }
+
+    /// BlueIOT(Beijing) Technology Co.,Ltd (`2421`)
+    @_alwaysEmitIntoClient
+    static var blueiotBeijingTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2421)
+    }
+
+    /// Fauna Audio GmbH (`2422`)
+    @_alwaysEmitIntoClient
+    static var faunaAudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2422)
+    }
+
+    /// TOYOTA motor corporation (`2423`)
+    @_alwaysEmitIntoClient
+    static var toyotaMotor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2423)
+    }
+
+    /// ZifferEins GmbH & Co. KG (`2424`)
+    @_alwaysEmitIntoClient
+    static var ziffereins: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2424)
+    }
+
+    /// BIOTRONIK SE & Co. KG (`2425`)
+    @_alwaysEmitIntoClient
+    static var biotronikSeKg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2425)
+    }
+
+    /// CORE CORPORATION (`2426`)
+    @_alwaysEmitIntoClient
+    static var core: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2426)
+    }
+
+    /// CTEK Sweden AB (`2427`)
+    @_alwaysEmitIntoClient
+    static var ctekSweden: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2427)
+    }
+
+    /// Thorley Industries, LLC (`2428`)
+    @_alwaysEmitIntoClient
+    static var thorleyIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2428)
+    }
+
+    /// CLB B.V. (`2429`)
+    @_alwaysEmitIntoClient
+    static var clb: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2429)
+    }
+
+    /// SonicSensory Inc (`2430`)
+    @_alwaysEmitIntoClient
+    static var sonicsensory: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2430)
+    }
+
+    /// ISEMAR S.R.L. (`2431`)
+    @_alwaysEmitIntoClient
+    static var isemar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2431)
+    }
+
+    /// DEKRA TESTING AND CERTIFICATION, S.A.U. (`2432`)
+    @_alwaysEmitIntoClient
+    static var dekraTestingAndCertificationU: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2432)
+    }
+
+    /// Bernard Krone Holding SE & Co.KG (`2433`)
+    @_alwaysEmitIntoClient
+    static var bernardKroneHoldingSeKg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2433)
+    }
+
+    /// ELPRO-BUCHS AG (`2434`)
+    @_alwaysEmitIntoClient
+    static var elproBuchs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2434)
+    }
+
+    /// Feedback Sports LLC (`2435`)
+    @_alwaysEmitIntoClient
+    static var feedbackSports: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2435)
+    }
+
+    /// TeraTron GmbH (`2436`)
+    @_alwaysEmitIntoClient
+    static var teratron: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2436)
+    }
+
+    /// Lumos Health Inc. (`2437`)
+    @_alwaysEmitIntoClient
+    static var lumosHealth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2437)
+    }
+
+    /// Cello Hill, LLC (`2438`)
+    @_alwaysEmitIntoClient
+    static var celloHill: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2438)
+    }
+
+    /// TSE BRAKES, INC. (`2439`)
+    @_alwaysEmitIntoClient
+    static var tseBrakes: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2439)
+    }
+
+    /// BHM-Tech Produktionsgesellschaft m.b.H (`2440`)
+    @_alwaysEmitIntoClient
+    static var bhmTechProduktionsgesellschaftMBH: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2440)
+    }
+
+    /// WIKA Alexander Wiegand SE & Co.KG (`2441`)
+    @_alwaysEmitIntoClient
+    static var wikaAlexanderWiegandSeKg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2441)
+    }
+
+    /// Biovigil (`2442`)
+    @_alwaysEmitIntoClient
+    static var biovigil: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2442)
+    }
+
+    /// Mequonic Engineering, S.L. (`2443`)
+    @_alwaysEmitIntoClient
+    static var mequonicEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2443)
+    }
+
+    /// bGrid B.V. (`2444`)
+    @_alwaysEmitIntoClient
+    static var bgrid: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2444)
+    }
+
+    /// C3-WIRELESS, LLC (`2445`)
+    @_alwaysEmitIntoClient
+    static var c3Wireless: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2445)
+    }
+
+    /// ADVEEZ (`2446`)
+    @_alwaysEmitIntoClient
+    static var adveez: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2446)
+    }
+
+    /// Aktiebolaget Regin (`2447`)
+    @_alwaysEmitIntoClient
+    static var aktiebolagetRegin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2447)
+    }
+
+    /// Anton Paar GmbH (`2448`)
+    @_alwaysEmitIntoClient
+    static var antonPaar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2448)
+    }
+
+    /// Telenor ASA (`2449`)
+    @_alwaysEmitIntoClient
+    static var telenor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2449)
+    }
+
+    /// Big Kaiser Precision Tooling Ltd (`2450`)
+    @_alwaysEmitIntoClient
+    static var bigKaiserPrecisionTooling: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2450)
+    }
+
+    /// Absolute Audio Labs B.V. (`2451`)
+    @_alwaysEmitIntoClient
+    static var absoluteAudioLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2451)
+    }
+
+    /// VT42 Pty Ltd (`2452`)
+    @_alwaysEmitIntoClient
+    static var vt42: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2452)
+    }
+
+    /// Bronkhorst High-Tech B.V. (`2453`)
+    @_alwaysEmitIntoClient
+    static var bronkhorstHighTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2453)
+    }
+
+    /// C. & E. Fein GmbH (`2454`)
+    @_alwaysEmitIntoClient
+    static var cEFein: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2454)
+    }
+
+    /// NextMind (`2455`)
+    @_alwaysEmitIntoClient
+    static var nextmind: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2455)
+    }
+
+    /// Pixie Dust Technologies, Inc. (`2456`)
+    @_alwaysEmitIntoClient
+    static var pixieDustTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2456)
+    }
+
+    /// eTactica ehf (`2457`)
+    @_alwaysEmitIntoClient
+    static var etacticaEhf: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2457)
+    }
+
+    /// New Audio LLC (`2458`)
+    @_alwaysEmitIntoClient
+    static var newAudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2458)
+    }
+
+    /// Sendum Wireless Corporation (`2459`)
+    @_alwaysEmitIntoClient
+    static var sendumWireless: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2459)
+    }
+
+    /// deister electronic GmbH (`2460`)
+    @_alwaysEmitIntoClient
+    static var deisterElectronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2460)
+    }
+
+    /// YKK AP Inc. (`2461`)
+    @_alwaysEmitIntoClient
+    static var ykkAp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2461)
+    }
+
+    /// Step One Limited (`2462`)
+    @_alwaysEmitIntoClient
+    static var stepOne: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2462)
+    }
+
+    /// Koya Medical, Inc. (`2463`)
+    @_alwaysEmitIntoClient
+    static var koyaMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2463)
+    }
+
+    /// Proof Diagnostics, Inc. (`2464`)
+    @_alwaysEmitIntoClient
+    static var proofDiagnostics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2464)
+    }
+
+    /// VOS Systems, LLC (`2465`)
+    @_alwaysEmitIntoClient
+    static var vosSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2465)
+    }
+
+    /// ENGAGENOW DATA SCIENCES PRIVATE LIMITED (`2466`)
+    @_alwaysEmitIntoClient
+    static var engagenowDataSciences: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2466)
+    }
+
+    /// ARDUINO SA (`2467`)
+    @_alwaysEmitIntoClient
+    static var arduino: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2467)
+    }
+
+    /// KUMHO ELECTRICS, INC (`2468`)
+    @_alwaysEmitIntoClient
+    static var kumhoElectrics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2468)
+    }
+
+    /// Security Enhancement Systems, LLC (`2469`)
+    @_alwaysEmitIntoClient
+    static var securityEnhancementSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2469)
+    }
+
+    /// BEIJING ELECTRIC VEHICLE CO.,LTD (`2470`)
+    @_alwaysEmitIntoClient
+    static var beijingElectricVehicle: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2470)
+    }
+
+    /// Paybuddy ApS (`2471`)
+    @_alwaysEmitIntoClient
+    static var paybuddy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2471)
+    }
+
+    /// KHN Solutions LLC (`2472`)
+    @_alwaysEmitIntoClient
+    static var khnSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2472)
+    }
+
+    /// Nippon Ceramic Co.,Ltd. (`2473`)
+    @_alwaysEmitIntoClient
+    static var nipponCeramic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2473)
+    }
+
+    /// PHOTODYNAMIC INCORPORATED (`2474`)
+    @_alwaysEmitIntoClient
+    static var photodynamic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2474)
+    }
+
+    /// DashLogic, Inc. (`2475`)
+    @_alwaysEmitIntoClient
+    static var dashlogic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2475)
+    }
+
+    /// Ambiq (`2476`)
+    @_alwaysEmitIntoClient
+    static var ambiq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2476)
+    }
+
+    /// Narhwall Inc. (`2477`)
+    @_alwaysEmitIntoClient
+    static var narhwall: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2477)
+    }
+
+    /// Pozyx NV (`2478`)
+    @_alwaysEmitIntoClient
+    static var pozyx: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2478)
+    }
+
+    /// ifLink Open Community (`2479`)
+    @_alwaysEmitIntoClient
+    static var iflinkOpenCommunity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2479)
+    }
+
+    /// Deublin Company, LLC (`2480`)
+    @_alwaysEmitIntoClient
+    static var deublin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2480)
+    }
+
+    /// BLINQY (`2481`)
+    @_alwaysEmitIntoClient
+    static var blinqy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2481)
+    }
+
+    /// DYPHI (`2482`)
+    @_alwaysEmitIntoClient
+    static var dyphi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2482)
+    }
+
+    /// BlueX Microelectronics Corp Ltd. (`2483`)
+    @_alwaysEmitIntoClient
+    static var bluexMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2483)
+    }
+
+    /// PentaLock Aps. (`2484`)
+    @_alwaysEmitIntoClient
+    static var pentalock: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2484)
+    }
+
+    /// AUTEC Gesellschaft fuer Automationstechnik mbH (`2485`)
+    @_alwaysEmitIntoClient
+    static var autecGesellschaftFuerAutomationstechnik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2485)
+    }
+
+    /// Pegasus Technologies, Inc. (`2486`)
+    @_alwaysEmitIntoClient
+    static var pegasusTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2486)
+    }
+
+    /// Bout Labs, LLC (`2487`)
+    @_alwaysEmitIntoClient
+    static var boutLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2487)
+    }
+
+    /// PlayerData Limited (`2488`)
+    @_alwaysEmitIntoClient
+    static var playerdata: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2488)
+    }
+
+    /// SAVOY ELECTRONIC LIGHTING (`2489`)
+    @_alwaysEmitIntoClient
+    static var savoyElectronicLighting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2489)
+    }
+
+    /// Elimo Engineering Ltd (`2490`)
+    @_alwaysEmitIntoClient
+    static var elimoEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2490)
+    }
+
+    /// SkyStream Corporation (`2491`)
+    @_alwaysEmitIntoClient
+    static var skystream: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2491)
+    }
+
+    /// Aerosens LLC (`2492`)
+    @_alwaysEmitIntoClient
+    static var aerosens: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2492)
+    }
+
+    /// Centre Suisse d'Electronique et de Microtechnique SA (`2493`)
+    @_alwaysEmitIntoClient
+    static var centreSuisseDElectroniqueEtDeMicrotechnique: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2493)
+    }
+
+    /// Vessel Ltd. (`2494`)
+    @_alwaysEmitIntoClient
+    static var vessel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2494)
+    }
+
+    /// Span.IO, Inc. (`2495`)
+    @_alwaysEmitIntoClient
+    static var spanIo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2495)
+    }
+
+    /// AnotherBrain inc. (`2496`)
+    @_alwaysEmitIntoClient
+    static var anotherbrain: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2496)
+    }
+
+    /// Rosewill (`2497`)
+    @_alwaysEmitIntoClient
+    static var rosewill: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2497)
+    }
+
+    /// Universal Audio, Inc. (`2498`)
+    @_alwaysEmitIntoClient
+    static var universalAudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2498)
+    }
+
+    /// JAPAN TOBACCO INC. (`2499`)
+    @_alwaysEmitIntoClient
+    static var japanTobacco: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2499)
+    }
+
+    /// UVISIO (`2500`)
+    @_alwaysEmitIntoClient
+    static var uvisio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2500)
+    }
+
+    /// HungYi Microelectronics Co.,Ltd. (`2501`)
+    @_alwaysEmitIntoClient
+    static var hungyiMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2501)
+    }
+
+    /// Honor Device Co., Ltd. (`2502`)
+    @_alwaysEmitIntoClient
+    static var honorDevice: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2502)
+    }
+
+    /// Combustion, LLC (`2503`)
+    @_alwaysEmitIntoClient
+    static var combustion: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2503)
+    }
+
+    /// XUNTONG (`2504`)
+    @_alwaysEmitIntoClient
+    static var xuntong: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2504)
+    }
+
+    /// CrowdGlow Ltd (`2505`)
+    @_alwaysEmitIntoClient
+    static var crowdglow: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2505)
+    }
+
+    /// Mobitrace (`2506`)
+    @_alwaysEmitIntoClient
+    static var mobitrace: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2506)
+    }
+
+    /// Hx Engineering, LLC (`2507`)
+    @_alwaysEmitIntoClient
+    static var hxEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2507)
+    }
+
+    /// Senso4s d.o.o. (`2508`)
+    @_alwaysEmitIntoClient
+    static var senso4S: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2508)
+    }
+
+    /// Blyott (`2509`)
+    @_alwaysEmitIntoClient
+    static var blyott: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2509)
+    }
+
+    /// Julius Blum GmbH (`2510`)
+    @_alwaysEmitIntoClient
+    static var juliusBlum: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2510)
+    }
+
+    /// BlueStreak IoT, LLC (`2511`)
+    @_alwaysEmitIntoClient
+    static var bluestreakIot: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2511)
+    }
+
+    /// Chess Wise B.V. (`2512`)
+    @_alwaysEmitIntoClient
+    static var chessWise: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2512)
+    }
+
+    /// ABLEPAY TECHNOLOGIES AS (`2513`)
+    @_alwaysEmitIntoClient
+    static var ablepayTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2513)
+    }
+
+    /// Temperature Sensitive Solutions Systems Sweden AB (`2514`)
+    @_alwaysEmitIntoClient
+    static var temperatureSensitiveSolutionsSystemsSweden: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2514)
+    }
+
+    /// HeartHero, inc. (`2515`)
+    @_alwaysEmitIntoClient
+    static var hearthero: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2515)
+    }
+
+    /// ORBIS Inc. (`2516`)
+    @_alwaysEmitIntoClient
+    static var orbis: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2516)
+    }
+
+    /// GEAR RADIO ELECTRONICS CORP. (`2517`)
+    @_alwaysEmitIntoClient
+    static var gearRadioElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2517)
+    }
+
+    /// EAR TEKNIK ISITME VE ODIOMETRI CIHAZLARI SANAYI VE TICARET ANONIM SIRKETI (`2518`)
+    @_alwaysEmitIntoClient
+    static var earTeknikIsitmeVeOdiometriCihazlarinayiVeTicaretAnonimSirketi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2518)
+    }
+
+    /// Coyotta (`2519`)
+    @_alwaysEmitIntoClient
+    static var coyotta: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2519)
+    }
+
+    /// Synergy Tecnologia em Sistemas Ltda (`2520`)
+    @_alwaysEmitIntoClient
+    static var synergyTecnologiaEmSistemas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2520)
+    }
+
+    /// VivoSensMedical GmbH (`2521`)
+    @_alwaysEmitIntoClient
+    static var vivosensmedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2521)
+    }
+
+    /// Nagravision SA (`2522`)
+    @_alwaysEmitIntoClient
+    static var nagravision: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2522)
+    }
+
+    /// Bionic Avionics Inc. (`2523`)
+    @_alwaysEmitIntoClient
+    static var bionicAvionics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2523)
+    }
+
+    /// AON2 Ltd. (`2524`)
+    @_alwaysEmitIntoClient
+    static var aon2: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2524)
+    }
+
+    /// Innoware Development AB (`2525`)
+    @_alwaysEmitIntoClient
+    static var innowareDevelopment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2525)
+    }
+
+    /// JLD Technology Solutions, LLC (`2526`)
+    @_alwaysEmitIntoClient
+    static var jldTechnologySolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2526)
+    }
+
+    /// Magnus Technology Sdn Bhd (`2527`)
+    @_alwaysEmitIntoClient
+    static var magnusTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2527)
+    }
+
+    /// Preddio Technologies Inc. (`2528`)
+    @_alwaysEmitIntoClient
+    static var preddioTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2528)
+    }
+
+    /// Tag-N-Trac Inc (`2529`)
+    @_alwaysEmitIntoClient
+    static var tagNTrac: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2529)
+    }
+
+    /// Wuhan Linptech Co.,Ltd. (`2530`)
+    @_alwaysEmitIntoClient
+    static var wuhanLinptech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2530)
+    }
+
+    /// Friday Home Aps (`2531`)
+    @_alwaysEmitIntoClient
+    static var fridayHome: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2531)
+    }
+
+    /// CPS AS (`2532`)
+    @_alwaysEmitIntoClient
+    static var cps: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2532)
+    }
+
+    /// Mobilogix (`2533`)
+    @_alwaysEmitIntoClient
+    static var mobilogix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2533)
+    }
+
+    /// Masonite Corporation (`2534`)
+    @_alwaysEmitIntoClient
+    static var masonite: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2534)
+    }
+
+    /// Kabushikigaisha HANERON (`2535`)
+    @_alwaysEmitIntoClient
+    static var kabushikigaishaHaneron: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2535)
+    }
+
+    /// Melange Systems Pvt. Ltd. (`2536`)
+    @_alwaysEmitIntoClient
+    static var melangeSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2536)
+    }
+
+    /// LumenRadio AB (`2537`)
+    @_alwaysEmitIntoClient
+    static var lumenradio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2537)
+    }
+
+    /// Athlos Oy (`2538`)
+    @_alwaysEmitIntoClient
+    static var athlos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2538)
+    }
+
+    /// KEAN ELECTRONICS PTY LTD (`2539`)
+    @_alwaysEmitIntoClient
+    static var keanElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2539)
+    }
+
+    /// Yukon advanced optics worldwide, UAB (`2540`)
+    @_alwaysEmitIntoClient
+    static var yukonAdvancedOpticsWorldwideUab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2540)
+    }
+
+    /// Sibel Inc. (`2541`)
+    @_alwaysEmitIntoClient
+    static var sibel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2541)
+    }
+
+    /// OJMAR SA (`2542`)
+    @_alwaysEmitIntoClient
+    static var ojmar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2542)
+    }
+
+    /// Steinel Solutions AG (`2543`)
+    @_alwaysEmitIntoClient
+    static var steinelSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2543)
+    }
+
+    /// WatchGas B.V. (`2544`)
+    @_alwaysEmitIntoClient
+    static var watchgas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2544)
+    }
+
+    /// OM Digital Solutions Corporation (`2545`)
+    @_alwaysEmitIntoClient
+    static var omDigitalSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2545)
+    }
+
+    /// Audeara Pty Ltd (`2546`)
+    @_alwaysEmitIntoClient
+    static var audeara: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2546)
+    }
+
+    /// Beijing Zero Zero Infinity Technology Co.,Ltd. (`2547`)
+    @_alwaysEmitIntoClient
+    static var beijingZeroZeroInfinityTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2547)
+    }
+
+    /// Spectrum Technologies, Inc. (`2548`)
+    @_alwaysEmitIntoClient
+    static var spectrumTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2548)
+    }
+
+    /// OKI Electric Industry Co., Ltd (`2549`)
+    @_alwaysEmitIntoClient
+    static var okiElectricIndustry: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2549)
+    }
+
+    /// Mobile Action Technology Inc. (`2550`)
+    @_alwaysEmitIntoClient
+    static var mobileActionTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2550)
+    }
+
+    /// SENSATEC Co., Ltd. (`2551`)
+    @_alwaysEmitIntoClient
+    static var sensatec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2551)
+    }
+
+    /// R.O. S.R.L. (`2552`)
+    @_alwaysEmitIntoClient
+    static var rO: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2552)
+    }
+
+    /// Hangzhou Yaguan Technology Co. LTD (`2553`)
+    @_alwaysEmitIntoClient
+    static var hangzhouYaguanTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2553)
+    }
+
+    /// Listen Technologies Corporation (`2554`)
+    @_alwaysEmitIntoClient
+    static var listenTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2554)
+    }
+
+    /// TOITU CO., LTD. (`2555`)
+    @_alwaysEmitIntoClient
+    static var toitu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2555)
+    }
+
+    /// Confidex (`2556`)
+    @_alwaysEmitIntoClient
+    static var confidex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2556)
+    }
+
+    /// Keep Technologies, Inc. (`2557`)
+    @_alwaysEmitIntoClient
+    static var keepTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2557)
+    }
+
+    /// Lichtvision Engineering GmbH (`2558`)
+    @_alwaysEmitIntoClient
+    static var lichtvisionEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2558)
+    }
+
+    /// AIRSTAR (`2559`)
+    @_alwaysEmitIntoClient
+    static var airstar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2559)
+    }
+
+    /// Ampler Bikes OU (`2560`)
+    @_alwaysEmitIntoClient
+    static var amplerBikesOu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2560)
+    }
+
+    /// Cleveron AS (`2561`)
+    @_alwaysEmitIntoClient
+    static var cleveron: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2561)
+    }
+
+    /// Ayxon-Dynamics GmbH (`2562`)
+    @_alwaysEmitIntoClient
+    static var ayxonDynamics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2562)
+    }
+
+    /// donutrobotics Co., Ltd. (`2563`)
+    @_alwaysEmitIntoClient
+    static var donutrobotics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2563)
+    }
+
+    /// Flosonics Medical (`2564`)
+    @_alwaysEmitIntoClient
+    static var flosonicsMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2564)
+    }
+
+    /// Southwire Company, LLC (`2565`)
+    @_alwaysEmitIntoClient
+    static var southwire: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2565)
+    }
+
+    /// Shanghai wuqi microelectronics Co.,Ltd (`2566`)
+    @_alwaysEmitIntoClient
+    static var shanghaiWuqiMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2566)
+    }
+
+    /// Reflow Pty Ltd (`2567`)
+    @_alwaysEmitIntoClient
+    static var reflow: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2567)
+    }
+
+    /// Oras Oy (`2568`)
+    @_alwaysEmitIntoClient
+    static var oras: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2568)
+    }
+
+    /// ECCT (`2569`)
+    @_alwaysEmitIntoClient
+    static var ecct: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2569)
+    }
+
+    /// Volan Technology Inc. (`2570`)
+    @_alwaysEmitIntoClient
+    static var volanTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2570)
+    }
+
+    /// SIANA Systems (`2571`)
+    @_alwaysEmitIntoClient
+    static var sianaSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2571)
+    }
+
+    /// Shanghai Yidian Intelligent Technology Co., Ltd. (`2572`)
+    @_alwaysEmitIntoClient
+    static var shanghaiYidianIntelligentTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2572)
+    }
+
+    /// Blue Peacock GmbH (`2573`)
+    @_alwaysEmitIntoClient
+    static var bluePeacock: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2573)
+    }
+
+    /// Roland Corporation (`2574`)
+    @_alwaysEmitIntoClient
+    static var roland: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2574)
+    }
+
+    /// LIXIL Corporation (`2575`)
+    @_alwaysEmitIntoClient
+    static var lixil: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2575)
+    }
+
+    /// SUBARU Corporation (`2576`)
+    @_alwaysEmitIntoClient
+    static var subaru: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2576)
+    }
+
+    /// Sensolus (`2577`)
+    @_alwaysEmitIntoClient
+    static var sensolus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2577)
+    }
+
+    /// Dyson Technology Limited (`2578`)
+    @_alwaysEmitIntoClient
+    static var dysonTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2578)
+    }
+
+    /// Tec4med LifeScience GmbH (`2579`)
+    @_alwaysEmitIntoClient
+    static var tec4MedLifescience: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2579)
+    }
+
+    /// CROXEL, INC. (`2580`)
+    @_alwaysEmitIntoClient
+    static var croxel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2580)
+    }
+
+    /// Syng Inc (`2581`)
+    @_alwaysEmitIntoClient
+    static var syng: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2581)
+    }
+
+    /// RIDE VISION LTD (`2582`)
+    @_alwaysEmitIntoClient
+    static var rideVision: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2582)
+    }
+
+    /// Plume Design Inc (`2583`)
+    @_alwaysEmitIntoClient
+    static var plumeDesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2583)
+    }
+
+    /// Cambridge Animal Technologies Ltd (`2584`)
+    @_alwaysEmitIntoClient
+    static var cambridgeAnimalTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2584)
+    }
+
+    /// Maxell, Ltd. (`2585`)
+    @_alwaysEmitIntoClient
+    static var maxell: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2585)
+    }
+
+    /// Link Labs, Inc. (`2586`)
+    @_alwaysEmitIntoClient
+    static var linkLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2586)
+    }
+
+    /// Embrava Pty Ltd (`2587`)
+    @_alwaysEmitIntoClient
+    static var embrava: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2587)
+    }
+
+    /// INPEAK S.C. (`2588`)
+    @_alwaysEmitIntoClient
+    static var inpeakSC: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2588)
+    }
+
+    /// API-K (`2589`)
+    @_alwaysEmitIntoClient
+    static var apiK: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2589)
+    }
+
+    /// CombiQ AB (`2590`)
+    @_alwaysEmitIntoClient
+    static var combiq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2590)
+    }
+
+    /// DeVilbiss Healthcare LLC (`2591`)
+    @_alwaysEmitIntoClient
+    static var devilbissHealthcare: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2591)
+    }
+
+    /// Jiangxi Innotech Technology Co., Ltd (`2592`)
+    @_alwaysEmitIntoClient
+    static var jiangxiInnotechTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2592)
+    }
+
+    /// Apollogic Sp. z o.o. (`2593`)
+    @_alwaysEmitIntoClient
+    static var apollogic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2593)
+    }
+
+    /// DAIICHIKOSHO CO., LTD. (`2594`)
+    @_alwaysEmitIntoClient
+    static var daiichikosho: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2594)
+    }
+
+    /// BIXOLON CO.,LTD (`2595`)
+    @_alwaysEmitIntoClient
+    static var bixolon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2595)
+    }
+
+    /// Atmosic Technologies, Inc. (`2596`)
+    @_alwaysEmitIntoClient
+    static var atmosicTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2596)
+    }
+
+    /// Eran Financial Services LLC (`2597`)
+    @_alwaysEmitIntoClient
+    static var eranFinancialServices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2597)
+    }
+
+    /// Louis Vuitton (`2598`)
+    @_alwaysEmitIntoClient
+    static var louisVuitton: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2598)
+    }
+
+    /// AYU DEVICES PRIVATE LIMITED (`2599`)
+    @_alwaysEmitIntoClient
+    static var ayuDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2599)
+    }
+
+    /// NanoFlex Power Corporation (`2600`)
+    @_alwaysEmitIntoClient
+    static var nanoflexPower: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2600)
+    }
+
+    /// Worthcloud Technology Co.,Ltd (`2601`)
+    @_alwaysEmitIntoClient
+    static var worthcloudTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2601)
+    }
+
+    /// Yamaha Corporation (`2602`)
+    @_alwaysEmitIntoClient
+    static var yamaha: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2602)
+    }
+
+    /// PaceBait IVS (`2603`)
+    @_alwaysEmitIntoClient
+    static var pacebait: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2603)
+    }
+
+    /// Shenzhen H&T Intelligent Control Co., Ltd (`2604`)
+    @_alwaysEmitIntoClient
+    static var shenzhenHTIntelligentControl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2604)
+    }
+
+    /// Shenzhen Feasycom Technology Co., Ltd. (`2605`)
+    @_alwaysEmitIntoClient
+    static var shenzhenFeasycomTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2605)
+    }
+
+    /// Zuma Array Limited (`2606`)
+    @_alwaysEmitIntoClient
+    static var zumaArray: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2606)
+    }
+
+    /// Instamic, Inc. (`2607`)
+    @_alwaysEmitIntoClient
+    static var instamic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2607)
+    }
+
+    /// Air-Weigh (`2608`)
+    @_alwaysEmitIntoClient
+    static var airWeigh: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2608)
+    }
+
+    /// Nevro Corp. (`2609`)
+    @_alwaysEmitIntoClient
+    static var nevro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2609)
+    }
+
+    /// Pinnacle Technology, Inc. (`2610`)
+    @_alwaysEmitIntoClient
+    static var pinnacleTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2610)
+    }
+
+    /// WMF AG (`2611`)
+    @_alwaysEmitIntoClient
+    static var wmf: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2611)
+    }
+
+    /// Luxer Corporation (`2612`)
+    @_alwaysEmitIntoClient
+    static var luxer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2612)
+    }
+
+    /// safectory GmbH (`2613`)
+    @_alwaysEmitIntoClient
+    static var safectory: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2613)
+    }
+
+    /// NGK SPARK PLUG CO., LTD. (`2614`)
+    @_alwaysEmitIntoClient
+    static var ngkSparkPlug: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2614)
+    }
+
+    /// 2587702 Ontario Inc. (`2615`)
+    @_alwaysEmitIntoClient
+    static var company2587702Ontario: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2615)
+    }
+
+    /// Bouffalo Lab (Nanjing)., Ltd. (`2616`)
+    @_alwaysEmitIntoClient
+    static var bouffaloLabNanjing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2616)
+    }
+
+    /// BLUETICKETING SRL (`2617`)
+    @_alwaysEmitIntoClient
+    static var blueticketing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2617)
+    }
+
+    /// Incotex Co. Ltd. (`2618`)
+    @_alwaysEmitIntoClient
+    static var incotex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2618)
+    }
+
+    /// Galileo Technology Limited (`2619`)
+    @_alwaysEmitIntoClient
+    static var galileoTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2619)
+    }
+
+    /// Siteco GmbH (`2620`)
+    @_alwaysEmitIntoClient
+    static var siteco: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2620)
+    }
+
+    /// DELABIE (`2621`)
+    @_alwaysEmitIntoClient
+    static var delabie: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2621)
+    }
+
+    /// Hefei Yunlian Semiconductor Co., Ltd (`2622`)
+    @_alwaysEmitIntoClient
+    static var hefeiYunlianSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2622)
+    }
+
+    /// Shenzhen Yopeak Optoelectronics Technology Co., Ltd. (`2623`)
+    @_alwaysEmitIntoClient
+    static var shenzhenYopeakOptoelectronicsTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2623)
+    }
+
+    /// GEWISS S.p.A. (`2624`)
+    @_alwaysEmitIntoClient
+    static var gewiss: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2624)
+    }
+
+    /// OPEX Corporation (`2625`)
+    @_alwaysEmitIntoClient
+    static var opex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2625)
+    }
+
+    /// Motionalysis, Inc. (`2626`)
+    @_alwaysEmitIntoClient
+    static var motionalysis: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2626)
+    }
+
+    /// Busch Systems International Inc. (`2627`)
+    @_alwaysEmitIntoClient
+    static var buschSystemsInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2627)
+    }
+
+    /// Novidan, Inc. (`2628`)
+    @_alwaysEmitIntoClient
+    static var novidan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2628)
+    }
+
+    /// 3SI Security Systems, Inc (`2629`)
+    @_alwaysEmitIntoClient
+    static var company3SiSecuritySystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2629)
+    }
+
+    /// Beijing HC-Infinite Technology Limited (`2630`)
+    @_alwaysEmitIntoClient
+    static var beijingHcInfiniteTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2630)
+    }
+
+    /// The Wand Company Ltd (`2631`)
+    @_alwaysEmitIntoClient
+    static var wandcompany: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2631)
+    }
+
+    /// JRC Mobility Inc. (`2632`)
+    @_alwaysEmitIntoClient
+    static var jrcMobility: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2632)
+    }
+
+    /// Venture Research Inc. (`2633`)
+    @_alwaysEmitIntoClient
+    static var ventureResearch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2633)
+    }
+
+    /// Map Large, Inc. (`2634`)
+    @_alwaysEmitIntoClient
+    static var mapLarge: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2634)
+    }
+
+    /// MistyWest Energy and Transport Ltd. (`2635`)
+    @_alwaysEmitIntoClient
+    static var mistywestEnergyAndTransport: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2635)
+    }
+
+    /// SiFli Technologies (shanghai) Inc. (`2636`)
+    @_alwaysEmitIntoClient
+    static var sifliTechnologiesShanghai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2636)
+    }
+
+    /// Lockn Technologies Private Limited (`2637`)
+    @_alwaysEmitIntoClient
+    static var locknTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2637)
+    }
+
+    /// Toytec Corporation (`2638`)
+    @_alwaysEmitIntoClient
+    static var toytec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2638)
+    }
+
+    /// VANMOOF Global Holding B.V. (`2639`)
+    @_alwaysEmitIntoClient
+    static var vanmoofGlobalHolding: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2639)
+    }
+
+    /// Nextscape Inc. (`2640`)
+    @_alwaysEmitIntoClient
+    static var nextscape: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2640)
+    }
+
+    /// CSIRO (`2641`)
+    @_alwaysEmitIntoClient
+    static var csiro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2641)
+    }
+
+    /// Follow Sense Europe B.V. (`2642`)
+    @_alwaysEmitIntoClient
+    static var followSenseEurope: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2642)
+    }
+
+    /// KKM COMPANY LIMITED (`2643`)
+    @_alwaysEmitIntoClient
+    static var kkm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2643)
+    }
+
+    /// SQL Technologies Corp. (`2644`)
+    @_alwaysEmitIntoClient
+    static var sqlTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2644)
+    }
+
+    /// Inugo Systems Limited (`2645`)
+    @_alwaysEmitIntoClient
+    static var inugoSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2645)
+    }
+
+    /// ambie (`2646`)
+    @_alwaysEmitIntoClient
+    static var ambie: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2646)
+    }
+
+    /// Meizhou Guo Wei Electronics Co., Ltd (`2647`)
+    @_alwaysEmitIntoClient
+    static var meizhouGuoWeiElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2647)
+    }
+
+    /// Indigo Diabetes (`2648`)
+    @_alwaysEmitIntoClient
+    static var indigoDiabetes: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2648)
+    }
+
+    /// TourBuilt, LLC (`2649`)
+    @_alwaysEmitIntoClient
+    static var tourbuilt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2649)
+    }
+
+    /// Sontheim Industrie Elektronik GmbH (`2650`)
+    @_alwaysEmitIntoClient
+    static var sontheimIndustrieElektronik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2650)
+    }
+
+    /// LEGIC Identsystems AG (`2651`)
+    @_alwaysEmitIntoClient
+    static var legicIdentsystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2651)
+    }
+
+    /// Innovative Design Labs Inc. (`2652`)
+    @_alwaysEmitIntoClient
+    static var innovativeDesignLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2652)
+    }
+
+    /// MG Energy Systems B.V. (`2653`)
+    @_alwaysEmitIntoClient
+    static var mgEnergySystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2653)
+    }
+
+    /// LaceClips llc (`2654`)
+    @_alwaysEmitIntoClient
+    static var laceclips: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2654)
+    }
+
+    /// stryker (`2655`)
+    @_alwaysEmitIntoClient
+    static var stryker: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2655)
+    }
+
+    /// DATANG SEMICONDUCTOR TECHNOLOGY CO.,LTD (`2656`)
+    @_alwaysEmitIntoClient
+    static var datangSemiconductorTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2656)
+    }
+
+    /// Smart Parks B.V. (`2657`)
+    @_alwaysEmitIntoClient
+    static var smartParks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2657)
+    }
+
+    /// MOKO TECHNOLOGY Ltd (`2658`)
+    @_alwaysEmitIntoClient
+    static var mokoTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2658)
+    }
+
+    /// Gremsy JSC (`2659`)
+    @_alwaysEmitIntoClient
+    static var gremsyJsc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2659)
+    }
+
+    /// Geopal system A/S (`2660`)
+    @_alwaysEmitIntoClient
+    static var geopalSystem: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2660)
+    }
+
+    /// Lytx, INC. (`2661`)
+    @_alwaysEmitIntoClient
+    static var lytx: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2661)
+    }
+
+    /// JUSTMORPH PTE. LTD. (`2662`)
+    @_alwaysEmitIntoClient
+    static var justmorphPte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2662)
+    }
+
+    /// Beijing SuperHexa Century Technology CO. Ltd (`2663`)
+    @_alwaysEmitIntoClient
+    static var beijingSuperhexaCenturyTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2663)
+    }
+
+    /// Focus Ingenieria SRL (`2664`)
+    @_alwaysEmitIntoClient
+    static var focusIngenieria: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2664)
+    }
+
+    /// HAPPIEST BABY, INC. (`2665`)
+    @_alwaysEmitIntoClient
+    static var happiestBaby: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2665)
+    }
+
+    /// Scribble Design Inc. (`2666`)
+    @_alwaysEmitIntoClient
+    static var scribbleDesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2666)
+    }
+
+    /// Olympic Ophthalmics, Inc. (`2667`)
+    @_alwaysEmitIntoClient
+    static var olympicOphthalmics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2667)
+    }
+
+    /// Pokkels (`2668`)
+    @_alwaysEmitIntoClient
+    static var pokkels: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2668)
+    }
+
+    /// KUUKANJYOKIN Co.,Ltd. (`2669`)
+    @_alwaysEmitIntoClient
+    static var kuukanjyokin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2669)
+    }
+
+    /// Pac Sane Limited (`2670`)
+    @_alwaysEmitIntoClient
+    static var pacSane: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2670)
+    }
+
+    /// Warner Bros. (`2671`)
+    @_alwaysEmitIntoClient
+    static var warnerBros: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2671)
+    }
+
+    /// Ooma (`2672`)
+    @_alwaysEmitIntoClient
+    static var ooma: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2672)
+    }
+
+    /// Senquip Pty Ltd (`2673`)
+    @_alwaysEmitIntoClient
+    static var senquip: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2673)
+    }
+
+    /// Jumo GmbH & Co. KG (`2674`)
+    @_alwaysEmitIntoClient
+    static var jumo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2674)
+    }
+
+    /// Innohome Oy (`2675`)
+    @_alwaysEmitIntoClient
+    static var innohome: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2675)
+    }
+
+    /// MICROSON S.A. (`2676`)
+    @_alwaysEmitIntoClient
+    static var microson: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2676)
+    }
+
+    /// Delta Cycle Corporation (`2677`)
+    @_alwaysEmitIntoClient
+    static var deltaCycle: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2677)
+    }
+
+    /// Synaptics Incorporated (`2678`)
+    @_alwaysEmitIntoClient
+    static var synaptics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2678)
+    }
+
+    /// AXTRO PTE. LTD. (`2679`)
+    @_alwaysEmitIntoClient
+    static var axtroPte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2679)
+    }
+
+    /// Shenzhen Sunricher Technology Limited (`2680`)
+    @_alwaysEmitIntoClient
+    static var shenzhenSunricherTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2680)
+    }
+
+    /// Webasto SE (`2681`)
+    @_alwaysEmitIntoClient
+    static var webasto: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2681)
+    }
+
+    /// Emlid Limited (`2682`)
+    @_alwaysEmitIntoClient
+    static var emlid: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2682)
+    }
+
+    /// UniqAir Oy (`2683`)
+    @_alwaysEmitIntoClient
+    static var uniqair: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2683)
+    }
+
+    /// WAFERLOCK (`2684`)
+    @_alwaysEmitIntoClient
+    static var waferlock: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2684)
+    }
+
+    /// Freedman Electronics Pty Ltd (`2685`)
+    @_alwaysEmitIntoClient
+    static var freedmanElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2685)
+    }
+
+    /// KEBA Handover Automation GmbH (`2686`)
+    @_alwaysEmitIntoClient
+    static var kebaHandoverAutomation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2686)
+    }
+
+    /// Intuity Medical (`2687`)
+    @_alwaysEmitIntoClient
+    static var intuityMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2687)
+    }
+
+    /// Cleer Limited (`2688`)
+    @_alwaysEmitIntoClient
+    static var cleer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2688)
+    }
+
+    /// Universal Biosensors Pty Ltd (`2689`)
+    @_alwaysEmitIntoClient
+    static var universalBiosensors: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2689)
+    }
+
+    /// Corsair (`2690`)
+    @_alwaysEmitIntoClient
+    static var corsair: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2690)
+    }
+
+    /// Rivata, Inc. (`2691`)
+    @_alwaysEmitIntoClient
+    static var rivata: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2691)
+    }
+
+    /// Greennote Inc, (`2692`)
+    @_alwaysEmitIntoClient
+    static var greennote: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2692)
+    }
+
+    /// Snowball Technology Co., Ltd. (`2693`)
+    @_alwaysEmitIntoClient
+    static var snowballTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2693)
+    }
+
+    /// ALIZENT International (`2694`)
+    @_alwaysEmitIntoClient
+    static var alizentInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2694)
+    }
+
+    /// Shanghai Smart System Technology Co., Ltd (`2695`)
+    @_alwaysEmitIntoClient
+    static var shanghaiSmartSystemTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2695)
+    }
+
+    /// PSA Peugeot Citroen (`2696`)
+    @_alwaysEmitIntoClient
+    static var psaPeugeotCitroen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2696)
+    }
+
+    /// SES-Imagotag (`2697`)
+    @_alwaysEmitIntoClient
+    static var sesImagotag: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2697)
+    }
+
+    /// HAINBUCH GMBH SPANNENDE TECHNIK (`2698`)
+    @_alwaysEmitIntoClient
+    static var hainbuchSpannendeTechnik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2698)
+    }
+
+    /// SANlight GmbH (`2699`)
+    @_alwaysEmitIntoClient
+    static var sanlight: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2699)
+    }
+
+    /// DelpSys, s.r.o. (`2700`)
+    @_alwaysEmitIntoClient
+    static var delpsys: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2700)
+    }
+
+    /// JCM TECHNOLOGIES S.A. (`2701`)
+    @_alwaysEmitIntoClient
+    static var jcmTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2701)
+    }
+
+    /// Perfect Company (`2702`)
+    @_alwaysEmitIntoClient
+    static var perfect: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2702)
+    }
+
+    /// TOTO LTD. (`2703`)
+    @_alwaysEmitIntoClient
+    static var toto: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2703)
+    }
+
+    /// Shenzhen Grandsun Electronic Co.,Ltd. (`2704`)
+    @_alwaysEmitIntoClient
+    static var shenzhenGrandsunElectronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2704)
+    }
+
+    /// Monarch International Inc. (`2705`)
+    @_alwaysEmitIntoClient
+    static var monarchInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2705)
+    }
+
+    /// Carestream Dental LLC (`2706`)
+    @_alwaysEmitIntoClient
+    static var carestreamDental: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2706)
+    }
+
+    /// GiPStech S.r.l. (`2707`)
+    @_alwaysEmitIntoClient
+    static var gipstech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2707)
+    }
+
+    /// OOBIK Inc. (`2708`)
+    @_alwaysEmitIntoClient
+    static var oobik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2708)
+    }
+
+    /// Pamex Inc. (`2709`)
+    @_alwaysEmitIntoClient
+    static var pamex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2709)
+    }
+
+    /// Lightricity Ltd (`2710`)
+    @_alwaysEmitIntoClient
+    static var lightricity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2710)
+    }
+
+    /// SensTek (`2711`)
+    @_alwaysEmitIntoClient
+    static var senstek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2711)
+    }
+
+    /// Foil, Inc. (`2712`)
+    @_alwaysEmitIntoClient
+    static var foil: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2712)
+    }
+
+    /// Shanghai high-flying electronics technology Co.,Ltd (`2713`)
+    @_alwaysEmitIntoClient
+    static var shanghaiHighFlyingElectronicsTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2713)
+    }
+
+    /// TEMKIN ASSOCIATES, LLC (`2714`)
+    @_alwaysEmitIntoClient
+    static var temkinsociates: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2714)
+    }
+
+    /// Eello LLC (`2715`)
+    @_alwaysEmitIntoClient
+    static var eello: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2715)
+    }
+
+    /// Xi'an Fengyu Information Technology Co., Ltd. (`2716`)
+    @_alwaysEmitIntoClient
+    static var xiAnFengyuInformationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2716)
+    }
+
+    /// Canon Finetech Nisca Inc. (`2717`)
+    @_alwaysEmitIntoClient
+    static var canonFinetechNisca: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2717)
+    }
+
+    /// LifePlus, Inc. (`2718`)
+    @_alwaysEmitIntoClient
+    static var lifeplus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2718)
+    }
+
+    /// ista International GmbH (`2719`)
+    @_alwaysEmitIntoClient
+    static var istaInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2719)
+    }
+
+    /// Loy Tec electronics GmbH (`2720`)
+    @_alwaysEmitIntoClient
+    static var loyTecElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2720)
+    }
+
+    /// LINCOGN TECHNOLOGY CO. LIMITED (`2721`)
+    @_alwaysEmitIntoClient
+    static var lincognTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2721)
+    }
+
+    /// Care Bloom, LLC (`2722`)
+    @_alwaysEmitIntoClient
+    static var careBloom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2722)
+    }
+
+    /// DIC Corporation (`2723`)
+    @_alwaysEmitIntoClient
+    static var dic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2723)
+    }
+
+    /// FAZEPRO LLC (`2724`)
+    @_alwaysEmitIntoClient
+    static var fazepro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2724)
+    }
+
+    /// Shenzhen Uascent Technology Co., Ltd (`2725`)
+    @_alwaysEmitIntoClient
+    static var shenzhenUascentTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2725)
+    }
+
+    /// Realityworks, inc. (`2726`)
+    @_alwaysEmitIntoClient
+    static var realityworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2726)
+    }
+
+    /// Urbanista AB (`2727`)
+    @_alwaysEmitIntoClient
+    static var urbanista: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2727)
+    }
+
+    /// Zencontrol Pty Ltd (`2728`)
+    @_alwaysEmitIntoClient
+    static var zencontrol: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2728)
+    }
+
+    /// Spintly, Inc. (`2729`)
+    @_alwaysEmitIntoClient
+    static var spintly: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2729)
+    }
+
+    /// Computime International Ltd (`2730`)
+    @_alwaysEmitIntoClient
+    static var computimeInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2730)
+    }
+
+    /// Anhui Listenai Co (`2731`)
+    @_alwaysEmitIntoClient
+    static var anhuiListenaiCo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2731)
+    }
+
+    /// OSM HK Limited (`2732`)
+    @_alwaysEmitIntoClient
+    static var osm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2732)
+    }
+
+    /// Adevo Consulting AB (`2733`)
+    @_alwaysEmitIntoClient
+    static var adevoConsulting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2733)
+    }
+
+    /// PS Engineering, Inc. (`2734`)
+    @_alwaysEmitIntoClient
+    static var psEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2734)
+    }
+
+    /// AIAIAI ApS (`2735`)
+    @_alwaysEmitIntoClient
+    static var aiaiai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2735)
+    }
+
+    /// Visiontronic s.r.o. (`2736`)
+    @_alwaysEmitIntoClient
+    static var visiontronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2736)
+    }
+
+    /// InVue Security Products Inc (`2737`)
+    @_alwaysEmitIntoClient
+    static var invueSecurityProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2737)
+    }
+
+    /// TouchTronics, Inc. (`2738`)
+    @_alwaysEmitIntoClient
+    static var touchtronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2738)
+    }
+
+    /// INNER RANGE PTY. LTD. (`2739`)
+    @_alwaysEmitIntoClient
+    static var innerRange: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2739)
+    }
+
+    /// Ellenby Technologies, Inc. (`2740`)
+    @_alwaysEmitIntoClient
+    static var ellenbyTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2740)
+    }
+
+    /// Elstat Electronics Ltd. (`2741`)
+    @_alwaysEmitIntoClient
+    static var elstatElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2741)
+    }
+
+    /// Xenter, Inc. (`2742`)
+    @_alwaysEmitIntoClient
+    static var xenter: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2742)
+    }
+
+    /// LogTag North America Inc. (`2743`)
+    @_alwaysEmitIntoClient
+    static var logtagNorthAmerica: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2743)
+    }
+
+    /// Sens.ai Incorporated (`2744`)
+    @_alwaysEmitIntoClient
+    static var sensAi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2744)
+    }
+
+    /// STL (`2745`)
+    @_alwaysEmitIntoClient
+    static var stl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2745)
+    }
+
+    /// Open Bionics Ltd. (`2746`)
+    @_alwaysEmitIntoClient
+    static var openBionics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2746)
+    }
+
+    /// R-DAS, s.r.o. (`2747`)
+    @_alwaysEmitIntoClient
+    static var rDas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2747)
+    }
+
+    /// KCCS Mobile Engineering Co., Ltd. (`2748`)
+    @_alwaysEmitIntoClient
+    static var kccsMobileEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2748)
+    }
+
+    /// Inventas AS (`2749`)
+    @_alwaysEmitIntoClient
+    static var inventas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2749)
+    }
+
+    /// Robkoo Information & Technologies Co., Ltd. (`2750`)
+    @_alwaysEmitIntoClient
+    static var robkooInformationTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2750)
+    }
+
+    /// PAUL HARTMANN AG (`2751`)
+    @_alwaysEmitIntoClient
+    static var paulHartmann: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2751)
+    }
+
+    /// Omni-ID USA, INC. (`2752`)
+    @_alwaysEmitIntoClient
+    static var omniId: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2752)
+    }
+
+    /// Shenzhen Jingxun Technology Co., Ltd. (`2753`)
+    @_alwaysEmitIntoClient
+    static var shenzhenJingxunTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2753)
+    }
+
+    /// RealMega Microelectronics technology (Shanghai) Co. Ltd. (`2754`)
+    @_alwaysEmitIntoClient
+    static var realmegaMicroelectronicsTechnologyShanghai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2754)
+    }
+
+    /// Kenzen, Inc. (`2755`)
+    @_alwaysEmitIntoClient
+    static var kenzen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2755)
+    }
+
+    /// CODIUM (`2756`)
+    @_alwaysEmitIntoClient
+    static var codium: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2756)
+    }
+
+    /// Flexoptix GmbH (`2757`)
+    @_alwaysEmitIntoClient
+    static var flexoptix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2757)
+    }
+
+    /// Barnes Group Inc. (`2758`)
+    @_alwaysEmitIntoClient
+    static var barnesGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2758)
+    }
+
+    /// Chengdu Aich Technology Co.,Ltd (`2759`)
+    @_alwaysEmitIntoClient
+    static var chengduAichTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2759)
+    }
+
+    /// Keepin Co., Ltd. (`2760`)
+    @_alwaysEmitIntoClient
+    static var keepin: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2760)
+    }
+
+    /// Swedlock AB (`2761`)
+    @_alwaysEmitIntoClient
+    static var swedlock: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2761)
+    }
+
+    /// Shenzhen CoolKit Technology Co., Ltd (`2762`)
+    @_alwaysEmitIntoClient
+    static var shenzhenCoolkitTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2762)
+    }
+
+    /// ise Individuelle Software und Elektronik GmbH (`2763`)
+    @_alwaysEmitIntoClient
+    static var iseIndividuelleSoftwareUndElektronik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2763)
+    }
+
+    /// Nuvoton (`2764`)
+    @_alwaysEmitIntoClient
+    static var nuvoton: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2764)
+    }
+
+    /// Visuallex Sport International Limited (`2765`)
+    @_alwaysEmitIntoClient
+    static var visuallexSportInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2765)
+    }
+
+    /// KOBATA GAUGE MFG. CO., LTD. (`2766`)
+    @_alwaysEmitIntoClient
+    static var kobataGaugeMfg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2766)
+    }
+
+    /// CACI Technologies (`2767`)
+    @_alwaysEmitIntoClient
+    static var caciTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2767)
+    }
+
+    /// Nordic Strong ApS (`2768`)
+    @_alwaysEmitIntoClient
+    static var nordicStrong: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2768)
+    }
+
+    /// EAGLE KINGDOM TECHNOLOGIES LIMITED (`2769`)
+    @_alwaysEmitIntoClient
+    static var eagleKingdomTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2769)
+    }
+
+    /// Lautsprecher Teufel GmbH (`2770`)
+    @_alwaysEmitIntoClient
+    static var lautsprecherTeufel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2770)
+    }
+
+    /// SSV Software Systems GmbH (`2771`)
+    @_alwaysEmitIntoClient
+    static var ssvSoftwareSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2771)
+    }
+
+    /// Zhuhai Pantum Electronisc Co., Ltd (`2772`)
+    @_alwaysEmitIntoClient
+    static var zhuhaiPantumElectronisc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2772)
+    }
+
+    /// Streamit B.V. (`2773`)
+    @_alwaysEmitIntoClient
+    static var streamit: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2773)
+    }
+
+    /// nymea GmbH (`2774`)
+    @_alwaysEmitIntoClient
+    static var nymea: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2774)
+    }
+
+    /// AL-KO Geraete GmbH (`2775`)
+    @_alwaysEmitIntoClient
+    static var alKoGeraete: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2775)
+    }
+
+    /// Franz Kaldewei GmbH&Co KG (`2776`)
+    @_alwaysEmitIntoClient
+    static var franzKaldeweiCoKg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2776)
+    }
+
+    /// Shenzhen Aimore. Co.,Ltd (`2777`)
+    @_alwaysEmitIntoClient
+    static var shenzhenAimore: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2777)
+    }
+
+    /// Codefabrik GmbH (`2778`)
+    @_alwaysEmitIntoClient
+    static var codefabrik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2778)
+    }
+
+    /// Reelables, Inc. (`2779`)
+    @_alwaysEmitIntoClient
+    static var reelables: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2779)
+    }
+
+    /// Duravit AG (`2780`)
+    @_alwaysEmitIntoClient
+    static var duravit: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2780)
+    }
+
+    /// Boss Audio (`2781`)
+    @_alwaysEmitIntoClient
+    static var bossAudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2781)
+    }
+
+    /// Vocera Communications, Inc. (`2782`)
+    @_alwaysEmitIntoClient
+    static var voceraCommunications: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2782)
+    }
+
+    /// Douglas Dynamics L.L.C. (`2783`)
+    @_alwaysEmitIntoClient
+    static var douglasDynamicsLLC: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2783)
+    }
+
+    /// Viceroy Devices Corporation (`2784`)
+    @_alwaysEmitIntoClient
+    static var viceroyDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2784)
+    }
+
+    /// ChengDu ForThink Technology Co., Ltd. (`2785`)
+    @_alwaysEmitIntoClient
+    static var chengduForthinkTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2785)
+    }
+
+    /// IMATRIX SYSTEMS, INC. (`2786`)
+    @_alwaysEmitIntoClient
+    static var imatrixSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2786)
+    }
+
+    /// GlobalMed (`2787`)
+    @_alwaysEmitIntoClient
+    static var globalmed: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2787)
+    }
+
+    /// DALI Alliance (`2788`)
+    @_alwaysEmitIntoClient
+    static var daliAlliance: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2788)
+    }
+
+    /// unu GmbH (`2789`)
+    @_alwaysEmitIntoClient
+    static var unu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2789)
+    }
+
+    /// Hexology (`2790`)
+    @_alwaysEmitIntoClient
+    static var hexology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2790)
+    }
+
+    /// Sunplus Technology Co., Ltd. (`2791`)
+    @_alwaysEmitIntoClient
+    static var sunplusTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2791)
+    }
+
+    /// LEVEL, s.r.o. (`2792`)
+    @_alwaysEmitIntoClient
+    static var level: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2792)
+    }
+
+    /// FLIR Systems AB (`2793`)
+    @_alwaysEmitIntoClient
+    static var flirSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2793)
+    }
+
+    /// Borda Technology (`2794`)
+    @_alwaysEmitIntoClient
+    static var bordaTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2794)
+    }
+
+    /// Square, Inc. (`2795`)
+    @_alwaysEmitIntoClient
+    static var square: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2795)
+    }
+
+    /// FUTEK ADVANCED SENSOR TECHNOLOGY, INC (`2796`)
+    @_alwaysEmitIntoClient
+    static var futekAdvancedSensorTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2796)
+    }
+
+    /// Saxonar GmbH (`2797`)
+    @_alwaysEmitIntoClient
+    static var saxonar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2797)
+    }
+
+    /// Velentium, LLC (`2798`)
+    @_alwaysEmitIntoClient
+    static var velentium: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2798)
+    }
+
+    /// GLP German Light Products GmbH (`2799`)
+    @_alwaysEmitIntoClient
+    static var glpGermanLightProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2799)
+    }
+
+    /// Leupold & Stevens, Inc. (`2800`)
+    @_alwaysEmitIntoClient
+    static var leupoldStevens: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2800)
+    }
+
+    /// CRADERS,CO.,LTD (`2801`)
+    @_alwaysEmitIntoClient
+    static var craders: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2801)
+    }
+
+    /// Shanghai All Link Microelectronics Co.,Ltd (`2802`)
+    @_alwaysEmitIntoClient
+    static var shanghaiAllLinkMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2802)
+    }
+
+    /// 701x Inc. (`2803`)
+    @_alwaysEmitIntoClient
+    static var company701X: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2803)
+    }
+
+    /// Radioworks Microelectronics PTY LTD (`2804`)
+    @_alwaysEmitIntoClient
+    static var radioworksMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2804)
+    }
+
+    /// Unitech Electronic Inc. (`2805`)
+    @_alwaysEmitIntoClient
+    static var unitechElectronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2805)
+    }
+
+    /// AMETEK, Inc. (`2806`)
+    @_alwaysEmitIntoClient
+    static var ametek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2806)
+    }
+
+    /// Irdeto (`2807`)
+    @_alwaysEmitIntoClient
+    static var irdeto: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2807)
+    }
+
+    /// First Design System Inc. (`2808`)
+    @_alwaysEmitIntoClient
+    static var firstDesignSystem: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2808)
+    }
+
+    /// Unisto AG (`2809`)
+    @_alwaysEmitIntoClient
+    static var unisto: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2809)
+    }
+
+    /// Chengdu Ambit Technology Co., Ltd. (`2810`)
+    @_alwaysEmitIntoClient
+    static var chengduAmbitTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2810)
+    }
+
+    /// SMT ELEKTRONIK GmbH (`2811`)
+    @_alwaysEmitIntoClient
+    static var smtElektronik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2811)
+    }
+
+    /// Cerebrum Sensor Technologies Inc. (`2812`)
+    @_alwaysEmitIntoClient
+    static var cerebrumSensorTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2812)
+    }
+
+    /// Weber Sensors, LLC (`2813`)
+    @_alwaysEmitIntoClient
+    static var weberSensors: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2813)
+    }
+
+    /// Earda Technologies Co.,Ltd (`2814`)
+    @_alwaysEmitIntoClient
+    static var eardaTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2814)
+    }
+
+    /// FUSEAWARE LIMITED (`2815`)
+    @_alwaysEmitIntoClient
+    static var fuseaware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2815)
+    }
+
+    /// Flaircomm Microelectronics Inc. (`2816`)
+    @_alwaysEmitIntoClient
+    static var flaircommMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2816)
+    }
+
+    /// RESIDEO TECHNOLOGIES, INC. (`2817`)
+    @_alwaysEmitIntoClient
+    static var resideoTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2817)
+    }
+
+    /// IORA Technology Development Ltd. Sti. (`2818`)
+    @_alwaysEmitIntoClient
+    static var ioraTechnologyDevelopmentSti: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2818)
+    }
+
+    /// Precision Triathlon Systems Limited (`2819`)
+    @_alwaysEmitIntoClient
+    static var precisionTriathlonSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2819)
+    }
+
+    /// I-PERCUT (`2820`)
+    @_alwaysEmitIntoClient
+    static var iPercut: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2820)
+    }
+
+    /// Marquardt GmbH (`2821`)
+    @_alwaysEmitIntoClient
+    static var marquardt: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2821)
+    }
+
+    /// FAZUA GmbH (`2822`)
+    @_alwaysEmitIntoClient
+    static var fazua: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2822)
+    }
+
+    /// Workaround Gmbh (`2823`)
+    @_alwaysEmitIntoClient
+    static var workaround: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2823)
+    }
+
+    /// Shenzhen Qianfenyi Intelligent Technology Co., LTD (`2824`)
+    @_alwaysEmitIntoClient
+    static var shenzhenQianfenyiIntelligentTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2824)
+    }
+
+    /// soonisys (`2825`)
+    @_alwaysEmitIntoClient
+    static var soonisys: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2825)
+    }
+
+    /// Belun Technology Company Limited (`2826`)
+    @_alwaysEmitIntoClient
+    static var belunTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2826)
+    }
+
+    /// Sanistaal A/S (`2827`)
+    @_alwaysEmitIntoClient
+    static var sanistaal: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2827)
+    }
+
+    /// BluPeak (`2828`)
+    @_alwaysEmitIntoClient
+    static var blupeak: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2828)
+    }
+
+    /// SANYO DENKO Co.,Ltd. (`2829`)
+    @_alwaysEmitIntoClient
+    static var sanyoDenko: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2829)
+    }
+
+    /// Honda Lock Mfg. Co.,Ltd. (`2830`)
+    @_alwaysEmitIntoClient
+    static var hondaLockMfg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2830)
+    }
+
+    /// B.E.A. S.A. (`2831`)
+    @_alwaysEmitIntoClient
+    static var bEA: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2831)
+    }
+
+    /// Alfa Laval Corporate AB (`2832`)
+    @_alwaysEmitIntoClient
+    static var alfaLavalorate: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2832)
+    }
+
+    /// ThermoWorks, Inc. (`2833`)
+    @_alwaysEmitIntoClient
+    static var thermoworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2833)
+    }
+
+    /// ToughBuilt Industries LLC (`2834`)
+    @_alwaysEmitIntoClient
+    static var toughbuiltIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2834)
+    }
+
+    /// IOTOOLS (`2835`)
+    @_alwaysEmitIntoClient
+    static var iotools: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2835)
+    }
+
+    /// Olumee (`2836`)
+    @_alwaysEmitIntoClient
+    static var olumee: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2836)
+    }
+
+    /// NAOS JAPAN K.K. (`2837`)
+    @_alwaysEmitIntoClient
+    static var naosJapanKK: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2837)
+    }
+
+    /// Guard RFID Solutions Inc. (`2838`)
+    @_alwaysEmitIntoClient
+    static var guardRfidSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2838)
+    }
+
+    /// SIG SAUER, INC. (`2839`)
+    @_alwaysEmitIntoClient
+    static var siguer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2839)
+    }
+
+    /// DECATHLON SE (`2840`)
+    @_alwaysEmitIntoClient
+    static var decathlon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2840)
+    }
+
+    /// WBS PROJECT H PTY LTD (`2841`)
+    @_alwaysEmitIntoClient
+    static var wbsProjectH: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2841)
+    }
+
+    /// Roca Sanitario, S.A. (`2842`)
+    @_alwaysEmitIntoClient
+    static var rocaSanitario: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2842)
+    }
+
+    /// Enerpac Tool Group Corp. (`2843`)
+    @_alwaysEmitIntoClient
+    static var enerpacToolGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2843)
+    }
+
+    /// Nanoleq AG (`2844`)
+    @_alwaysEmitIntoClient
+    static var nanoleq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2844)
+    }
+
+    /// Accelerated Systems (`2845`)
+    @_alwaysEmitIntoClient
+    static var acceleratedSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2845)
+    }
+
+    /// PB INC. (`2846`)
+    @_alwaysEmitIntoClient
+    static var pb: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2846)
+    }
+
+    /// Beijing ESWIN Computing Technology Co., Ltd. (`2847`)
+    @_alwaysEmitIntoClient
+    static var beijingEswinComputingTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2847)
+    }
+
+    /// TKH Security B.V. (`2848`)
+    @_alwaysEmitIntoClient
+    static var tkhSecurity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2848)
+    }
+
+    /// ams AG (`2849`)
+    @_alwaysEmitIntoClient
+    static var ams: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2849)
+    }
+
+    /// Hygiene IQ, LLC. (`2850`)
+    @_alwaysEmitIntoClient
+    static var hygieneIq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2850)
+    }
+
+    /// iRhythm Technologies, Inc. (`2851`)
+    @_alwaysEmitIntoClient
+    static var irhythmTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2851)
+    }
+
+    /// BeiJing ZiJie TiaoDong KeJi Co.,Ltd. (`2852`)
+    @_alwaysEmitIntoClient
+    static var beijingZijieTiaodongKeji: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2852)
+    }
+
+    /// NIBROTECH LTD (`2853`)
+    @_alwaysEmitIntoClient
+    static var nibrotech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2853)
+    }
+
+    /// Baracoda Daily Healthtech. (`2854`)
+    @_alwaysEmitIntoClient
+    static var baracodaDailyHealthtech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2854)
+    }
+
+    /// Lumi United Technology Co., Ltd (`2855`)
+    @_alwaysEmitIntoClient
+    static var lumiUnitedTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2855)
+    }
+
+    /// CHACON (`2856`)
+    @_alwaysEmitIntoClient
+    static var chacon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2856)
+    }
+
+    /// Tech-Venom Entertainment Private Limited (`2857`)
+    @_alwaysEmitIntoClient
+    static var techVenomEntertainment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2857)
+    }
+
+    /// ACL Airshop B.V. (`2858`)
+    @_alwaysEmitIntoClient
+    static var aclAirshop: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2858)
+    }
+
+    /// MAINBOT (`2859`)
+    @_alwaysEmitIntoClient
+    static var mainbot: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2859)
+    }
+
+    /// ILLUMAGEAR, Inc. (`2860`)
+    @_alwaysEmitIntoClient
+    static var illumagear: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2860)
+    }
+
+    /// REDARC ELECTRONICS PTY LTD (`2861`)
+    @_alwaysEmitIntoClient
+    static var redarcElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2861)
+    }
+
+    /// MOCA System Inc. (`2862`)
+    @_alwaysEmitIntoClient
+    static var mocaSystem: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2862)
+    }
+
+    /// Duke Manufacturing Co (`2863`)
+    @_alwaysEmitIntoClient
+    static var dukeManufacturingCo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2863)
+    }
+
+    /// ART SPA (`2864`)
+    @_alwaysEmitIntoClient
+    static var artSpa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2864)
+    }
+
+    /// Silver Wolf Vehicles Inc. (`2865`)
+    @_alwaysEmitIntoClient
+    static var silverWolfVehicles: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2865)
+    }
+
+    /// Hala Systems, Inc. (`2866`)
+    @_alwaysEmitIntoClient
+    static var halaSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2866)
+    }
+
+    /// ARMATURA LLC (`2867`)
+    @_alwaysEmitIntoClient
+    static var armatura: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2867)
+    }
+
+    /// CONZUMEX INDUSTRIES PRIVATE LIMITED (`2868`)
+    @_alwaysEmitIntoClient
+    static var conzumexIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2868)
+    }
+
+    /// BH SENS (`2869`)
+    @_alwaysEmitIntoClient
+    static var bhSens: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2869)
+    }
+
+    /// SINTEF (`2870`)
+    @_alwaysEmitIntoClient
+    static var sintef: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2870)
+    }
+
+    /// Omnivoltaic Energy Solutions Limited Company (`2871`)
+    @_alwaysEmitIntoClient
+    static var omnivoltaicEnergySolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2871)
+    }
+
+    /// WISYCOM S.R.L. (`2872`)
+    @_alwaysEmitIntoClient
+    static var wisycom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2872)
+    }
+
+    /// Red 100 Lighting Co., ltd. (`2873`)
+    @_alwaysEmitIntoClient
+    static var red100Lighting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2873)
+    }
+
+    /// Impact Biosystems, Inc. (`2874`)
+    @_alwaysEmitIntoClient
+    static var impactBiosystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2874)
+    }
+
+    /// AIC semiconductor (Shanghai) Co., Ltd. (`2875`)
+    @_alwaysEmitIntoClient
+    static var aicSemiconductorShanghai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2875)
+    }
+
+    /// Dodge Industrial, Inc. (`2876`)
+    @_alwaysEmitIntoClient
+    static var dodgeIndustrial: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2876)
+    }
+
+    /// REALTIMEID AS (`2877`)
+    @_alwaysEmitIntoClient
+    static var realtimeid: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2877)
+    }
+
+    /// ISEO Serrature S.p.a. (`2878`)
+    @_alwaysEmitIntoClient
+    static var iseoSerrature: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2878)
+    }
+
+    /// MindRhythm, Inc. (`2879`)
+    @_alwaysEmitIntoClient
+    static var mindrhythm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2879)
+    }
+
+    /// Havells India Limited (`2880`)
+    @_alwaysEmitIntoClient
+    static var havellsIndia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2880)
+    }
+
+    /// Sentrax GmbH (`2881`)
+    @_alwaysEmitIntoClient
+    static var sentrax: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2881)
+    }
+
+    /// TSI (`2882`)
+    @_alwaysEmitIntoClient
+    static var tsi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2882)
+    }
+
+    /// INCITAT ENVIRONNEMENT (`2883`)
+    @_alwaysEmitIntoClient
+    static var incitatEnvironnement: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2883)
+    }
+
+    /// nFore Technology Co., Ltd. (`2884`)
+    @_alwaysEmitIntoClient
+    static var nforeTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2884)
+    }
+
+    /// Electronic Sensors, Inc. (`2885`)
+    @_alwaysEmitIntoClient
+    static var electronicSensors: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2885)
+    }
+
+    /// Bird Rides, Inc. (`2886`)
+    @_alwaysEmitIntoClient
+    static var birdRides: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2886)
+    }
+
+    /// Gentex Corporation (`2887`)
+    @_alwaysEmitIntoClient
+    static var gentex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2887)
+    }
+
+    /// NIO USA, Inc. (`2888`)
+    @_alwaysEmitIntoClient
+    static var nio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2888)
+    }
+
+    /// SkyHawke Technologies (`2889`)
+    @_alwaysEmitIntoClient
+    static var skyhawkeTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2889)
+    }
+
+    /// Nomono AS (`2890`)
+    @_alwaysEmitIntoClient
+    static var nomono: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2890)
+    }
+
+    /// EMS Integrators, LLC (`2891`)
+    @_alwaysEmitIntoClient
+    static var emsIntegrators: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2891)
+    }
+
+    /// BiosBob.Biz (`2892`)
+    @_alwaysEmitIntoClient
+    static var biosbobBiz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2892)
+    }
+
+    /// Adam Hall GmbH (`2893`)
+    @_alwaysEmitIntoClient
+    static var adamHall: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2893)
+    }
+
+    /// ICP Systems B.V. (`2894`)
+    @_alwaysEmitIntoClient
+    static var icpSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2894)
+    }
+
+    /// Breezi.io, Inc. (`2895`)
+    @_alwaysEmitIntoClient
+    static var breeziIo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2895)
+    }
+
+    /// Mesh Systems LLC (`2896`)
+    @_alwaysEmitIntoClient
+    static var meshSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2896)
+    }
+
+    /// FUN FACTORY GmbH (`2897`)
+    @_alwaysEmitIntoClient
+    static var funFactory: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2897)
+    }
+
+    /// ZIIP Inc (`2898`)
+    @_alwaysEmitIntoClient
+    static var ziip: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2898)
+    }
+
+    /// SHENZHEN KAADAS INTELLIGENT TECHNOLOGY CO.,Ltd (`2899`)
+    @_alwaysEmitIntoClient
+    static var shenzhenKaadasIntelligentTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2899)
+    }
+
+    /// Emotion Fitness GmbH & Co. KG (`2900`)
+    @_alwaysEmitIntoClient
+    static var emotionFitness: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2900)
+    }
+
+    /// H G M Automotive Electronics, Inc. (`2901`)
+    @_alwaysEmitIntoClient
+    static var hGMAutomotiveElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2901)
+    }
+
+    /// BORA - Vertriebs GmbH & Co KG (`2902`)
+    @_alwaysEmitIntoClient
+    static var boraVertriebs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2902)
+    }
+
+    /// CONVERTRONIX TECHNOLOGIES AND SERVICES LLP (`2903`)
+    @_alwaysEmitIntoClient
+    static var convertronixTechnologiesAndServicesLlp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2903)
+    }
+
+    /// TOKAI-DENSHI INC (`2904`)
+    @_alwaysEmitIntoClient
+    static var tokaiDenshi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2904)
+    }
+
+    /// Versa Group B.V. (`2905`)
+    @_alwaysEmitIntoClient
+    static var versaGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2905)
+    }
+
+    /// H.P. Shelby Manufacturing, LLC. (`2906`)
+    @_alwaysEmitIntoClient
+    static var hPShelbyManufacturing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2906)
+    }
+
+    /// Shenzhen ImagineVision Technology Limited (`2907`)
+    @_alwaysEmitIntoClient
+    static var shenzhenImaginevisionTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2907)
+    }
+
+    /// Exponential Power, Inc. (`2908`)
+    @_alwaysEmitIntoClient
+    static var exponentialPower: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2908)
+    }
+
+    /// Fujian Newland Auto-ID Tech. Co., Ltd. (`2909`)
+    @_alwaysEmitIntoClient
+    static var fujianNewlandAutoIdTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2909)
+    }
+
+    /// CELLCONTROL, INC. (`2910`)
+    @_alwaysEmitIntoClient
+    static var cellcontrol: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2910)
+    }
+
+    /// Rivieh, Inc. (`2911`)
+    @_alwaysEmitIntoClient
+    static var rivieh: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2911)
+    }
+
+    /// RATOC Systems, Inc. (`2912`)
+    @_alwaysEmitIntoClient
+    static var ratocSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2912)
+    }
+
+    /// Sentek Pty Ltd (`2913`)
+    @_alwaysEmitIntoClient
+    static var sentek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2913)
+    }
+
+    /// NOVEA ENERGIES (`2914`)
+    @_alwaysEmitIntoClient
+    static var noveaEnergies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2914)
+    }
+
+    /// Innolux Corporation (`2915`)
+    @_alwaysEmitIntoClient
+    static var innolux: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2915)
+    }
+
+    /// NingBo klite Electric Manufacture Co.,LTD (`2916`)
+    @_alwaysEmitIntoClient
+    static var ningboKliteElectricManufacture: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2916)
+    }
+
+    /// The Apache Software Foundation (`2917`)
+    @_alwaysEmitIntoClient
+    static var apacheSoftwareFoundation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2917)
+    }
+
+    /// MITSUBISHI ELECTRIC AUTOMATION (THAILAND) COMPANY LIMITED (`2918`)
+    @_alwaysEmitIntoClient
+    static var mitsubishiElectricAutomationThailand: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2918)
+    }
+
+    /// CleanSpace Technology Pty Ltd (`2919`)
+    @_alwaysEmitIntoClient
+    static var cleanspaceTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2919)
+    }
+
+    /// Quha oy (`2920`)
+    @_alwaysEmitIntoClient
+    static var quha: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2920)
+    }
+
+    /// Addaday (`2921`)
+    @_alwaysEmitIntoClient
+    static var addaday: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2921)
+    }
+
+    /// Dymo (`2922`)
+    @_alwaysEmitIntoClient
+    static var dymo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2922)
+    }
+
+    /// Samsara Networks, Inc (`2923`)
+    @_alwaysEmitIntoClient
+    static var samsaraNetworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2923)
+    }
+
+    /// Sensitech, Inc. (`2924`)
+    @_alwaysEmitIntoClient
+    static var sensitech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2924)
+    }
+
+    /// SOLUM CO., LTD (`2925`)
+    @_alwaysEmitIntoClient
+    static var solum: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2925)
+    }
+
+    /// React Mobile (`2926`)
+    @_alwaysEmitIntoClient
+    static var reactMobile: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2926)
+    }
+
+    /// Shenzhen Malide Technology Co.,Ltd (`2927`)
+    @_alwaysEmitIntoClient
+    static var shenzhenMalideTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2927)
+    }
+
+    /// JDRF Electromag Engineering Inc (`2928`)
+    @_alwaysEmitIntoClient
+    static var jdrfElectromagEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2928)
+    }
+
+    /// lilbit ODM AS (`2929`)
+    @_alwaysEmitIntoClient
+    static var lilbitOdm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2929)
+    }
+
+    /// Geeknet, Inc. (`2930`)
+    @_alwaysEmitIntoClient
+    static var geeknet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2930)
+    }
+
+    /// HARADA INDUSTRY CO., LTD. (`2931`)
+    @_alwaysEmitIntoClient
+    static var haradaIndustry: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2931)
+    }
+
+    /// BQN (`2932`)
+    @_alwaysEmitIntoClient
+    static var bqn: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2932)
+    }
+
+    /// Triple W Japan Inc. (`2933`)
+    @_alwaysEmitIntoClient
+    static var tripleWJapan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2933)
+    }
+
+    /// MAX-co., ltd (`2934`)
+    @_alwaysEmitIntoClient
+    static var max: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2934)
+    }
+
+    /// Aixlink(Chengdu) Co., Ltd. (`2935`)
+    @_alwaysEmitIntoClient
+    static var aixlinkChengdu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2935)
+    }
+
+    /// FIELD DESIGN INC. (`2936`)
+    @_alwaysEmitIntoClient
+    static var fieldDesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2936)
+    }
+
+    /// Sankyo Air Tech Co.,Ltd. (`2937`)
+    @_alwaysEmitIntoClient
+    static var sankyoAirTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2937)
+    }
+
+    /// Shenzhen KTC Technology Co.,Ltd. (`2938`)
+    @_alwaysEmitIntoClient
+    static var shenzhenKtcTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2938)
+    }
+
+    /// Hardcoder Oy (`2939`)
+    @_alwaysEmitIntoClient
+    static var hardcoder: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2939)
+    }
+
+    /// Scangrip A/S (`2940`)
+    @_alwaysEmitIntoClient
+    static var scangrip: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2940)
+    }
+
+    /// FoundersLane GmbH (`2941`)
+    @_alwaysEmitIntoClient
+    static var founderslane: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2941)
+    }
+
+    /// Offcode Oy (`2942`)
+    @_alwaysEmitIntoClient
+    static var offcode: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2942)
+    }
+
+    /// ICU tech GmbH (`2943`)
+    @_alwaysEmitIntoClient
+    static var icuTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2943)
+    }
+
+    /// AXELIFE (`2944`)
+    @_alwaysEmitIntoClient
+    static var axelife: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2944)
+    }
+
+    /// SCM Group (`2945`)
+    @_alwaysEmitIntoClient
+    static var scmGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2945)
+    }
+
+    /// Mammut Sports Group AG (`2946`)
+    @_alwaysEmitIntoClient
+    static var mammutSportsGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2946)
+    }
+
+    /// Taiga Motors Inc. (`2947`)
+    @_alwaysEmitIntoClient
+    static var taigaMotors: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2947)
+    }
+
+    /// Presidio Medical, Inc. (`2948`)
+    @_alwaysEmitIntoClient
+    static var presidioMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2948)
+    }
+
+    /// VIMANA TECH PTY LTD (`2949`)
+    @_alwaysEmitIntoClient
+    static var vimanaTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2949)
+    }
+
+    /// Trek Bicycle (`2950`)
+    @_alwaysEmitIntoClient
+    static var trekBicycle: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2950)
+    }
+
+    /// Ampetronic Ltd (`2951`)
+    @_alwaysEmitIntoClient
+    static var ampetronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2951)
+    }
+
+    /// Muguang (Guangdong) Intelligent Lighting Technology Co., Ltd (`2952`)
+    @_alwaysEmitIntoClient
+    static var muguangGuangdongIntelligentLightingTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2952)
+    }
+
+    /// Rotronic AG (`2953`)
+    @_alwaysEmitIntoClient
+    static var rotronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2953)
+    }
+
+    /// Seiko Instruments Inc. (`2954`)
+    @_alwaysEmitIntoClient
+    static var seikoInstruments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2954)
+    }
+
+    /// American Technology Components, Incorporated (`2955`)
+    @_alwaysEmitIntoClient
+    static var americanTechnologyComponents: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2955)
+    }
+
+    /// MOTREX (`2956`)
+    @_alwaysEmitIntoClient
+    static var motrex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2956)
+    }
+
+    /// Pertech Industries Inc (`2957`)
+    @_alwaysEmitIntoClient
+    static var pertechIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2957)
+    }
+
+    /// Gentle Energy Corp. (`2958`)
+    @_alwaysEmitIntoClient
+    static var gentleEnergy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2958)
+    }
+
+    /// Senscomm Semiconductor Co., Ltd. (`2959`)
+    @_alwaysEmitIntoClient
+    static var senscommSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2959)
+    }
+
+    /// Ineos Automotive Limited (`2960`)
+    @_alwaysEmitIntoClient
+    static var ineosAutomotive: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2960)
+    }
+
+    /// Alfen ICU B.V. (`2961`)
+    @_alwaysEmitIntoClient
+    static var alfenIcu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2961)
+    }
+
+    /// Citisend Solutions, SL (`2962`)
+    @_alwaysEmitIntoClient
+    static var citisendSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2962)
+    }
+
+    /// Hangzhou BroadLink Technology Co., Ltd. (`2963`)
+    @_alwaysEmitIntoClient
+    static var hangzhouBroadlinkTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2963)
+    }
+
+    /// Dreem SAS (`2964`)
+    @_alwaysEmitIntoClient
+    static var dreems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2964)
+    }
+
+    /// Netwake GmbH (`2965`)
+    @_alwaysEmitIntoClient
+    static var netwake: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2965)
+    }
+
+    /// Telecom Design (`2966`)
+    @_alwaysEmitIntoClient
+    static var telecomDesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2966)
+    }
+
+    /// SILVER TREE LABS, INC. (`2967`)
+    @_alwaysEmitIntoClient
+    static var silverTreeLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2967)
+    }
+
+    /// Gymstory B.V. (`2968`)
+    @_alwaysEmitIntoClient
+    static var gymstory: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2968)
+    }
+
+    /// The Goodyear Tire & Rubber Company (`2969`)
+    @_alwaysEmitIntoClient
+    static var goodyearTireRubber: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2969)
+    }
+
+    /// Beijing Wisepool Infinite Intelligence Technology Co.,Ltd (`2970`)
+    @_alwaysEmitIntoClient
+    static var beijingWisepoolInfiniteIntelligenceTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2970)
+    }
+
+    /// GISMAN (`2971`)
+    @_alwaysEmitIntoClient
+    static var gisman: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2971)
+    }
+
+    /// Komatsu Ltd. (`2972`)
+    @_alwaysEmitIntoClient
+    static var komatsu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2972)
+    }
+
+    /// Sensoria Holdings LTD (`2973`)
+    @_alwaysEmitIntoClient
+    static var sensoriaHoldings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2973)
+    }
+
+    /// Audio Partnership Plc (`2974`)
+    @_alwaysEmitIntoClient
+    static var audioPartnershipPlc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2974)
+    }
+
+    /// Group Lotus Limited (`2975`)
+    @_alwaysEmitIntoClient
+    static var groupLotus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2975)
+    }
+
+    /// Data Sciences International (`2976`)
+    @_alwaysEmitIntoClient
+    static var dataSciencesInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2976)
+    }
+
+    /// Bunn-O-Matic Corporation (`2977`)
+    @_alwaysEmitIntoClient
+    static var bunnOMatic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2977)
+    }
+
+    /// TireCheck GmbH (`2978`)
+    @_alwaysEmitIntoClient
+    static var tirecheck: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2978)
+    }
+
+    /// Sonova Consumer Hearing GmbH (`2979`)
+    @_alwaysEmitIntoClient
+    static var sonovaConsumerHearing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2979)
+    }
+
+    /// Vervent Audio Group (`2980`)
+    @_alwaysEmitIntoClient
+    static var verventAudioGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2980)
+    }
+
+    /// SONICOS ENTERPRISES, LLC (`2981`)
+    @_alwaysEmitIntoClient
+    static var sonicosEnterprises: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2981)
+    }
+
+    /// Nissan Motor Co., Ltd. (`2982`)
+    @_alwaysEmitIntoClient
+    static var nissanMotor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2982)
+    }
+
+    /// hearX Group (Pty) Ltd (`2983`)
+    @_alwaysEmitIntoClient
+    static var hearxGroupPty: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2983)
+    }
+
+    /// GLOWFORGE INC. (`2984`)
+    @_alwaysEmitIntoClient
+    static var glowforge: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2984)
+    }
+
+    /// Allterco Robotics ltd (`2985`)
+    @_alwaysEmitIntoClient
+    static var alltercoRobotics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2985)
+    }
+
+    /// Infinitegra, Inc. (`2986`)
+    @_alwaysEmitIntoClient
+    static var infinitegra: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2986)
+    }
+
+    /// Grandex International Corporation (`2987`)
+    @_alwaysEmitIntoClient
+    static var grandexInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2987)
+    }
+
+    /// Machfu Inc. (`2988`)
+    @_alwaysEmitIntoClient
+    static var machfu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2988)
+    }
+
+    /// Roambotics, Inc. (`2989`)
+    @_alwaysEmitIntoClient
+    static var roambotics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2989)
+    }
+
+    /// Soma Labs LLC (`2990`)
+    @_alwaysEmitIntoClient
+    static var somaLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2990)
+    }
+
+    /// NITTO KOGYO CORPORATION (`2991`)
+    @_alwaysEmitIntoClient
+    static var nittoKogyo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2991)
+    }
+
+    /// Ecolab Inc. (`2992`)
+    @_alwaysEmitIntoClient
+    static var ecolab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2992)
+    }
+
+    /// Beijing ranxin intelligence technology Co.,LTD (`2993`)
+    @_alwaysEmitIntoClient
+    static var beijingRanxinIntelligenceTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2993)
+    }
+
+    /// Fjorden Electra AS (`2994`)
+    @_alwaysEmitIntoClient
+    static var fjordenElectra: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2994)
+    }
+
+    /// Flender GmbH (`2995`)
+    @_alwaysEmitIntoClient
+    static var flender: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2995)
+    }
+
+    /// New Cosmos USA, Inc. (`2996`)
+    @_alwaysEmitIntoClient
+    static var newCosmos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2996)
+    }
+
+    /// Xirgo Technologies, LLC (`2997`)
+    @_alwaysEmitIntoClient
+    static var xirgoTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2997)
+    }
+
+    /// Build With Robots Inc. (`2998`)
+    @_alwaysEmitIntoClient
+    static var buildWithRobots: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2998)
+    }
+
+    /// IONA Tech LLC (`2999`)
+    @_alwaysEmitIntoClient
+    static var ionaTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 2999)
+    }
+
+    /// INNOVAG PTY. LTD. (`3000`)
+    @_alwaysEmitIntoClient
+    static var innovag: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3000)
+    }
+
+    /// SaluStim Group Oy (`3001`)
+    @_alwaysEmitIntoClient
+    static var salustimGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3001)
+    }
+
+    /// Huso, INC (`3002`)
+    @_alwaysEmitIntoClient
+    static var huso: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3002)
+    }
+
+    /// SWISSINNO SOLUTIONS AG (`3003`)
+    @_alwaysEmitIntoClient
+    static var swissinnoSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3003)
+    }
+
+    /// T2REALITY SOLUTIONS PRIVATE LIMITED (`3004`)
+    @_alwaysEmitIntoClient
+    static var t2RealitySolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3004)
+    }
+
+    /// ETHEORY PTY LTD (`3005`)
+    @_alwaysEmitIntoClient
+    static var etheory: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3005)
+    }
+
+    /// SAAB Aktiebolag (`3006`)
+    @_alwaysEmitIntoClient
+    static var saabAktiebolag: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3006)
+    }
+
+    /// HIMSA II K/S (`3007`)
+    @_alwaysEmitIntoClient
+    static var himsaIiKS: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3007)
+    }
+
+    /// READY FOR SKY LLP (`3008`)
+    @_alwaysEmitIntoClient
+    static var readyForSkyLlp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3008)
+    }
+
+    /// Miele & Cie. KG (`3009`)
+    @_alwaysEmitIntoClient
+    static var mieleCieKg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3009)
+    }
+
+    /// EntWick Co. (`3010`)
+    @_alwaysEmitIntoClient
+    static var entwick: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3010)
+    }
+
+    /// MCOT INC. (`3011`)
+    @_alwaysEmitIntoClient
+    static var mcot: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3011)
+    }
+
+    /// TECHTICS ENGINEERING B.V. (`3012`)
+    @_alwaysEmitIntoClient
+    static var techticsEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3012)
+    }
+
+    /// Aperia Technologies, Inc. (`3013`)
+    @_alwaysEmitIntoClient
+    static var aperiaTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3013)
+    }
+
+    /// TCL COMMUNICATION EQUIPMENT CO.,LTD. (`3014`)
+    @_alwaysEmitIntoClient
+    static var tclCommunicationEquipment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3014)
+    }
+
+    /// Signtle Inc. (`3015`)
+    @_alwaysEmitIntoClient
+    static var signtle: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3015)
+    }
+
+    /// OTF Distribution, LLC (`3016`)
+    @_alwaysEmitIntoClient
+    static var otfDistribution: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3016)
+    }
+
+    /// Neuvatek Inc. (`3017`)
+    @_alwaysEmitIntoClient
+    static var neuvatek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3017)
+    }
+
+    /// Perimeter Technologies, Inc. (`3018`)
+    @_alwaysEmitIntoClient
+    static var perimeterTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3018)
+    }
+
+    /// Divesoft s.r.o. (`3019`)
+    @_alwaysEmitIntoClient
+    static var divesoft: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3019)
+    }
+
+    /// Sylvac sa (`3020`)
+    @_alwaysEmitIntoClient
+    static var sylvacSa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3020)
+    }
+
+    /// Amiko srl (`3021`)
+    @_alwaysEmitIntoClient
+    static var amiko: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3021)
+    }
+
+    /// Neurosity, Inc. (`3022`)
+    @_alwaysEmitIntoClient
+    static var neurosity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3022)
+    }
+
+    /// LL Tec Group LLC (`3023`)
+    @_alwaysEmitIntoClient
+    static var llTecGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3023)
+    }
+
+    /// Durag GmbH (`3024`)
+    @_alwaysEmitIntoClient
+    static var durag: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3024)
+    }
+
+    /// Hubei Yuan Times Technology Co., Ltd. (`3025`)
+    @_alwaysEmitIntoClient
+    static var hubeiYuanTimesTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3025)
+    }
+
+    /// IDEC (`3026`)
+    @_alwaysEmitIntoClient
+    static var idec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3026)
+    }
+
+    /// Procon Analytics, LLC (`3027`)
+    @_alwaysEmitIntoClient
+    static var proconAnalytics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3027)
+    }
+
+    /// ndd Medizintechnik AG (`3028`)
+    @_alwaysEmitIntoClient
+    static var nddMedizintechnik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3028)
+    }
+
+    /// Super B Lithium Power B.V. (`3029`)
+    @_alwaysEmitIntoClient
+    static var superBLithiumPower: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3029)
+    }
+
+    /// Shenzhen Injoinic Technology Co., Ltd. (`3030`)
+    @_alwaysEmitIntoClient
+    static var shenzhenInjoinicTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3030)
+    }
+
+    /// VINFAST TRADING AND PRODUCTION JOINT STOCK COMPANY (`3031`)
+    @_alwaysEmitIntoClient
+    static var vinfastTradingAndProduction: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3031)
+    }
+
+    /// PURA SCENTS, INC. (`3032`)
+    @_alwaysEmitIntoClient
+    static var puraScents: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3032)
+    }
+
+    /// Elics Basis Ltd. (`3033`)
+    @_alwaysEmitIntoClient
+    static var elicsBasis: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3033)
+    }
+
+    /// Aardex Ltd. (`3034`)
+    @_alwaysEmitIntoClient
+    static var aardex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3034)
+    }
+
+    /// CHAR-BROIL, LLC (`3035`)
+    @_alwaysEmitIntoClient
+    static var charBroil: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3035)
+    }
+
+    /// Ledworks S.r.l. (`3036`)
+    @_alwaysEmitIntoClient
+    static var ledworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3036)
+    }
+
+    /// Coroflo Limited (`3037`)
+    @_alwaysEmitIntoClient
+    static var coroflo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3037)
+    }
+
+    /// Yale (`3038`)
+    @_alwaysEmitIntoClient
+    static var yale: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3038)
+    }
+
+    /// WINKEY ENTERPRISE (HONG KONG) LIMITED (`3039`)
+    @_alwaysEmitIntoClient
+    static var winkeyEnterpriseHongKong: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3039)
+    }
+
+    /// Koizumi Lighting Technology corp. (`3040`)
+    @_alwaysEmitIntoClient
+    static var koizumiLightingTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3040)
+    }
+
+    /// Back40 Precision (`3041`)
+    @_alwaysEmitIntoClient
+    static var back40Precision: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3041)
+    }
+
+    /// OTC engineering (`3042`)
+    @_alwaysEmitIntoClient
+    static var otcEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3042)
+    }
+
+    /// Comtel Systems Ltd. (`3043`)
+    @_alwaysEmitIntoClient
+    static var comtelSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3043)
+    }
+
+    /// Deepfield Connect GmbH (`3044`)
+    @_alwaysEmitIntoClient
+    static var deepfieldConnect: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3044)
+    }
+
+    /// ZWILLING J.A. Henckels Aktiengesellschaft (`3045`)
+    @_alwaysEmitIntoClient
+    static var zwillingJAHenckelsAktiengesellschaft: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3045)
+    }
+
+    /// Puratap Pty Ltd (`3046`)
+    @_alwaysEmitIntoClient
+    static var puratap: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3046)
+    }
+
+    /// Fresnel Technologies, Inc. (`3047`)
+    @_alwaysEmitIntoClient
+    static var fresnelTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3047)
+    }
+
+    /// Sensormate AG (`3048`)
+    @_alwaysEmitIntoClient
+    static var sensormate: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3048)
+    }
+
+    /// Shindengen Electric Manufacturing Co., Ltd. (`3049`)
+    @_alwaysEmitIntoClient
+    static var shindengenElectricManufacturing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3049)
+    }
+
+    /// Twenty Five Seven, prodaja in storitve, d.o.o. (`3050`)
+    @_alwaysEmitIntoClient
+    static var twentyFiveSevenProdajaInStoritve: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3050)
+    }
+
+    /// Luna Health, Inc. (`3051`)
+    @_alwaysEmitIntoClient
+    static var lunaHealth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3051)
+    }
+
+    /// Miracle-Ear, Inc. (`3052`)
+    @_alwaysEmitIntoClient
+    static var miracleEar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3052)
+    }
+
+    /// CORAL-TAIYI Co. Ltd. (`3053`)
+    @_alwaysEmitIntoClient
+    static var coralTaiyi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3053)
+    }
+
+    /// LINKSYS USA, INC. (`3054`)
+    @_alwaysEmitIntoClient
+    static var linksys: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3054)
+    }
+
+    /// Safetytest GmbH (`3055`)
+    @_alwaysEmitIntoClient
+    static var safetytest: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3055)
+    }
+
+    /// KIDO SPORTS CO., LTD. (`3056`)
+    @_alwaysEmitIntoClient
+    static var kidoSports: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3056)
+    }
+
+    /// Site IQ LLC (`3057`)
+    @_alwaysEmitIntoClient
+    static var siteIq: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3057)
+    }
+
+    /// Angel Medical Systems, Inc. (`3058`)
+    @_alwaysEmitIntoClient
+    static var angelMedicalSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3058)
+    }
+
+    /// PONE BIOMETRICS AS (`3059`)
+    @_alwaysEmitIntoClient
+    static var poneBiometrics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3059)
+    }
+
+    /// ER Lab LLC (`3060`)
+    @_alwaysEmitIntoClient
+    static var erLab: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3060)
+    }
+
+    /// T5 tek, Inc. (`3061`)
+    @_alwaysEmitIntoClient
+    static var t5Tek: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3061)
+    }
+
+    /// greenTEG AG (`3062`)
+    @_alwaysEmitIntoClient
+    static var greenteg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3062)
+    }
+
+    /// Wacker Neuson SE (`3063`)
+    @_alwaysEmitIntoClient
+    static var wackerNeuson: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3063)
+    }
+
+    /// Innovacionnye Resheniya (`3064`)
+    @_alwaysEmitIntoClient
+    static var innovacionnyeResheniya: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3064)
+    }
+
+    /// Alio, Inc (`3065`)
+    @_alwaysEmitIntoClient
+    static var alio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3065)
+    }
+
+    /// CleanBands Systems Ltd. (`3066`)
+    @_alwaysEmitIntoClient
+    static var cleanbandsSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3066)
+    }
+
+    /// Dodam Enersys Co., Ltd (`3067`)
+    @_alwaysEmitIntoClient
+    static var dodamEnersys: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3067)
+    }
+
+    /// T+A elektroakustik GmbH & Co.KG (`3068`)
+    @_alwaysEmitIntoClient
+    static var tAElektroakustikKg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3068)
+    }
+
+    /// Esmé Solutions (`3069`)
+    @_alwaysEmitIntoClient
+    static var esmeSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3069)
+    }
+
+    /// Media-Cartec GmbH (`3070`)
+    @_alwaysEmitIntoClient
+    static var mediaCartec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3070)
+    }
+
+    /// Ratio Electric BV (`3071`)
+    @_alwaysEmitIntoClient
+    static var ratioElectric: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3071)
+    }
+
+    /// MQA Limited (`3072`)
+    @_alwaysEmitIntoClient
+    static var mqa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3072)
+    }
+
+    /// NEOWRK SISTEMAS INTELIGENTES S.A. (`3073`)
+    @_alwaysEmitIntoClient
+    static var neowrkSistemasInteligentes: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3073)
+    }
+
+    /// Loomanet, Inc. (`3074`)
+    @_alwaysEmitIntoClient
+    static var loomanet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3074)
+    }
+
+    /// Puff Corp (`3075`)
+    @_alwaysEmitIntoClient
+    static var puff: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3075)
+    }
+
+    /// Happy Health, Inc. (`3076`)
+    @_alwaysEmitIntoClient
+    static var happyHealth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3076)
+    }
+
+    /// Montage Connect, Inc. (`3077`)
+    @_alwaysEmitIntoClient
+    static var montageConnect: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3077)
+    }
+
+    /// LED Smart Inc. (`3078`)
+    @_alwaysEmitIntoClient
+    static var ledSmart: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3078)
+    }
+
+    /// CONSTRUKTS, INC. (`3079`)
+    @_alwaysEmitIntoClient
+    static var construkts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3079)
+    }
+
+    /// limited liability company "Red" (`3080`)
+    @_alwaysEmitIntoClient
+    static var red: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3080)
+    }
+
+    /// Senic Inc. (`3081`)
+    @_alwaysEmitIntoClient
+    static var senic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3081)
+    }
+
+    /// Automated Pet Care Products, LLC (`3082`)
+    @_alwaysEmitIntoClient
+    static var automatedPetCareProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3082)
+    }
+
+    /// aconno GmbH (`3083`)
+    @_alwaysEmitIntoClient
+    static var aconno: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3083)
+    }
+
+    /// Mendeltron, Inc. (`3084`)
+    @_alwaysEmitIntoClient
+    static var mendeltron: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3084)
+    }
+
+    /// Mereltron bv (`3085`)
+    @_alwaysEmitIntoClient
+    static var mereltronBv: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3085)
+    }
+
+    /// ALEX DENKO CO.,LTD. (`3086`)
+    @_alwaysEmitIntoClient
+    static var alexDenko: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3086)
+    }
+
+    /// AETERLINK (`3087`)
+    @_alwaysEmitIntoClient
+    static var aeterlink: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3087)
+    }
+
+    /// Cosmed s.r.l. (`3088`)
+    @_alwaysEmitIntoClient
+    static var cosmed: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3088)
+    }
+
+    /// Gordon Murray Design Limited (`3089`)
+    @_alwaysEmitIntoClient
+    static var gordonMurrayDesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3089)
+    }
+
+    /// IoSA (`3090`)
+    @_alwaysEmitIntoClient
+    static var iosa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3090)
+    }
+
+    /// Scandinavian Health Limited (`3091`)
+    @_alwaysEmitIntoClient
+    static var scandinavianHealth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3091)
+    }
+
+    /// Fasetto, Inc. (`3092`)
+    @_alwaysEmitIntoClient
+    static var fasetto: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3092)
+    }
+
+    /// Geva Sol B.V. (`3093`)
+    @_alwaysEmitIntoClient
+    static var gevaSol: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3093)
+    }
+
+    /// TYKEE PTY. LTD. (`3094`)
+    @_alwaysEmitIntoClient
+    static var tykee: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3094)
+    }
+
+    /// SomnoMed Limited (`3095`)
+    @_alwaysEmitIntoClient
+    static var somnomed: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3095)
+    }
+
+    /// CORROHM (`3096`)
+    @_alwaysEmitIntoClient
+    static var corrohm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3096)
+    }
+
+    /// Arlo Technologies, Inc. (`3097`)
+    @_alwaysEmitIntoClient
+    static var arloTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3097)
+    }
+
+    /// Catapult Group International Ltd (`3098`)
+    @_alwaysEmitIntoClient
+    static var catapultGroupInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3098)
+    }
+
+    /// Rockchip Electronics Co., Ltd. (`3099`)
+    @_alwaysEmitIntoClient
+    static var rockchipElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3099)
+    }
+
+    /// GEMU (`3100`)
+    @_alwaysEmitIntoClient
+    static var gemu: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3100)
+    }
+
+    /// OFF Line Japan Co., Ltd. (`3101`)
+    @_alwaysEmitIntoClient
+    static var offLineJapan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3101)
+    }
+
+    /// EC sense co., Ltd (`3102`)
+    @_alwaysEmitIntoClient
+    static var ecSense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3102)
+    }
+
+    /// LVI Co. (`3103`)
+    @_alwaysEmitIntoClient
+    static var lvi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3103)
+    }
+
+    /// COMELIT GROUP S.P.A. (`3104`)
+    @_alwaysEmitIntoClient
+    static var comelitGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3104)
+    }
+
+    /// Foshan Viomi Electrical Technology Co., Ltd (`3105`)
+    @_alwaysEmitIntoClient
+    static var foshanViomiElectricalTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3105)
+    }
+
+    /// Glamo Inc. (`3106`)
+    @_alwaysEmitIntoClient
+    static var glamo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3106)
+    }
+
+    /// KEYTEC,Inc. (`3107`)
+    @_alwaysEmitIntoClient
+    static var keytec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3107)
+    }
+
+    /// SMARTD TECHNOLOGIES INC. (`3108`)
+    @_alwaysEmitIntoClient
+    static var smartdTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3108)
+    }
+
+    /// JURA Elektroapparate AG (`3109`)
+    @_alwaysEmitIntoClient
+    static var juraElektroapparate: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3109)
+    }
+
+    /// Performance Electronics, Ltd. (`3110`)
+    @_alwaysEmitIntoClient
+    static var performanceElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3110)
+    }
+
+    /// Pal Electronics (`3111`)
+    @_alwaysEmitIntoClient
+    static var palElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3111)
+    }
+
+    /// Embecta Corp. (`3112`)
+    @_alwaysEmitIntoClient
+    static var embecta: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3112)
+    }
+
+    /// DENSO AIRCOOL CORPORATION (`3113`)
+    @_alwaysEmitIntoClient
+    static var densoAircool: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3113)
+    }
+
+    /// Caresix Inc. (`3114`)
+    @_alwaysEmitIntoClient
+    static var caresix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3114)
+    }
+
+    /// GigaDevice Semiconductor Inc. (`3115`)
+    @_alwaysEmitIntoClient
+    static var gigadeviceSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3115)
+    }
+
+    /// Zeku Technology (Shanghai) Corp., Ltd. (`3116`)
+    @_alwaysEmitIntoClient
+    static var zekuTechnologyShanghai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3116)
+    }
+
+    /// OTF Product Sourcing, LLC (`3117`)
+    @_alwaysEmitIntoClient
+    static var otfProductSourcing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3117)
+    }
+
+    /// Easee AS (`3118`)
+    @_alwaysEmitIntoClient
+    static var easee: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3118)
+    }
+
+    /// BEEHERO, INC. (`3119`)
+    @_alwaysEmitIntoClient
+    static var beehero: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3119)
+    }
+
+    /// McIntosh Group Inc (`3120`)
+    @_alwaysEmitIntoClient
+    static var mcintoshGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3120)
+    }
+
+    /// KINDOO LLP (`3121`)
+    @_alwaysEmitIntoClient
+    static var kindooLlp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3121)
+    }
+
+    /// Xian Yisuobao Electronic Technology Co., Ltd. (`3122`)
+    @_alwaysEmitIntoClient
+    static var xianYisuobaoElectronicTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3122)
+    }
+
+    /// Exeger Operations AB (`3123`)
+    @_alwaysEmitIntoClient
+    static var exegerOperations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3123)
+    }
+
+    /// BYD Company Limited (`3124`)
+    @_alwaysEmitIntoClient
+    static var byd: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3124)
+    }
+
+    /// Thermokon-Sensortechnik GmbH (`3125`)
+    @_alwaysEmitIntoClient
+    static var thermokonSensortechnik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3125)
+    }
+
+    /// Cosmicnode BV (`3126`)
+    @_alwaysEmitIntoClient
+    static var cosmicnode: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3126)
+    }
+
+    /// SignalQuest, LLC (`3127`)
+    @_alwaysEmitIntoClient
+    static var signalquest: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3127)
+    }
+
+    /// Noritz Corporation. (`3128`)
+    @_alwaysEmitIntoClient
+    static var noritz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3128)
+    }
+
+    /// TIGER CORPORATION (`3129`)
+    @_alwaysEmitIntoClient
+    static var tiger: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3129)
+    }
+
+    /// Equinosis, LLC (`3130`)
+    @_alwaysEmitIntoClient
+    static var equinosis: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3130)
+    }
+
+    /// ORB Innovations Ltd (`3131`)
+    @_alwaysEmitIntoClient
+    static var orbInnovations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3131)
+    }
+
+    /// Classified Cycling (`3132`)
+    @_alwaysEmitIntoClient
+    static var classifiedCycling: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3132)
+    }
+
+    /// Wrmth Corp. (`3133`)
+    @_alwaysEmitIntoClient
+    static var wrmth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3133)
+    }
+
+    /// BELLDESIGN Inc. (`3134`)
+    @_alwaysEmitIntoClient
+    static var belldesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3134)
+    }
+
+    /// Stinger Equipment, Inc. (`3135`)
+    @_alwaysEmitIntoClient
+    static var stingerEquipment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3135)
+    }
+
+    /// HORIBA, Ltd. (`3136`)
+    @_alwaysEmitIntoClient
+    static var horiba: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3136)
+    }
+
+    /// Control Solutions LLC (`3137`)
+    @_alwaysEmitIntoClient
+    static var controlSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3137)
+    }
+
+    /// Heath Consultants Inc. (`3138`)
+    @_alwaysEmitIntoClient
+    static var heathConsultants: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3138)
+    }
+
+    /// Berlinger & Co. AG (`3139`)
+    @_alwaysEmitIntoClient
+    static var berlinger: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3139)
+    }
+
+    /// ONCELABS LLC (`3140`)
+    @_alwaysEmitIntoClient
+    static var oncelabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3140)
+    }
+
+    /// Brose Verwaltung SE, Bamberg (`3141`)
+    @_alwaysEmitIntoClient
+    static var broseVerwaltungSeBamberg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3141)
+    }
+
+    /// Granwin IoT Technology (Guangzhou) Co.,Ltd (`3142`)
+    @_alwaysEmitIntoClient
+    static var granwinIotTechnologyGuangzhou: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3142)
+    }
+
+    /// Epsilon Electronics,lnc (`3143`)
+    @_alwaysEmitIntoClient
+    static var epsilonElectronicsLnc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3143)
+    }
+
+    /// VALEO MANAGEMENT SERVICES (`3144`)
+    @_alwaysEmitIntoClient
+    static var valeoManagementServices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3144)
+    }
+
+    /// twopounds gmbh (`3145`)
+    @_alwaysEmitIntoClient
+    static var twopounds: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3145)
+    }
+
+    /// atSpiro ApS (`3146`)
+    @_alwaysEmitIntoClient
+    static var atspiro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3146)
+    }
+
+    /// ADTRAN, Inc. (`3147`)
+    @_alwaysEmitIntoClient
+    static var adtran: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3147)
+    }
+
+    /// Orpyx Medical Technologies Inc. (`3148`)
+    @_alwaysEmitIntoClient
+    static var orpyxMedicalTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3148)
+    }
+
+    /// Seekwave Technology Co.,ltd. (`3149`)
+    @_alwaysEmitIntoClient
+    static var seekwaveTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3149)
+    }
+
+    /// Tactile Engineering, Inc. (`3150`)
+    @_alwaysEmitIntoClient
+    static var tactileEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3150)
+    }
+
+    /// SharkNinja Operating LLC (`3151`)
+    @_alwaysEmitIntoClient
+    static var sharkninjaOperating: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3151)
+    }
+
+    /// Imostar Technologies Inc. (`3152`)
+    @_alwaysEmitIntoClient
+    static var imostarTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3152)
+    }
+
+    /// INNOVA S.R.L. (`3153`)
+    @_alwaysEmitIntoClient
+    static var innova: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3153)
+    }
+
+    /// ESCEA LIMITED (`3154`)
+    @_alwaysEmitIntoClient
+    static var escea: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3154)
+    }
+
+    /// Taco, Inc. (`3155`)
+    @_alwaysEmitIntoClient
+    static var taco: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3155)
+    }
+
+    /// HiViz Lighting, Inc. (`3156`)
+    @_alwaysEmitIntoClient
+    static var hivizLighting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3156)
+    }
+
+    /// Zintouch B.V. (`3157`)
+    @_alwaysEmitIntoClient
+    static var zintouch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3157)
+    }
+
+    /// Rheem Sales Company, Inc. (`3158`)
+    @_alwaysEmitIntoClient
+    static var rheemSales: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3158)
+    }
+
+    /// UNEEG medical A/S (`3159`)
+    @_alwaysEmitIntoClient
+    static var uneegMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3159)
+    }
+
+    /// Hykso Inc. (`3160`)
+    @_alwaysEmitIntoClient
+    static var hykso: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3160)
+    }
+
+    /// CYBERDYNE Inc. (`3161`)
+    @_alwaysEmitIntoClient
+    static var cyberdyne: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3161)
+    }
+
+    /// Lockswitch Sdn Bhd (`3162`)
+    @_alwaysEmitIntoClient
+    static var lockswitch: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3162)
+    }
+
+    /// Alban Giacomo S.P.A. (`3163`)
+    @_alwaysEmitIntoClient
+    static var albanGiacomo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3163)
+    }
+
+    /// MGM WIRELESSS HOLDINGS PTY LTD (`3164`)
+    @_alwaysEmitIntoClient
+    static var mgmWirelesssHoldings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3164)
+    }
+
+    /// StepUp Solutions ApS (`3165`)
+    @_alwaysEmitIntoClient
+    static var stepupSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3165)
+    }
+
+    /// BlueID GmbH (`3166`)
+    @_alwaysEmitIntoClient
+    static var blueid: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3166)
+    }
+
+    /// Wuxi Linkpower Microelectronics Co.,Ltd (`3167`)
+    @_alwaysEmitIntoClient
+    static var wuxiLinkpowerMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3167)
+    }
+
+    /// KEBA Energy Automation GmbH (`3168`)
+    @_alwaysEmitIntoClient
+    static var kebaEnergyAutomation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3168)
+    }
+
+    /// NNOXX, Inc (`3169`)
+    @_alwaysEmitIntoClient
+    static var nnoxx: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3169)
+    }
+
+    /// Phiaton Corporation (`3170`)
+    @_alwaysEmitIntoClient
+    static var phiaton: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3170)
+    }
+
+    /// phg Peter Hengstler GmbH + Co. KG (`3171`)
+    @_alwaysEmitIntoClient
+    static var phgPeterHengstlerKg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3171)
+    }
+
+    /// dormakaba Holding AG (`3172`)
+    @_alwaysEmitIntoClient
+    static var dormakabaHolding: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3172)
+    }
+
+    /// WAKO CO,.LTD (`3173`)
+    @_alwaysEmitIntoClient
+    static var wakoCoLtd: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3173)
+    }
+
+    /// DEN Smart Home B.V. (`3174`)
+    @_alwaysEmitIntoClient
+    static var denSmartHome: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3174)
+    }
+
+    /// TRACKTING S.R.L. (`3175`)
+    @_alwaysEmitIntoClient
+    static var trackting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3175)
+    }
+
+    /// Emerja Corporation (`3176`)
+    @_alwaysEmitIntoClient
+    static var emerja: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3176)
+    }
+
+    /// BLITZ electric motors. LTD (`3177`)
+    @_alwaysEmitIntoClient
+    static var blitzElectricMotors: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3177)
+    }
+
+    /// CONSORCIO TRUST CONTROL - NETTEL (`3178`)
+    @_alwaysEmitIntoClient
+    static var consorcioTrustControlNettel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3178)
+    }
+
+    /// GILSON SAS (`3179`)
+    @_alwaysEmitIntoClient
+    static var gilsons: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3179)
+    }
+
+    /// SNIFF LOGIC LTD (`3180`)
+    @_alwaysEmitIntoClient
+    static var sniffLogic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3180)
+    }
+
+    /// Fidure Corp. (`3181`)
+    @_alwaysEmitIntoClient
+    static var fidure: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3181)
+    }
+
+    /// Sensa LLC (`3182`)
+    @_alwaysEmitIntoClient
+    static var sensa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3182)
+    }
+
+    /// Parakey AB (`3183`)
+    @_alwaysEmitIntoClient
+    static var parakey: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3183)
+    }
+
+    /// SCARAB SOLUTIONS LTD (`3184`)
+    @_alwaysEmitIntoClient
+    static var scarabSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3184)
+    }
+
+    /// BitGreen Technolabz (OPC) Private Limited (`3185`)
+    @_alwaysEmitIntoClient
+    static var bitgreenTechnolabzOpc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3185)
+    }
+
+    /// StreetCar ORV, LLC (`3186`)
+    @_alwaysEmitIntoClient
+    static var streetcarOrv: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3186)
+    }
+
+    /// Truma Gerätetechnik GmbH & Co. KG (`3187`)
+    @_alwaysEmitIntoClient
+    static var trumaGeratetechnik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3187)
+    }
+
+    /// yupiteru (`3188`)
+    @_alwaysEmitIntoClient
+    static var yupiteru: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3188)
+    }
+
+    /// Embedded Engineering Solutions LLC (`3189`)
+    @_alwaysEmitIntoClient
+    static var embeddedEngineeringSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3189)
+    }
+
+    /// Shenzhen Gwell Times Technology Co. , Ltd (`3190`)
+    @_alwaysEmitIntoClient
+    static var shenzhenGwellTimesTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3190)
+    }
+
+    /// TEAC Corporation (`3191`)
+    @_alwaysEmitIntoClient
+    static var teac: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3191)
+    }
+
+    /// CHARGTRON IOT PRIVATE LIMITED (`3192`)
+    @_alwaysEmitIntoClient
+    static var chargtronIot: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3192)
+    }
+
+    /// Zhuhai Smartlink Technology Co., Ltd (`3193`)
+    @_alwaysEmitIntoClient
+    static var zhuhaiSmartlinkTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3193)
+    }
+
+    /// Triductor Technology (Suzhou), Inc. (`3194`)
+    @_alwaysEmitIntoClient
+    static var triductorTechnologySuzhou: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3194)
+    }
+
+    /// PT SADAMAYA GRAHA TEKNOLOGI (`3195`)
+    @_alwaysEmitIntoClient
+    static var ptdamayaGrahaTeknologi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3195)
+    }
+
+    /// Mopeka Products LLC (`3196`)
+    @_alwaysEmitIntoClient
+    static var mopekaProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3196)
+    }
+
+    /// 3ALogics, Inc. (`3197`)
+    @_alwaysEmitIntoClient
+    static var company3Alogics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3197)
+    }
+
+    /// BOOMING OF THINGS (`3198`)
+    @_alwaysEmitIntoClient
+    static var boomingOfThings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3198)
+    }
+
+    /// Rochester Sensors, LLC (`3199`)
+    @_alwaysEmitIntoClient
+    static var rochesterSensors: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3199)
+    }
+
+    /// CARDIOID - TECHNOLOGIES, LDA (`3200`)
+    @_alwaysEmitIntoClient
+    static var cardioidTechnologiesLda: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3200)
+    }
+
+    /// Carrier Corporation (`3201`)
+    @_alwaysEmitIntoClient
+    static var carrier: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3201)
+    }
+
+    /// NACON (`3202`)
+    @_alwaysEmitIntoClient
+    static var nacon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3202)
+    }
+
+    /// Watchdog Systems LLC (`3203`)
+    @_alwaysEmitIntoClient
+    static var watchdogSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3203)
+    }
+
+    /// MAXON INDUSTRIES, INC. (`3204`)
+    @_alwaysEmitIntoClient
+    static var maxonIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3204)
+    }
+
+    /// Amlogic, Inc. (`3205`)
+    @_alwaysEmitIntoClient
+    static var amlogic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3205)
+    }
+
+    /// Qingdao Eastsoft Communication Technology Co.,Ltd (`3206`)
+    @_alwaysEmitIntoClient
+    static var qingdaoEastsoftCommunicationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3206)
+    }
+
+    /// Weltek Technologies Company Limited (`3207`)
+    @_alwaysEmitIntoClient
+    static var weltekTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3207)
+    }
+
+    /// Nextivity Inc. (`3208`)
+    @_alwaysEmitIntoClient
+    static var nextivity: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3208)
+    }
+
+    /// AGZZX OPTOELECTRONICS TECHNOLOGY CO., LTD (`3209`)
+    @_alwaysEmitIntoClient
+    static var agzzxOptoelectronicsTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3209)
+    }
+
+    /// A.GLOBAL co.,Ltd. (`3210`)
+    @_alwaysEmitIntoClient
+    static var aGlobal: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3210)
+    }
+
+    /// Heavys Inc (`3211`)
+    @_alwaysEmitIntoClient
+    static var heavys: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3211)
+    }
+
+    /// T-Mobile USA (`3212`)
+    @_alwaysEmitIntoClient
+    static var tMobileUsa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3212)
+    }
+
+    /// tonies GmbH (`3213`)
+    @_alwaysEmitIntoClient
+    static var tonies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3213)
+    }
+
+    /// Technocon Engineering Ltd. (`3214`)
+    @_alwaysEmitIntoClient
+    static var technoconEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3214)
+    }
+
+    /// Radar Automobile Sales(Shandong)Co.,Ltd. (`3215`)
+    @_alwaysEmitIntoClient
+    static var radarAutomobileSalesShandong: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3215)
+    }
+
+    /// WESCO AG (`3216`)
+    @_alwaysEmitIntoClient
+    static var wesco: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3216)
+    }
+
+    /// Yashu Systems (`3217`)
+    @_alwaysEmitIntoClient
+    static var yashuSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3217)
+    }
+
+    /// Kesseböhmer Ergonomietechnik GmbH (`3218`)
+    @_alwaysEmitIntoClient
+    static var kessebohmerErgonomietechnik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3218)
+    }
+
+    /// Movesense Oy (`3219`)
+    @_alwaysEmitIntoClient
+    static var movesense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3219)
+    }
+
+    /// Baxter Healthcare Corporation (`3220`)
+    @_alwaysEmitIntoClient
+    static var baxterHealthcare: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3220)
+    }
+
+    /// Gemstone Lights Canada Ltd. (`3221`)
+    @_alwaysEmitIntoClient
+    static var gemstoneLightsCanada: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3221)
+    }
+
+    /// H+B Hightech GmbH (`3222`)
+    @_alwaysEmitIntoClient
+    static var hBHightech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3222)
+    }
+
+    /// Deako (`3223`)
+    @_alwaysEmitIntoClient
+    static var deako: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3223)
+    }
+
+    /// MiX Telematics International (PTY) LTD (`3224`)
+    @_alwaysEmitIntoClient
+    static var mixTelematicsInternationalPty: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3224)
+    }
+
+    /// Vire Health Oy (`3225`)
+    @_alwaysEmitIntoClient
+    static var vireHealth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3225)
+    }
+
+    /// ALF Inc. (`3226`)
+    @_alwaysEmitIntoClient
+    static var alf: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3226)
+    }
+
+    /// NTT sonority, Inc. (`3227`)
+    @_alwaysEmitIntoClient
+    static var nttSonority: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3227)
+    }
+
+    /// Sunstone-RTLS Ipari Szolgaltato Korlatolt Felelossegu Tarsasag (`3228`)
+    @_alwaysEmitIntoClient
+    static var sunstoneRtlsIpariSzolgaltatoKorlatoltFelelosseguTarsasag: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3228)
+    }
+
+    /// Ribbiot, INC. (`3229`)
+    @_alwaysEmitIntoClient
+    static var ribbiot: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3229)
+    }
+
+    /// ECCEL CORPORATION SAS (`3230`)
+    @_alwaysEmitIntoClient
+    static var eccels: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3230)
+    }
+
+    /// Dragonfly Energy Corp. (`3231`)
+    @_alwaysEmitIntoClient
+    static var dragonflyEnergy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3231)
+    }
+
+    /// BIGBEN (`3232`)
+    @_alwaysEmitIntoClient
+    static var bigben: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3232)
+    }
+
+    /// YAMAHA MOTOR CO.,LTD. (`3233`)
+    @_alwaysEmitIntoClient
+    static var yamahaMotor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3233)
+    }
+
+    /// XSENSE LTD (`3234`)
+    @_alwaysEmitIntoClient
+    static var xsense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3234)
+    }
+
+    /// MAQUET GmbH (`3235`)
+    @_alwaysEmitIntoClient
+    static var maquet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3235)
+    }
+
+    /// MITSUBISHI ELECTRIC LIGHTING CO, LTD (`3236`)
+    @_alwaysEmitIntoClient
+    static var mitsubishiElectricLighting: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3236)
+    }
+
+    /// Princess Cruise Lines, Ltd. (`3237`)
+    @_alwaysEmitIntoClient
+    static var princessCruiseLines: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3237)
+    }
+
+    /// Megger Ltd (`3238`)
+    @_alwaysEmitIntoClient
+    static var megger: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3238)
+    }
+
+    /// Verve InfoTec Pty Ltd (`3239`)
+    @_alwaysEmitIntoClient
+    static var verveInfotec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3239)
+    }
+
+    /// Sonas, Inc. (`3240`)
+    @_alwaysEmitIntoClient
+    static var sonas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3240)
+    }
+
+    /// Mievo Technologies Private Limited (`3241`)
+    @_alwaysEmitIntoClient
+    static var mievoTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3241)
+    }
+
+    /// Shenzhen Poseidon Network Technology Co., Ltd (`3242`)
+    @_alwaysEmitIntoClient
+    static var shenzhenPoseidonNetworkTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3242)
+    }
+
+    /// HERUTU ELECTRONICS CORPORATION (`3243`)
+    @_alwaysEmitIntoClient
+    static var herutuElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3243)
+    }
+
+    /// Shenzhen Shokz Co.,Ltd. (`3244`)
+    @_alwaysEmitIntoClient
+    static var shenzhenShokz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3244)
+    }
+
+    /// Shenzhen Openhearing Tech CO., LTD . (`3245`)
+    @_alwaysEmitIntoClient
+    static var shenzhenOpenhearingTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3245)
+    }
+
+    /// Evident Corporation (`3246`)
+    @_alwaysEmitIntoClient
+    static var evident: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3246)
+    }
+
+    /// NEURINNOV (`3247`)
+    @_alwaysEmitIntoClient
+    static var neurinnov: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3247)
+    }
+
+    /// SwipeSense, Inc. (`3248`)
+    @_alwaysEmitIntoClient
+    static var swipesense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3248)
+    }
+
+    /// RF Creations (`3249`)
+    @_alwaysEmitIntoClient
+    static var rfCreations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3249)
+    }
+
+    /// SHINKAWA Sensor Technology, Inc. (`3250`)
+    @_alwaysEmitIntoClient
+    static var shinkawaSensorTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3250)
+    }
+
+    /// janova GmbH (`3251`)
+    @_alwaysEmitIntoClient
+    static var janova: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3251)
+    }
+
+    /// Eberspaecher Climate Control Systems GmbH (`3252`)
+    @_alwaysEmitIntoClient
+    static var eberspaecherClimateControlSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3252)
+    }
+
+    /// Racketry, d. o. o. (`3253`)
+    @_alwaysEmitIntoClient
+    static var racketryDOO: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3253)
+    }
+
+    /// THE EELECTRIC MACARON LLC (`3254`)
+    @_alwaysEmitIntoClient
+    static var eelectricMacaron: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3254)
+    }
+
+    /// Cucumber Lighting Controls Limited (`3255`)
+    @_alwaysEmitIntoClient
+    static var cucumberLightingControls: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3255)
+    }
+
+    /// Shanghai Proxy Network Technology Co., Ltd. (`3256`)
+    @_alwaysEmitIntoClient
+    static var shanghaiProxyNetworkTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3256)
+    }
+
+    /// seca GmbH & Co. KG (`3257`)
+    @_alwaysEmitIntoClient
+    static var seca: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3257)
+    }
+
+    /// Ameso Tech (OPC) Private Limited (`3258`)
+    @_alwaysEmitIntoClient
+    static var amesoTechOpc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3258)
+    }
+
+    /// Emlid Tech Kft. (`3259`)
+    @_alwaysEmitIntoClient
+    static var emlidTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3259)
+    }
+
+    /// TROX GmbH (`3260`)
+    @_alwaysEmitIntoClient
+    static var trox: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3260)
+    }
+
+    /// Pricer AB (`3261`)
+    @_alwaysEmitIntoClient
+    static var pricer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3261)
+    }
+
+    /// Forward Thinking Systems LLC. (`3263`)
+    @_alwaysEmitIntoClient
+    static var forwardThinkingSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3263)
+    }
+
+    /// Garnet Instruments Ltd. (`3264`)
+    @_alwaysEmitIntoClient
+    static var garnetInstruments: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3264)
+    }
+
+    /// CLEIO Inc. (`3265`)
+    @_alwaysEmitIntoClient
+    static var cleio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3265)
+    }
+
+    /// Anker Innovations Limited (`3266`)
+    @_alwaysEmitIntoClient
+    static var ankerInnovations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3266)
+    }
+
+    /// HMD Global Oy (`3267`)
+    @_alwaysEmitIntoClient
+    static var hmdGlobal: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3267)
+    }
+
+    /// ABUS August Bremicker Soehne Kommanditgesellschaft (`3268`)
+    @_alwaysEmitIntoClient
+    static var abusAugustBremickerSoehneKommanditgesellschaft: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3268)
+    }
+
+    /// Open Road Solutions, Inc. (`3269`)
+    @_alwaysEmitIntoClient
+    static var openRoadSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3269)
+    }
+
+    /// Serial Technology Corporation (`3270`)
+    @_alwaysEmitIntoClient
+    static var serialTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3270)
+    }
+
+    /// SB C&S Corp. (`3271`)
+    @_alwaysEmitIntoClient
+    static var sbCS: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3271)
+    }
+
+    /// TrikThom (`3272`)
+    @_alwaysEmitIntoClient
+    static var trikthom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3272)
+    }
+
+    /// Innocent Technology Co., Ltd. (`3273`)
+    @_alwaysEmitIntoClient
+    static var innocentTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3273)
+    }
+
+    /// Cyclops Marine Ltd (`3274`)
+    @_alwaysEmitIntoClient
+    static var cyclopsMarine: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3274)
+    }
+
+    /// NOTHING TECHNOLOGY LIMITED (`3275`)
+    @_alwaysEmitIntoClient
+    static var nothingTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3275)
+    }
+
+    /// Kord Defence Pty Ltd (`3276`)
+    @_alwaysEmitIntoClient
+    static var kordDefence: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3276)
+    }
+
+    /// YanFeng Visteon(Chongqing) Automotive Electronic Co.,Ltd (`3277`)
+    @_alwaysEmitIntoClient
+    static var yanfengVisteonChongqingAutomotiveElectronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3277)
+    }
+
+    /// SENOSPACE LLC (`3278`)
+    @_alwaysEmitIntoClient
+    static var senospace: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3278)
+    }
+
+    /// Shenzhen CESI Information Technology Co., Ltd. (`3279`)
+    @_alwaysEmitIntoClient
+    static var shenzhenCesiInformationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3279)
+    }
+
+    /// MooreSilicon Semiconductor Technology (Shanghai) Co., LTD. (`3280`)
+    @_alwaysEmitIntoClient
+    static var mooresiliconSemiconductorTechnologyShanghai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3280)
+    }
+
+    /// Imagine Marketing Limited (`3281`)
+    @_alwaysEmitIntoClient
+    static var imagineMarketing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3281)
+    }
+
+    /// EQOM SSC B.V. (`3282`)
+    @_alwaysEmitIntoClient
+    static var eqomSsc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3282)
+    }
+
+    /// TechSwipe (`3283`)
+    @_alwaysEmitIntoClient
+    static var techswipe: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3283)
+    }
+
+    /// Reoqoo IoT Technology Co., Ltd. (`3284`)
+    @_alwaysEmitIntoClient
+    static var reoqooIotTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3284)
+    }
+
+    /// Numa Products, LLC (`3285`)
+    @_alwaysEmitIntoClient
+    static var numaProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3285)
+    }
+
+    /// HHO (Hangzhou) Digital Technology Co., Ltd. (`3286`)
+    @_alwaysEmitIntoClient
+    static var hhoHangzhouDigitalTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3286)
+    }
+
+    /// Maztech Industries, LLC (`3287`)
+    @_alwaysEmitIntoClient
+    static var maztechIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3287)
+    }
+
+    /// SIA Mesh Group (`3288`)
+    @_alwaysEmitIntoClient
+    static var siaMeshGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3288)
+    }
+
+    /// Minami acoustics Limited (`3289`)
+    @_alwaysEmitIntoClient
+    static var minamiAcoustics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3289)
+    }
+
+    /// Wolf Steel ltd (`3290`)
+    @_alwaysEmitIntoClient
+    static var wolfSteel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3290)
+    }
+
+    /// Circus World Displays Limited (`3291`)
+    @_alwaysEmitIntoClient
+    static var circusWorldDisplays: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3291)
+    }
+
+    /// Ypsomed AG (`3292`)
+    @_alwaysEmitIntoClient
+    static var ypsomed: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3292)
+    }
+
+    /// Alif Semiconductor, Inc. (`3293`)
+    @_alwaysEmitIntoClient
+    static var alifSemiconductor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3293)
+    }
+
+    /// RESPONSE TECHNOLOGIES, LTD. (`3294`)
+    @_alwaysEmitIntoClient
+    static var responseTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3294)
+    }
+
+    /// SHENZHEN CHENYUN ELECTRONICS  CO., LTD (`3295`)
+    @_alwaysEmitIntoClient
+    static var shenzhenChenyunElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3295)
+    }
+
+    /// VODALOGIC PTY LTD (`3296`)
+    @_alwaysEmitIntoClient
+    static var vodalogic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3296)
+    }
+
+    /// Regal Beloit America, Inc. (`3297`)
+    @_alwaysEmitIntoClient
+    static var regalBeloitAmerica: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3297)
+    }
+
+    /// CORVENT MEDICAL, INC. (`3298`)
+    @_alwaysEmitIntoClient
+    static var corventMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3298)
+    }
+
+    /// Taiwan Fuhsing (`3299`)
+    @_alwaysEmitIntoClient
+    static var taiwanFuhsing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3299)
+    }
+
+    /// Off-Highway Powertrain Services Germany GmbH (`3300`)
+    @_alwaysEmitIntoClient
+    static var offHighwayPowertrainServicesGermany: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3300)
+    }
+
+    /// Amina Distribution AS (`3301`)
+    @_alwaysEmitIntoClient
+    static var aminaDistribution: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3301)
+    }
+
+    /// McWong International, Inc. (`3302`)
+    @_alwaysEmitIntoClient
+    static var mcwongInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3302)
+    }
+
+    /// TAG HEUER SA (`3303`)
+    @_alwaysEmitIntoClient
+    static var tagHeuer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3303)
+    }
+
+    /// Dongguan Yougo Electronics Co.,Ltd. (`3304`)
+    @_alwaysEmitIntoClient
+    static var dongguanYougoElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3304)
+    }
+
+    /// PEAG, LLC dba JLab Audio (`3305`)
+    @_alwaysEmitIntoClient
+    static var peagDbaJlabAudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3305)
+    }
+
+    /// HAYWARD INDUSTRIES, INC. (`3306`)
+    @_alwaysEmitIntoClient
+    static var haywardIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3306)
+    }
+
+    /// Shenzhen Tingting Technology Co. LTD (`3307`)
+    @_alwaysEmitIntoClient
+    static var shenzhenTingtingTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3307)
+    }
+
+    /// Pacific Coast Fishery Services (2003) Inc. (`3308`)
+    @_alwaysEmitIntoClient
+    static var pacificCoastFisheryServices2003: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3308)
+    }
+
+    /// CV. NURI TEKNIK (`3309`)
+    @_alwaysEmitIntoClient
+    static var cvNuriTeknik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3309)
+    }
+
+    /// MadgeTech, Inc (`3310`)
+    @_alwaysEmitIntoClient
+    static var madgetech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3310)
+    }
+
+    /// POGS B.V. (`3311`)
+    @_alwaysEmitIntoClient
+    static var pogs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3311)
+    }
+
+    /// THOTAKA TEKHNOLOGIES INDIA PRIVATE LIMITED (`3312`)
+    @_alwaysEmitIntoClient
+    static var thotakaTekhnologiesIndia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3312)
+    }
+
+    /// Midmark (`3313`)
+    @_alwaysEmitIntoClient
+    static var midmark: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3313)
+    }
+
+    /// BestSens AG (`3314`)
+    @_alwaysEmitIntoClient
+    static var bestsens: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3314)
+    }
+
+    /// Radio Sound (`3315`)
+    @_alwaysEmitIntoClient
+    static var radioSound: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3315)
+    }
+
+    /// SOLUX PTY LTD (`3316`)
+    @_alwaysEmitIntoClient
+    static var solux: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3316)
+    }
+
+    /// BOS Balance of Storage Systems AG (`3317`)
+    @_alwaysEmitIntoClient
+    static var bosBalanceOfStorageSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3317)
+    }
+
+    /// OJ Electronics A/S (`3318`)
+    @_alwaysEmitIntoClient
+    static var ojElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3318)
+    }
+
+    /// TVS Motor Company Ltd. (`3319`)
+    @_alwaysEmitIntoClient
+    static var tvsMotor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3319)
+    }
+
+    /// core sensing GmbH (`3320`)
+    @_alwaysEmitIntoClient
+    static var coreSensing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3320)
+    }
+
+    /// Tamblue Oy (`3321`)
+    @_alwaysEmitIntoClient
+    static var tamblue: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3321)
+    }
+
+    /// Protect Animals With Satellites LLC (`3322`)
+    @_alwaysEmitIntoClient
+    static var protectAnimalsWithSatellites: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3322)
+    }
+
+    /// Tyromotion GmbH (`3323`)
+    @_alwaysEmitIntoClient
+    static var tyromotion: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3323)
+    }
+
+    /// ElectronX design (`3324`)
+    @_alwaysEmitIntoClient
+    static var electronxDesign: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3324)
+    }
+
+    /// Wuhan Woncan Construction Technologies Co., Ltd. (`3325`)
+    @_alwaysEmitIntoClient
+    static var wuhanWoncanConstructionTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3325)
+    }
+
+    /// Thule Group AB (`3326`)
+    @_alwaysEmitIntoClient
+    static var thuleGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3326)
+    }
+
+    /// Ergodriven Inc (`3327`)
+    @_alwaysEmitIntoClient
+    static var ergodriven: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3327)
+    }
+
+    /// Sparkpark AS (`3328`)
+    @_alwaysEmitIntoClient
+    static var sparkpark: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3328)
+    }
+
+    /// KEEPEN (`3329`)
+    @_alwaysEmitIntoClient
+    static var keepen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3329)
+    }
+
+    /// Rocky Mountain ATV/MC Jake Wilson (`3330`)
+    @_alwaysEmitIntoClient
+    static var rockyMountainAtvMcJakeWilson: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3330)
+    }
+
+    /// MakuSafe Corp (`3331`)
+    @_alwaysEmitIntoClient
+    static var makusafe: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3331)
+    }
+
+    /// Bartec Auto Id Ltd (`3332`)
+    @_alwaysEmitIntoClient
+    static var bartecAutoId: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3332)
+    }
+
+    /// Energy Technology and Control Limited (`3333`)
+    @_alwaysEmitIntoClient
+    static var energyTechnologyAndControl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3333)
+    }
+
+    /// doubleO Co., Ltd. (`3334`)
+    @_alwaysEmitIntoClient
+    static var doubleo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3334)
+    }
+
+    /// Datalogic S.r.l. (`3335`)
+    @_alwaysEmitIntoClient
+    static var datalogic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3335)
+    }
+
+    /// Datalogic USA, Inc. (`3336`)
+    @_alwaysEmitIntoClient
+    static var datalogic2: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3336)
+    }
+
+    /// Leica Geosystems AG (`3337`)
+    @_alwaysEmitIntoClient
+    static var leicaGeosystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3337)
+    }
+
+    /// CATEYE Co., Ltd. (`3338`)
+    @_alwaysEmitIntoClient
+    static var cateye: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3338)
+    }
+
+    /// Research Products Corporation (`3339`)
+    @_alwaysEmitIntoClient
+    static var researchProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3339)
+    }
+
+    /// Planmeca Oy (`3340`)
+    @_alwaysEmitIntoClient
+    static var planmeca: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3340)
+    }
+
+    /// C.Ed. Schulte GmbH Zylinderschlossfabrik (`3341`)
+    @_alwaysEmitIntoClient
+    static var cEdSchulteZylinderschlossfabrik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3341)
+    }
+
+    /// PetVoice Co., Ltd. (`3342`)
+    @_alwaysEmitIntoClient
+    static var petvoice: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3342)
+    }
+
+    /// Timebirds Australia Pty Ltd (`3343`)
+    @_alwaysEmitIntoClient
+    static var timebirdsAustralia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3343)
+    }
+
+    /// JVC KENWOOD Corporation (`3344`)
+    @_alwaysEmitIntoClient
+    static var jvcKenwood: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3344)
+    }
+
+    /// Great Dane LLC (`3345`)
+    @_alwaysEmitIntoClient
+    static var greatDane: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3345)
+    }
+
+    /// Spartek Systems Inc. (`3346`)
+    @_alwaysEmitIntoClient
+    static var spartekSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3346)
+    }
+
+    /// MERRY ELECTRONICS CO., LTD. (`3347`)
+    @_alwaysEmitIntoClient
+    static var merryElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3347)
+    }
+
+    /// Merry Electronics (S) Pte Ltd (`3348`)
+    @_alwaysEmitIntoClient
+    static var merryElectronicsSPte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3348)
+    }
+
+    /// Spark (`3349`)
+    @_alwaysEmitIntoClient
+    static var spark: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3349)
+    }
+
+    /// Nations Technologies Inc. (`3350`)
+    @_alwaysEmitIntoClient
+    static var nationsTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3350)
+    }
+
+    /// Akix S.r.l. (`3351`)
+    @_alwaysEmitIntoClient
+    static var akix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3351)
+    }
+
+    /// Bioliberty Ltd (`3352`)
+    @_alwaysEmitIntoClient
+    static var bioliberty: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3352)
+    }
+
+    /// C.G. Air Systemes Inc. (`3353`)
+    @_alwaysEmitIntoClient
+    static var cGAirSystemes: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3353)
+    }
+
+    /// Maturix ApS (`3354`)
+    @_alwaysEmitIntoClient
+    static var maturix: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3354)
+    }
+
+    /// RACHIO, INC. (`3355`)
+    @_alwaysEmitIntoClient
+    static var rachio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3355)
+    }
+
+    /// LIMBOID LLC (`3356`)
+    @_alwaysEmitIntoClient
+    static var limboid: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3356)
+    }
+
+    /// Electronics4All Inc. (`3357`)
+    @_alwaysEmitIntoClient
+    static var electronics4All: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3357)
+    }
+
+    /// FESTINA LOTUS SA (`3358`)
+    @_alwaysEmitIntoClient
+    static var festinaLotus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3358)
+    }
+
+    /// Synkopi, Inc. (`3359`)
+    @_alwaysEmitIntoClient
+    static var synkopi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3359)
+    }
+
+    /// SCIENTERRA LIMITED (`3360`)
+    @_alwaysEmitIntoClient
+    static var scienterra: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3360)
+    }
+
+    /// Cennox Group Limited (`3361`)
+    @_alwaysEmitIntoClient
+    static var cennoxGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3361)
+    }
+
+    /// Cedarware, Corp. (`3362`)
+    @_alwaysEmitIntoClient
+    static var cedarware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3362)
+    }
+
+    /// GREE Electric Appliances, Inc. of Zhuhai (`3363`)
+    @_alwaysEmitIntoClient
+    static var greeElectricAppliancesOfZhuhai: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3363)
+    }
+
+    /// Japan Display Inc. (`3364`)
+    @_alwaysEmitIntoClient
+    static var japanDisplay: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3364)
+    }
+
+    /// System Elite Holdings Group Limited (`3365`)
+    @_alwaysEmitIntoClient
+    static var systemEliteHoldingsGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3365)
+    }
+
+    /// Burkert Werke GmbH & Co. KG (`3366`)
+    @_alwaysEmitIntoClient
+    static var burkertWerke: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3366)
+    }
+
+    /// velocitux (`3367`)
+    @_alwaysEmitIntoClient
+    static var velocitux: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3367)
+    }
+
+    /// FUJITSU COMPONENT LIMITED (`3368`)
+    @_alwaysEmitIntoClient
+    static var fujitsuComponent: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3368)
+    }
+
+    /// MIYAKAWA ELECTRIC WORKS LTD. (`3369`)
+    @_alwaysEmitIntoClient
+    static var miyakawaElectricWorks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3369)
+    }
+
+    /// PhysioLogic Devices, Inc. (`3370`)
+    @_alwaysEmitIntoClient
+    static var physiologicDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3370)
+    }
+
+    /// Sensoryx AG (`3371`)
+    @_alwaysEmitIntoClient
+    static var sensoryx: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3371)
+    }
+
+    /// SIL System Integration Laboratory GmbH (`3372`)
+    @_alwaysEmitIntoClient
+    static var silSystemIntegrationLaboratory: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3372)
+    }
+
+    /// Cooler Pro, LLC (`3373`)
+    @_alwaysEmitIntoClient
+    static var coolerPro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3373)
+    }
+
+    /// Advanced Electronic Applications, Inc (`3374`)
+    @_alwaysEmitIntoClient
+    static var advancedElectronicApplications: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3374)
+    }
+
+    /// Delta Development Team, Inc (`3375`)
+    @_alwaysEmitIntoClient
+    static var deltaDevelopmentTeam: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3375)
+    }
+
+    /// Laxmi Therapeutic Devices, Inc. (`3376`)
+    @_alwaysEmitIntoClient
+    static var laxmiTherapeuticDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3376)
+    }
+
+    /// SYNCHRON, INC. (`3377`)
+    @_alwaysEmitIntoClient
+    static var synchron: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3377)
+    }
+
+    /// Badger Meter (`3378`)
+    @_alwaysEmitIntoClient
+    static var badgerMeter: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3378)
+    }
+
+    /// Micropower Group AB (`3379`)
+    @_alwaysEmitIntoClient
+    static var micropowerGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3379)
+    }
+
+    /// ZILLIOT TECHNOLOGIES PRIVATE LIMITED (`3380`)
+    @_alwaysEmitIntoClient
+    static var zilliotTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3380)
+    }
+
+    /// Universidad Politecnica de Madrid (`3381`)
+    @_alwaysEmitIntoClient
+    static var universidadPolitecnicaDeMadrid: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3381)
+    }
+
+    /// XIHAO INTELLIGENGT TECHNOLOGY CO., LTD (`3382`)
+    @_alwaysEmitIntoClient
+    static var xihaoIntelligengtTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3382)
+    }
+
+    /// Zerene Inc. (`3383`)
+    @_alwaysEmitIntoClient
+    static var zerene: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3383)
+    }
+
+    /// CycLock (`3384`)
+    @_alwaysEmitIntoClient
+    static var cyclock: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3384)
+    }
+
+    /// Systemic Games, LLC (`3385`)
+    @_alwaysEmitIntoClient
+    static var systemicGames: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3385)
+    }
+
+    /// Frost Solutions, LLC (`3386`)
+    @_alwaysEmitIntoClient
+    static var frostSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3386)
+    }
+
+    /// Lone Star Marine Pty Ltd (`3387`)
+    @_alwaysEmitIntoClient
+    static var loneStarMarine: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3387)
+    }
+
+    /// SIRONA Dental Systems GmbH (`3388`)
+    @_alwaysEmitIntoClient
+    static var sironaDentalSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3388)
+    }
+
+    /// bHaptics Inc. (`3389`)
+    @_alwaysEmitIntoClient
+    static var bhaptics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3389)
+    }
+
+    /// LUMINOAH, INC. (`3390`)
+    @_alwaysEmitIntoClient
+    static var luminoah: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3390)
+    }
+
+    /// Vogels Products B.V. (`3391`)
+    @_alwaysEmitIntoClient
+    static var vogelsProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3391)
+    }
+
+    /// SignalFire Telemetry, Inc. (`3392`)
+    @_alwaysEmitIntoClient
+    static var signalfireTelemetry: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3392)
+    }
+
+    /// CPAC Systems AB (`3393`)
+    @_alwaysEmitIntoClient
+    static var cpacSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3393)
+    }
+
+    /// TEKTRO TECHNOLOGY CORPORATION (`3394`)
+    @_alwaysEmitIntoClient
+    static var tektroTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3394)
+    }
+
+    /// Gosuncn Technology Group Co., Ltd. (`3395`)
+    @_alwaysEmitIntoClient
+    static var gosuncnTechnologyGroup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3395)
+    }
+
+    /// Ex Makhina Inc. (`3396`)
+    @_alwaysEmitIntoClient
+    static var exMakhina: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3396)
+    }
+
+    /// Odeon, Inc. (`3397`)
+    @_alwaysEmitIntoClient
+    static var odeon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3397)
+    }
+
+    /// Thales Simulation & Training AG (`3398`)
+    @_alwaysEmitIntoClient
+    static var thalesSimulationTraining: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3398)
+    }
+
+    /// Shenzhen DOKE Electronic Co., Ltd (`3399`)
+    @_alwaysEmitIntoClient
+    static var shenzhenDokeElectronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3399)
+    }
+
+    /// Vemcon GmbH (`3400`)
+    @_alwaysEmitIntoClient
+    static var vemcon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3400)
+    }
+
+    /// Refrigerated Transport Electronics, Inc. (`3401`)
+    @_alwaysEmitIntoClient
+    static var refrigeratedTransportElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3401)
+    }
+
+    /// Rockpile Solutions, LLC (`3402`)
+    @_alwaysEmitIntoClient
+    static var rockpileSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3402)
+    }
+
+    /// Soundwave Hearing, LLC (`3403`)
+    @_alwaysEmitIntoClient
+    static var soundwaveHearing: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3403)
+    }
+
+    /// IotGizmo Corporation (`3404`)
+    @_alwaysEmitIntoClient
+    static var iotgizmo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3404)
+    }
+
+    /// Optec, LLC (`3405`)
+    @_alwaysEmitIntoClient
+    static var optec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3405)
+    }
+
+    /// NIKAT SOLUTIONS PRIVATE LIMITED (`3406`)
+    @_alwaysEmitIntoClient
+    static var nikatSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3406)
+    }
+
+    /// Movano Inc. (`3407`)
+    @_alwaysEmitIntoClient
+    static var movano: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3407)
+    }
+
+    /// NINGBO FOTILE KITCHENWARE CO., LTD. (`3408`)
+    @_alwaysEmitIntoClient
+    static var ningboFotileKitchenware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3408)
+    }
+
+    /// Genetus inc. (`3409`)
+    @_alwaysEmitIntoClient
+    static var genetus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3409)
+    }
+
+    /// DIVAN TRADING CO., LTD. (`3410`)
+    @_alwaysEmitIntoClient
+    static var divanTrading: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3410)
+    }
+
+    /// Luxottica Group S.p.A (`3411`)
+    @_alwaysEmitIntoClient
+    static var luxotticaGroupSPA: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3411)
+    }
+
+    /// ISEKI FRANCE S.A.S (`3412`)
+    @_alwaysEmitIntoClient
+    static var isekiFrance: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3412)
+    }
+
+    /// NO CLIMB PRODUCTS LTD (`3413`)
+    @_alwaysEmitIntoClient
+    static var noClimbProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3413)
+    }
+
+    /// Wellang.Co,.Ltd (`3414`)
+    @_alwaysEmitIntoClient
+    static var wellangCoLtd: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3414)
+    }
+
+    /// Nanjing Xinxiangyuan Microelectronics Co., Ltd. (`3415`)
+    @_alwaysEmitIntoClient
+    static var nanjingXinxiangyuanMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3415)
+    }
+
+    /// ifm electronic gmbh (`3416`)
+    @_alwaysEmitIntoClient
+    static var ifmElectronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3416)
+    }
+
+    /// HYUPSUNG MACHINERY ELECTRIC CO., LTD. (`3417`)
+    @_alwaysEmitIntoClient
+    static var hyupsungMachineryElectric: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3417)
+    }
+
+    /// Gunnebo Aktiebolag (`3418`)
+    @_alwaysEmitIntoClient
+    static var gunneboAktiebolag: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3418)
+    }
+
+    /// Axis Communications AB (`3419`)
+    @_alwaysEmitIntoClient
+    static var axisCommunications: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3419)
+    }
+
+    /// Pison Technology, Inc. (`3420`)
+    @_alwaysEmitIntoClient
+    static var pisonTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3420)
+    }
+
+    /// Stogger B.V. (`3421`)
+    @_alwaysEmitIntoClient
+    static var stogger: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3421)
+    }
+
+    /// Pella Corp (`3422`)
+    @_alwaysEmitIntoClient
+    static var pella: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3422)
+    }
+
+    /// SiChuan Homme Intelligent Technology co.,Ltd. (`3423`)
+    @_alwaysEmitIntoClient
+    static var sichuanHommeIntelligentTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3423)
+    }
+
+    /// Smart Products Connection, S.A. (`3424`)
+    @_alwaysEmitIntoClient
+    static var smartProductsConnection: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3424)
+    }
+
+    /// F.I.P. FORMATURA INIEZIONE POLIMERI - S.P.A. (`3425`)
+    @_alwaysEmitIntoClient
+    static var fIPFormaturaIniezionePolimeri: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3425)
+    }
+
+    /// MEBSTER s.r.o. (`3426`)
+    @_alwaysEmitIntoClient
+    static var mebster: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3426)
+    }
+
+    /// SKF France (`3427`)
+    @_alwaysEmitIntoClient
+    static var skfFrance: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3427)
+    }
+
+    /// Southco (`3428`)
+    @_alwaysEmitIntoClient
+    static var southco: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3428)
+    }
+
+    /// Molnlycke Health Care AB (`3429`)
+    @_alwaysEmitIntoClient
+    static var molnlyckeHealthCare: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3429)
+    }
+
+    /// Hendrickson USA , L.L.C (`3430`)
+    @_alwaysEmitIntoClient
+    static var hendricksonUsaLLC: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3430)
+    }
+
+    /// BLACK BOX NETWORK SERVICES INDIA PRIVATE LIMITED (`3431`)
+    @_alwaysEmitIntoClient
+    static var blackBoxNetworkServicesIndia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3431)
+    }
+
+    /// Status Audio LLC (`3432`)
+    @_alwaysEmitIntoClient
+    static var statusAudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3432)
+    }
+
+    /// AIR AROMA INTERNATIONAL PTY LTD (`3433`)
+    @_alwaysEmitIntoClient
+    static var airAromaInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3433)
+    }
+
+    /// Helge Kaiser GmbH (`3434`)
+    @_alwaysEmitIntoClient
+    static var helgeKaiser: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3434)
+    }
+
+    /// Crane Payment Innovations, Inc. (`3435`)
+    @_alwaysEmitIntoClient
+    static var cranePaymentInnovations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3435)
+    }
+
+    /// Ambient IoT Pty Ltd (`3436`)
+    @_alwaysEmitIntoClient
+    static var ambientIot: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3436)
+    }
+
+    /// DYNAMOX S/A (`3437`)
+    @_alwaysEmitIntoClient
+    static var dynamoxSA: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3437)
+    }
+
+    /// Look Cycle International (`3438`)
+    @_alwaysEmitIntoClient
+    static var lookCycleInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3438)
+    }
+
+    /// Closed Joint Stock Company NVP BOLID (`3439`)
+    @_alwaysEmitIntoClient
+    static var nvpBolid: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3439)
+    }
+
+    /// Kindhome (`3440`)
+    @_alwaysEmitIntoClient
+    static var kindhome: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3440)
+    }
+
+    /// Kiteras Inc. (`3441`)
+    @_alwaysEmitIntoClient
+    static var kiteras: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3441)
+    }
+
+    /// Earfun Technology (HK) Limited (`3442`)
+    @_alwaysEmitIntoClient
+    static var earfunTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3442)
+    }
+
+    /// iota Biosciences, Inc. (`3443`)
+    @_alwaysEmitIntoClient
+    static var iotaBiosciences: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3443)
+    }
+
+    /// ANUME s.r.o. (`3444`)
+    @_alwaysEmitIntoClient
+    static var anume: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3444)
+    }
+
+    /// Indistinguishable From Magic, Inc. (`3445`)
+    @_alwaysEmitIntoClient
+    static var indistinguishableFromMagic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3445)
+    }
+
+    /// i-focus Co.,Ltd (`3446`)
+    @_alwaysEmitIntoClient
+    static var iFocus: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3446)
+    }
+
+    /// DualNetworks SA (`3447`)
+    @_alwaysEmitIntoClient
+    static var dualnetworks: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3447)
+    }
+
+    /// MITACHI CO.,LTD. (`3448`)
+    @_alwaysEmitIntoClient
+    static var mitachi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3448)
+    }
+
+    /// VIVIWARE JAPAN, Inc. (`3449`)
+    @_alwaysEmitIntoClient
+    static var viviwareJapan: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3449)
+    }
+
+    /// Xiamen Intretech Inc. (`3450`)
+    @_alwaysEmitIntoClient
+    static var xiamenIntretech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3450)
+    }
+
+    /// MindMaze SA (`3451`)
+    @_alwaysEmitIntoClient
+    static var mindmaze: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3451)
+    }
+
+    /// BeiJing SmartChip Microelectronics Technology Co.,Ltd (`3452`)
+    @_alwaysEmitIntoClient
+    static var beijingSmartchipMicroelectronicsTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3452)
+    }
+
+    /// Taiko Audio B.V. (`3453`)
+    @_alwaysEmitIntoClient
+    static var taikoAudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3453)
+    }
+
+    /// Daihatsu Motor Co., Ltd. (`3454`)
+    @_alwaysEmitIntoClient
+    static var daihatsuMotor: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3454)
+    }
+
+    /// Konova (`3455`)
+    @_alwaysEmitIntoClient
+    static var konova: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3455)
+    }
+
+    /// Gravaa B.V. (`3456`)
+    @_alwaysEmitIntoClient
+    static var gravaa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3456)
+    }
+
+    /// Beyerdynamic GmbH & Co. KG (`3457`)
+    @_alwaysEmitIntoClient
+    static var beyerdynamic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3457)
+    }
+
+    /// VELCO (`3458`)
+    @_alwaysEmitIntoClient
+    static var velco: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3458)
+    }
+
+    /// ATLANTIC SOCIETE FRANCAISE DE DEVELOPPEMENT THERMIQUE (`3459`)
+    @_alwaysEmitIntoClient
+    static var atlanticSocieteFrancaiseDeDeveloppementThermique: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3459)
+    }
+
+    /// Testo SE & Co. KGaA (`3460`)
+    @_alwaysEmitIntoClient
+    static var testoSeKgaa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3460)
+    }
+
+    /// SEW-EURODRIVE GmbH & Co KG (`3461`)
+    @_alwaysEmitIntoClient
+    static var sewEurodrive: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3461)
+    }
+
+    /// ROCKWELL AUTOMATION, INC. (`3462`)
+    @_alwaysEmitIntoClient
+    static var rockwellAutomation: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3462)
+    }
+
+    /// Quectel Wireless Solutions Co., Ltd. (`3463`)
+    @_alwaysEmitIntoClient
+    static var quectelWirelessSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3463)
+    }
+
+    /// Geocene Inc. (`3464`)
+    @_alwaysEmitIntoClient
+    static var geocene: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3464)
+    }
+
+    /// Nanohex Corp (`3465`)
+    @_alwaysEmitIntoClient
+    static var nanohex: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3465)
+    }
+
+    /// Simply Embedded Inc. (`3466`)
+    @_alwaysEmitIntoClient
+    static var simplyEmbedded: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3466)
+    }
+
+    /// Software Development, LLC (`3467`)
+    @_alwaysEmitIntoClient
+    static var softwareDevelopment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3467)
+    }
+
+    /// Ultimea Technology (Shenzhen) Limited (`3468`)
+    @_alwaysEmitIntoClient
+    static var ultimeaTechnologyShenzhen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3468)
+    }
+
+    /// RF Electronics Limited (`3469`)
+    @_alwaysEmitIntoClient
+    static var rfElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3469)
+    }
+
+    /// Optivolt Labs, Inc. (`3470`)
+    @_alwaysEmitIntoClient
+    static var optivoltLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3470)
+    }
+
+    /// Canon Electronics Inc. (`3471`)
+    @_alwaysEmitIntoClient
+    static var canonElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3471)
+    }
+
+    /// LAAS ApS (`3472`)
+    @_alwaysEmitIntoClient
+    static var laas: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3472)
+    }
+
+    /// Beamex Oy Ab (`3473`)
+    @_alwaysEmitIntoClient
+    static var beamexAb: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3473)
+    }
+
+    /// TACHIKAWA CORPORATION (`3474`)
+    @_alwaysEmitIntoClient
+    static var tachikawa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3474)
+    }
+
+    /// HagerEnergy GmbH (`3475`)
+    @_alwaysEmitIntoClient
+    static var hagerenergy: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3475)
+    }
+
+    /// Shrooly Inc (`3476`)
+    @_alwaysEmitIntoClient
+    static var shrooly: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3476)
+    }
+
+    /// Hunter Industries Incorporated (`3477`)
+    @_alwaysEmitIntoClient
+    static var hunterIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3477)
+    }
+
+    /// NEOKOHM SISTEMAS ELETRONICOS LTDA (`3478`)
+    @_alwaysEmitIntoClient
+    static var neokohmSistemasEletronicos: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3478)
+    }
+
+    /// Zhejiang Huanfu Technology Co., LTD (`3479`)
+    @_alwaysEmitIntoClient
+    static var zhejiangHuanfuTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3479)
+    }
+
+    /// E.F. Johnson Company (`3480`)
+    @_alwaysEmitIntoClient
+    static var eFJohnson: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3480)
+    }
+
+    /// Caire Inc. (`3481`)
+    @_alwaysEmitIntoClient
+    static var caire: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3481)
+    }
+
+    /// Yeasound (Xiamen) Hearing Technology Co., Ltd (`3482`)
+    @_alwaysEmitIntoClient
+    static var yeasoundXiamenHearingTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3482)
+    }
+
+    /// Boxyz, Inc. (`3483`)
+    @_alwaysEmitIntoClient
+    static var boxyz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3483)
+    }
+
+    /// Skytech Creations Limited (`3484`)
+    @_alwaysEmitIntoClient
+    static var skytechCreations: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3484)
+    }
+
+    /// Cear, Inc. (`3485`)
+    @_alwaysEmitIntoClient
+    static var cear: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3485)
+    }
+
+    /// Impulse Wellness LLC (`3486`)
+    @_alwaysEmitIntoClient
+    static var impulseWellness: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3486)
+    }
+
+    /// MML US, Inc (`3487`)
+    @_alwaysEmitIntoClient
+    static var mmlUs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3487)
+    }
+
+    /// SICK AG (`3488`)
+    @_alwaysEmitIntoClient
+    static var sick: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3488)
+    }
+
+    /// Fen Systems Ltd. (`3489`)
+    @_alwaysEmitIntoClient
+    static var fenSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3489)
+    }
+
+    /// KIWI.KI GmbH (`3490`)
+    @_alwaysEmitIntoClient
+    static var kiwiKi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3490)
+    }
+
+    /// Airgraft Inc. (`3491`)
+    @_alwaysEmitIntoClient
+    static var airgraft: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3491)
+    }
+
+    /// HP Tuners (`3492`)
+    @_alwaysEmitIntoClient
+    static var hpTuners: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3492)
+    }
+
+    /// PIXELA CORPORATION (`3493`)
+    @_alwaysEmitIntoClient
+    static var pixela: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3493)
+    }
+
+    /// Generac Corporation (`3494`)
+    @_alwaysEmitIntoClient
+    static var generac: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3494)
+    }
+
+    /// Novoferm tormatic GmbH (`3495`)
+    @_alwaysEmitIntoClient
+    static var novofermTormatic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3495)
+    }
+
+    /// Airwallet ApS (`3496`)
+    @_alwaysEmitIntoClient
+    static var airwallet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3496)
+    }
+
+    /// Inventronics GmbH (`3497`)
+    @_alwaysEmitIntoClient
+    static var inventronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3497)
+    }
+
+    /// Shenzhen EBELONG Technology Co., Ltd. (`3498`)
+    @_alwaysEmitIntoClient
+    static var shenzhenEbelongTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3498)
+    }
+
+    /// Efento (`3499`)
+    @_alwaysEmitIntoClient
+    static var efento: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3499)
+    }
+
+    /// ITALTRACTOR ITM S.P.A. (`3500`)
+    @_alwaysEmitIntoClient
+    static var italtractorItm: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3500)
+    }
+
+    /// linktop (`3501`)
+    @_alwaysEmitIntoClient
+    static var linktop: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3501)
+    }
+
+    /// TITUM AUDIO, INC. (`3502`)
+    @_alwaysEmitIntoClient
+    static var titumAudio: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3502)
+    }
+
+    /// Hexagon Aura Reality AG (`3503`)
+    @_alwaysEmitIntoClient
+    static var hexagonAuraReality: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3503)
+    }
+
+    /// Invisalert Solutions, Inc. (`3504`)
+    @_alwaysEmitIntoClient
+    static var invisalertSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3504)
+    }
+
+    /// TELE System Communications Pte. Ltd. (`3505`)
+    @_alwaysEmitIntoClient
+    static var teleSystemCommunicationsPte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3505)
+    }
+
+    /// Whirlpool (`3506`)
+    @_alwaysEmitIntoClient
+    static var whirlpool: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3506)
+    }
+
+    /// SHENZHEN REFLYING ELECTRONIC CO., LTD (`3507`)
+    @_alwaysEmitIntoClient
+    static var shenzhenReflyingElectronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3507)
+    }
+
+    /// Franklin Control Systems (`3508`)
+    @_alwaysEmitIntoClient
+    static var franklinControlSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3508)
+    }
+
+    /// Djup AB (`3509`)
+    @_alwaysEmitIntoClient
+    static var djup: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3509)
+    }
+
+    /// SAFEGUARD EQUIPMENT, INC. (`3510`)
+    @_alwaysEmitIntoClient
+    static var safeguardEquipment: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3510)
+    }
+
+    /// Morningstar Corporation (`3511`)
+    @_alwaysEmitIntoClient
+    static var morningstar: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3511)
+    }
+
+    /// Shenzhen Chuangyuan Digital Technology Co., Ltd (`3512`)
+    @_alwaysEmitIntoClient
+    static var shenzhenChuangyuanDigitalTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3512)
+    }
+
+    /// CompanyDeep Ltd (`3513`)
+    @_alwaysEmitIntoClient
+    static var companydeep: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3513)
+    }
+
+    /// Veo Technologies ApS (`3514`)
+    @_alwaysEmitIntoClient
+    static var veoTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3514)
+    }
+
+    /// Nexis Link Technology Co., Ltd. (`3515`)
+    @_alwaysEmitIntoClient
+    static var nexisLinkTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3515)
+    }
+
+    /// Felion Technologies Company Limited (`3516`)
+    @_alwaysEmitIntoClient
+    static var felionTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3516)
+    }
+
+    /// MAATEL (`3517`)
+    @_alwaysEmitIntoClient
+    static var maatel: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3517)
+    }
+
+    /// HELLA GmbH & Co. KGaA (`3518`)
+    @_alwaysEmitIntoClient
+    static var hellaAa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3518)
+    }
+
+    /// HWM-Water Limited (`3519`)
+    @_alwaysEmitIntoClient
+    static var hwmWater: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3519)
+    }
+
+    /// Shenzhen Jahport Electronic Technology Co., Ltd. (`3520`)
+    @_alwaysEmitIntoClient
+    static var shenzhenJahportElectronicTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3520)
+    }
+
+    /// NACHI-FUJIKOSHI CORP. (`3521`)
+    @_alwaysEmitIntoClient
+    static var nachiFujikoshi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3521)
+    }
+
+    /// Cirrus Research plc (`3522`)
+    @_alwaysEmitIntoClient
+    static var cirrusResearchPlc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3522)
+    }
+
+    /// GEARBAC TECHNOLOGIES INC. (`3523`)
+    @_alwaysEmitIntoClient
+    static var gearbacTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3523)
+    }
+
+    /// Hangzhou NationalChip Science & Technology Co.,Ltd (`3524`)
+    @_alwaysEmitIntoClient
+    static var hangzhouNationalchipScienceTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3524)
+    }
+
+    /// DHL (`3525`)
+    @_alwaysEmitIntoClient
+    static var dhl: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3525)
+    }
+
+    /// Levita (`3526`)
+    @_alwaysEmitIntoClient
+    static var levita: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3526)
+    }
+
+    /// MORNINGSTAR FX PTE. LTD. (`3527`)
+    @_alwaysEmitIntoClient
+    static var morningstarFxPte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3527)
+    }
+
+    /// ETO GRUPPE TECHNOLOGIES GmbH (`3528`)
+    @_alwaysEmitIntoClient
+    static var etoGruppeTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3528)
+    }
+
+    /// farmunited GmbH (`3529`)
+    @_alwaysEmitIntoClient
+    static var farmunited: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3529)
+    }
+
+    /// Aptener Mechatronics Private Limited (`3530`)
+    @_alwaysEmitIntoClient
+    static var aptenerMechatronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3530)
+    }
+
+    /// GEOPH, LLC (`3531`)
+    @_alwaysEmitIntoClient
+    static var geoph: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3531)
+    }
+
+    /// Trotec GmbH (`3532`)
+    @_alwaysEmitIntoClient
+    static var trotec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3532)
+    }
+
+    /// Astra LED AG (`3533`)
+    @_alwaysEmitIntoClient
+    static var astraLed: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3533)
+    }
+
+    /// NOVAFON - Electromedical devices limited liability company (`3534`)
+    @_alwaysEmitIntoClient
+    static var novafonElectromedicalDevicesLiability: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3534)
+    }
+
+    /// KUBU SMART LIMITED (`3535`)
+    @_alwaysEmitIntoClient
+    static var kubuSmart: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3535)
+    }
+
+    /// ESNAH (`3536`)
+    @_alwaysEmitIntoClient
+    static var esnah: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3536)
+    }
+
+    /// OrangeMicro Limited (`3537`)
+    @_alwaysEmitIntoClient
+    static var orangemicro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3537)
+    }
+
+    /// Sitecom Europe B.V. (`3538`)
+    @_alwaysEmitIntoClient
+    static var sitecomEurope: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3538)
+    }
+
+    /// Global Satellite Engineering (`3539`)
+    @_alwaysEmitIntoClient
+    static var globalSatelliteEngineering: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3539)
+    }
+
+    /// KOQOON GmbH & Co.KG (`3540`)
+    @_alwaysEmitIntoClient
+    static var koqoonKg: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3540)
+    }
+
+    /// BEEPINGS (`3541`)
+    @_alwaysEmitIntoClient
+    static var beepings: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3541)
+    }
+
+    /// MODULAR MEDICAL, INC. (`3542`)
+    @_alwaysEmitIntoClient
+    static var modularMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3542)
+    }
+
+    /// Xiant Technologies, Inc. (`3543`)
+    @_alwaysEmitIntoClient
+    static var xiantTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3543)
+    }
+
+    /// Granchip IoT Technology (Guangzhou) Co.,Ltd (`3544`)
+    @_alwaysEmitIntoClient
+    static var granchipIotTechnologyGuangzhou: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3544)
+    }
+
+    /// SCHELL GmbH & Co. KG (`3545`)
+    @_alwaysEmitIntoClient
+    static var schell: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3545)
+    }
+
+    /// Minebea Intec GmbH (`3546`)
+    @_alwaysEmitIntoClient
+    static var minebeaIntec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3546)
+    }
+
+    /// KAGA FEI Co., Ltd. (`3547`)
+    @_alwaysEmitIntoClient
+    static var kagaFei: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3547)
+    }
+
+    /// AUTHOR-ALARM, razvoj in prodaja avtomobilskih sistemov proti kraji, d.o.o. (`3548`)
+    @_alwaysEmitIntoClient
+    static var authorAlarmRazvojInProdajaAvtomobilskihSistemovProtiKraji: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3548)
+    }
+
+    /// Tozoa LLC (`3549`)
+    @_alwaysEmitIntoClient
+    static var tozoa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3549)
+    }
+
+    /// SHENZHEN DNS INDUSTRIES CO., LTD. (`3550`)
+    @_alwaysEmitIntoClient
+    static var shenzhenDnsIndustries: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3550)
+    }
+
+    /// Shenzhen Lunci Technology Co., Ltd (`3551`)
+    @_alwaysEmitIntoClient
+    static var shenzhenLunciTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3551)
+    }
+
+    /// KNOG PTY. LTD. (`3552`)
+    @_alwaysEmitIntoClient
+    static var knog: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3552)
+    }
+
+    /// Outshiny India Private Limited (`3553`)
+    @_alwaysEmitIntoClient
+    static var outshinyIndia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3553)
+    }
+
+    /// TAMADIC Co., Ltd. (`3554`)
+    @_alwaysEmitIntoClient
+    static var tamadic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3554)
+    }
+
+    /// Shenzhen MODSEMI Co., Ltd (`3555`)
+    @_alwaysEmitIntoClient
+    static var shenzhenModsemi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3555)
+    }
+
+    /// EMBEINT INC (`3556`)
+    @_alwaysEmitIntoClient
+    static var embeint: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3556)
+    }
+
+    /// Ehong Technology Co.,Ltd (`3557`)
+    @_alwaysEmitIntoClient
+    static var ehongTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3557)
+    }
+
+    /// DEXATEK Technology LTD (`3558`)
+    @_alwaysEmitIntoClient
+    static var dexatekTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3558)
+    }
+
+    /// Dendro Technologies, Inc. (`3559`)
+    @_alwaysEmitIntoClient
+    static var dendroTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3559)
+    }
+
+    /// Vivint, Inc. (`3560`)
+    @_alwaysEmitIntoClient
+    static var vivint: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3560)
+    }
+
+    /// General Laser GmbH (`3561`)
+    @_alwaysEmitIntoClient
+    static var generalLaser: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3561)
+    }
+
+    /// Kathrein Solutions GmbH (`3562`)
+    @_alwaysEmitIntoClient
+    static var kathreinSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3562)
+    }
+
+    /// Fitz Inc. (`3563`)
+    @_alwaysEmitIntoClient
+    static var fitz: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3563)
+    }
+
+    /// ATEGENOS PHARMACEUTICALS INC (`3564`)
+    @_alwaysEmitIntoClient
+    static var ategenosPharmaceuticals: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3564)
+    }
+
+    /// Flextronic GmbH (`3565`)
+    @_alwaysEmitIntoClient
+    static var flextronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3565)
+    }
+
+    /// Safety Swim LLC (`3566`)
+    @_alwaysEmitIntoClient
+    static var safetySwim: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3566)
+    }
+
+    /// SING SUN TECHNOLOGY (INTERNATIONAL) LIMITED (`3567`)
+    @_alwaysEmitIntoClient
+    static var singSunTechnologyInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3567)
+    }
+
+    /// Woncan (Hong Kong) Limited (`3568`)
+    @_alwaysEmitIntoClient
+    static var woncanHongKong: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3568)
+    }
+
+    /// iFLYTEK (Suzhou) Technology Co., Ltd. (`3569`)
+    @_alwaysEmitIntoClient
+    static var iflytekSuzhouTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3569)
+    }
+
+    /// Weber-Stephen Products LLC (`3570`)
+    @_alwaysEmitIntoClient
+    static var weberStephenProducts: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3570)
+    }
+
+    /// hDrop Technologies Inc. (`3571`)
+    @_alwaysEmitIntoClient
+    static var hdropTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3571)
+    }
+
+    /// REEKON TOOLS INC. (`3572`)
+    @_alwaysEmitIntoClient
+    static var reekonTools: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3572)
+    }
+
+    /// Delta Faucet Company (`3573`)
+    @_alwaysEmitIntoClient
+    static var deltaFaucet: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3573)
+    }
+
+    /// Mutrack Co., Ltd (`3574`)
+    @_alwaysEmitIntoClient
+    static var mutrack: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3574)
+    }
+
+    /// Hangzhou Zhaotong Microelectronics Co., Ltd. (`3575`)
+    @_alwaysEmitIntoClient
+    static var hangzhouZhaotongMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3575)
+    }
+
+    /// Chengdu CSCT Microelectronics Co., Ltd. (`3576`)
+    @_alwaysEmitIntoClient
+    static var chengduCsctMicroelectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3576)
+    }
+
+    /// Belusun Technology Ltd. (`3577`)
+    @_alwaysEmitIntoClient
+    static var belusunTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3577)
+    }
+
+    /// Shenzhen Matches IoT Technology Co., Ltd. (`3578`)
+    @_alwaysEmitIntoClient
+    static var shenzhenMatchesIotTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3578)
+    }
+
+    /// Beidou Intelligent Connected Vehicle Technology Co., Ltd. (`3579`)
+    @_alwaysEmitIntoClient
+    static var beidouIntelligentConnectedVehicleTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3579)
+    }
+
+    /// SOJI ELECTRONICS JOINT STOCK COMPANY (`3580`)
+    @_alwaysEmitIntoClient
+    static var sojiElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3580)
+    }
+
+    /// BH Technologies (`3581`)
+    @_alwaysEmitIntoClient
+    static var bhTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3581)
+    }
+
+    /// Haptech, Inc. (`3582`)
+    @_alwaysEmitIntoClient
+    static var haptech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3582)
+    }
+
+    /// WaveRF, Corp. (`3583`)
+    @_alwaysEmitIntoClient
+    static var waverf: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3583)
+    }
+
+    /// SHENZHEN SOUNDSOUL INFORMATION TECHNOLOGY CO.,LTD (`3584`)
+    @_alwaysEmitIntoClient
+    static var shenzhenSoundsoulInformationTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3584)
+    }
+
+    /// Wuhu Mengbo Technology Co., Ltd. (`3585`)
+    @_alwaysEmitIntoClient
+    static var wuhuMengboTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3585)
+    }
+
+    /// PROSYS DEV LIMITED (`3586`)
+    @_alwaysEmitIntoClient
+    static var prosysDev: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3586)
+    }
+
+    /// Shenzhen eMeet technology Co.,Ltd (`3587`)
+    @_alwaysEmitIntoClient
+    static var shenzhenEmeetTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3587)
+    }
+
+    /// Doro AB (`3588`)
+    @_alwaysEmitIntoClient
+    static var doro: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3588)
+    }
+
+    /// SUREPULSE MEDICAL LIMITED (`3589`)
+    @_alwaysEmitIntoClient
+    static var surepulseMedical: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3589)
+    }
+
+    /// iodyne, LLC (`3590`)
+    @_alwaysEmitIntoClient
+    static var iodyne: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3590)
+    }
+
+    /// Pinpoint GmbH (`3591`)
+    @_alwaysEmitIntoClient
+    static var pinpoint: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3591)
+    }
+
+    /// Heinrich Kopp GmbH (`3592`)
+    @_alwaysEmitIntoClient
+    static var heinrichKopp: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3592)
+    }
+
+    /// Evolutive Systems SL (`3593`)
+    @_alwaysEmitIntoClient
+    static var evolutiveSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3593)
+    }
+
+    /// PRINT INTERNATIONAL LIMITED (`3594`)
+    @_alwaysEmitIntoClient
+    static var printInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3594)
+    }
+
+    /// Sounding Audio Industrial Ltd. (`3595`)
+    @_alwaysEmitIntoClient
+    static var soundingAudioIndustrial: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3595)
+    }
+
+    /// Yuanfeng Technology Co., Ltd. (`3596`)
+    @_alwaysEmitIntoClient
+    static var yuanfengTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3596)
+    }
+
+    /// FrontAct Co., Ltd. (`3597`)
+    @_alwaysEmitIntoClient
+    static var frontact: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3597)
+    }
+
+    /// ALOGIC CORPORATION PTY LTD (`3598`)
+    @_alwaysEmitIntoClient
+    static var alogic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3598)
+    }
+
+    /// SenseWorks Tecnologia Ltda. (`3599`)
+    @_alwaysEmitIntoClient
+    static var senseworksTecnologia: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3599)
+    }
+
+    /// Eko Health, Inc. (`3600`)
+    @_alwaysEmitIntoClient
+    static var ekoHealth: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3600)
+    }
+
+    /// Wanzl GmbH & Co. KGaA (`3601`)
+    @_alwaysEmitIntoClient
+    static var wanzlAa: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3601)
+    }
+
+    /// CLEVER LOGGER TECHNOLOGIES PTY LIMITED (`3602`)
+    @_alwaysEmitIntoClient
+    static var cleverLoggerTechnologies: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3602)
+    }
+
+    /// ASYSTOM (`3603`)
+    @_alwaysEmitIntoClient
+    static var asystom: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3603)
+    }
+
+    /// Heilongjiang Tianyouwei Electronics Co.,Ltd. (`3604`)
+    @_alwaysEmitIntoClient
+    static var heilongjiangTianyouweiElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3604)
+    }
+
+    /// Eastern Partner Limited (`3605`)
+    @_alwaysEmitIntoClient
+    static var easternPartner: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3605)
+    }
+
+    /// Xiamen RUI YI Da Electronic Technology Co.,Ltd (`3606`)
+    @_alwaysEmitIntoClient
+    static var xiamenRuiYiDaElectronicTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3606)
+    }
+
+    /// Ad Hoc Electronics, llc. (`3607`)
+    @_alwaysEmitIntoClient
+    static var adHocElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3607)
+    }
+
+    /// Hangzhou Microimage Software Co.,Ltd. (`3608`)
+    @_alwaysEmitIntoClient
+    static var hangzhouMicroimageSoftware: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3608)
+    }
+
+    /// Hive-Zox International SA (`3609`)
+    @_alwaysEmitIntoClient
+    static var hiveZoxInternational: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3609)
+    }
+
+    /// Sensovo GmbH (`3610`)
+    @_alwaysEmitIntoClient
+    static var sensovo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3610)
+    }
+
+    /// Time Location Systems AS (`3611`)
+    @_alwaysEmitIntoClient
+    static var timeLocationSystems: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3611)
+    }
+
+    /// SHENZHEN DIGITECH CO., LTD (`3612`)
+    @_alwaysEmitIntoClient
+    static var shenzhenDigitech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3612)
+    }
+
+    /// Capte B.V. (`3613`)
+    @_alwaysEmitIntoClient
+    static var capte: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3613)
+    }
+
+    /// 9512-5837 QUEBEC INC. (`3614`)
+    @_alwaysEmitIntoClient
+    static var company95125837Quebec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3614)
+    }
+
+    /// Blecon Ltd (`3615`)
+    @_alwaysEmitIntoClient
+    static var blecon: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3615)
+    }
+
+    /// CFLAB TEKNOLOJI TICARET LIMITED SIRKETI (`3616`)
+    @_alwaysEmitIntoClient
+    static var cflabTeknolojiTicaretSirketi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3616)
+    }
+
+    /// FOGO (`3617`)
+    @_alwaysEmitIntoClient
+    static var fogo: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3617)
+    }
+
+    /// HITO INC (`3618`)
+    @_alwaysEmitIntoClient
+    static var hito: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3618)
+    }
+
+    /// MS kajak7 UG (limited liability) (`3620`)
+    @_alwaysEmitIntoClient
+    static var msKajak7UgLimitedLiability: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3620)
+    }
+
+    /// Hangzhou Hikvision Digital Technology Co., Ltd. (`3621`)
+    @_alwaysEmitIntoClient
+    static var hangzhouHikvisionDigitalTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3621)
+    }
+
+    /// LIHJOEN SPEED METER CO., LTD. (`3622`)
+    @_alwaysEmitIntoClient
+    static var lihjoenSpeedMeter: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3622)
+    }
+
+    /// NextSense, Inc. (`3623`)
+    @_alwaysEmitIntoClient
+    static var nextsense: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3623)
+    }
+
+    /// PatchRx, Inc. (`3624`)
+    @_alwaysEmitIntoClient
+    static var patchrx: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3624)
+    }
+
+    /// Flipper Devices Inc. (`3625`)
+    @_alwaysEmitIntoClient
+    static var flipperDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3625)
+    }
+
+    /// Huizhou Foryou General Electronics Co., Ltd. (`3626`)
+    @_alwaysEmitIntoClient
+    static var huizhouForyouGeneralElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3626)
+    }
+
+    /// JE electronic a/s (`3627`)
+    @_alwaysEmitIntoClient
+    static var jeElectronic: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3627)
+    }
+
+    /// 9313-7263 Quebec inc. (`3628`)
+    @_alwaysEmitIntoClient
+    static var company93137263Quebec: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3628)
+    }
+
+    /// ECARX (Hubei) Tech Co.,Ltd. (`3629`)
+    @_alwaysEmitIntoClient
+    static var ecarxHubeiTech: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3629)
+    }
+
+    /// NIHON KOHDEN CORPORATION (`3630`)
+    @_alwaysEmitIntoClient
+    static var nihonKohden: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3630)
+    }
+
+    /// ONWI (`3631`)
+    @_alwaysEmitIntoClient
+    static var onwi: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3631)
+    }
+
+    /// Primax Electronics Ltd. (`3632`)
+    @_alwaysEmitIntoClient
+    static var primaxElectronics: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3632)
+    }
+
+    /// AlphaTheta Corporation (`3633`)
+    @_alwaysEmitIntoClient
+    static var alphatheta: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3633)
+    }
+
+    /// PACIFIC INDUSTRIAL CO., LTD. (`3634`)
+    @_alwaysEmitIntoClient
+    static var pacificIndustrial: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3634)
+    }
+
+    /// Crescent NV (`3635`)
+    @_alwaysEmitIntoClient
+    static var crescent: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3635)
+    }
+
+    /// Vermis, software solutions llc (`3636`)
+    @_alwaysEmitIntoClient
+    static var vermisSoftwareSolutions: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3636)
+    }
+
+    /// SNAPPWISH LLC (`3637`)
+    @_alwaysEmitIntoClient
+    static var snappwish: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3637)
+    }
+
+    /// Cousins and Sears LLC (`3638`)
+    @_alwaysEmitIntoClient
+    static var cousinsAndSears: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3638)
+    }
+
+    /// CESYS Gesellschaft für angewandte Mikroelektronik mbH (`3639`)
+    @_alwaysEmitIntoClient
+    static var cesysGesellschaftFurAngewandteMikroelektronik: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3639)
+    }
+
+    /// SLOC GmbH (`3640`)
+    @_alwaysEmitIntoClient
+    static var sloc: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3640)
+    }
+
+    /// IRES Infrarot Energie Systeme GmbH (`3641`)
+    @_alwaysEmitIntoClient
+    static var iresInfrarotEnergieSysteme: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3641)
+    }
+
+    /// OFIVE LIMITED (`3642`)
+    @_alwaysEmitIntoClient
+    static var ofive: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3642)
+    }
+
+    /// Swift IOT Tech (Shenzhen) Co., LTD. (`3643`)
+    @_alwaysEmitIntoClient
+    static var swiftIotTechShenzhen: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3643)
+    }
+
+    /// Viselabs (`3644`)
+    @_alwaysEmitIntoClient
+    static var viselabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3644)
+    }
+
+    /// Walmart Inc. (`3645`)
+    @_alwaysEmitIntoClient
+    static var walmart: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3645)
+    }
+
+    /// VANBOX (`3646`)
+    @_alwaysEmitIntoClient
+    static var vanbox: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3646)
+    }
+
+    /// Wiser Devices, LLC (`3647`)
+    @_alwaysEmitIntoClient
+    static var wiserDevices: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3647)
+    }
+
+    /// WKD Labs Ltd (`3648`)
+    @_alwaysEmitIntoClient
+    static var wkdLabs: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3648)
+    }
+
+    /// Asustek Computer Inc. (`3649`)
+    @_alwaysEmitIntoClient
+    static var asustekComputer: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3649)
+    }
+
+    /// Z-ONE Technology Co., Ltd. (`3650`)
+    @_alwaysEmitIntoClient
+    static var zOneTechnology: CompanyIdentifier {
+        return CompanyIdentifier(rawValue: 3650)
+    }
+
+}
+#endif

--- a/pico-w-ble-peripheral-sdk/Bluetooth/Generated/GeneratedUnitIdentifiers.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/Generated/GeneratedUnitIdentifiers.swift
@@ -1,0 +1,772 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if (swift(<5.6) || !SWIFTPM_ENABLE_PLUGINS) && !os(WASI)
+public extension UnitIdentifier {
+
+    /// unitless (`0x2700`)
+    @_alwaysEmitIntoClient
+    static var unitless: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2700)
+    }
+
+    /// length (metre) (`0x2701`)
+    @_alwaysEmitIntoClient
+    static var metre: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2701)
+    }
+
+    /// mass (kilogram) (`0x2702`)
+    @_alwaysEmitIntoClient
+    static var kilogram: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2702)
+    }
+
+    /// time (second) (`0x2703`)
+    @_alwaysEmitIntoClient
+    static var second: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2703)
+    }
+
+    /// electric current (ampere) (`0x2704`)
+    @_alwaysEmitIntoClient
+    static var ampere: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2704)
+    }
+
+    /// thermodynamic temperature (kelvin) (`0x2705`)
+    @_alwaysEmitIntoClient
+    static var kelvin: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2705)
+    }
+
+    /// amount of substance (mole) (`0x2706`)
+    @_alwaysEmitIntoClient
+    static var mole: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2706)
+    }
+
+    /// luminous intensity (candela) (`0x2707`)
+    @_alwaysEmitIntoClient
+    static var candela: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2707)
+    }
+
+    /// area (square metres) (`0x2710`)
+    @_alwaysEmitIntoClient
+    static var area: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2710)
+    }
+
+    /// volume (cubic metres) (`0x2711`)
+    @_alwaysEmitIntoClient
+    static var volume: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2711)
+    }
+
+    /// velocity (metres per second) (`0x2712`)
+    @_alwaysEmitIntoClient
+    static var velocity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2712)
+    }
+
+    /// acceleration (metres per second squared) (`0x2713`)
+    @_alwaysEmitIntoClient
+    static var acceleration: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2713)
+    }
+
+    /// wavenumber (reciprocal metre) (`0x2714`)
+    @_alwaysEmitIntoClient
+    static var wavenumber: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2714)
+    }
+
+    /// density (kilogram per cubic metre) (`0x2715`)
+    @_alwaysEmitIntoClient
+    static var density: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2715)
+    }
+
+    /// surface density (kilogram per square metre) (`0x2716`)
+    @_alwaysEmitIntoClient
+    static var surfaceDensity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2716)
+    }
+
+    /// specific volume (cubic metre per kilogram) (`0x2717`)
+    @_alwaysEmitIntoClient
+    static var specificVolume: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2717)
+    }
+
+    /// current density (ampere per square metre) (`0x2718`)
+    @_alwaysEmitIntoClient
+    static var currentDensity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2718)
+    }
+
+    /// magnetic field strength (ampere per metre) (`0x2719`)
+    @_alwaysEmitIntoClient
+    static var magneticFieldStrengh: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2719)
+    }
+
+    /// amount concentration (mole per cubic metre) (`0x271A`)
+    @_alwaysEmitIntoClient
+    static var amountConcentration: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x271A)
+    }
+
+    /// mass concentration (kilogram per cubic metre) (`0x271B`)
+    @_alwaysEmitIntoClient
+    static var massConcentration: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x271B)
+    }
+
+    /// luminance (candela per square metre) (`0x271C`)
+    @_alwaysEmitIntoClient
+    static var luminance: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x271C)
+    }
+
+    /// refractive index (`0x271D`)
+    @_alwaysEmitIntoClient
+    static var refractiveIndex: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x271D)
+    }
+
+    /// relative permeability (`0x271E`)
+    @_alwaysEmitIntoClient
+    static var relativePermeability: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x271E)
+    }
+
+    /// plane angle (radian) (`0x2720`)
+    @_alwaysEmitIntoClient
+    static var planeAngle: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2720)
+    }
+
+    /// solid angle (steradian) (`0x2721`)
+    @_alwaysEmitIntoClient
+    static var solidAngle: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2721)
+    }
+
+    /// frequency (hertz) (`0x2722`)
+    @_alwaysEmitIntoClient
+    static var frequency: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2722)
+    }
+
+    /// force (newton) (`0x2723`)
+    @_alwaysEmitIntoClient
+    static var force: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2723)
+    }
+
+    /// pressure (pascal) (`0x2724`)
+    @_alwaysEmitIntoClient
+    static var pascalPressure: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2724)
+    }
+
+    /// energy (joule) (`0x2725`)
+    @_alwaysEmitIntoClient
+    static var energy: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2725)
+    }
+
+    /// power (watt) (`0x2726`)
+    @_alwaysEmitIntoClient
+    static var power: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2726)
+    }
+
+    /// electric charge (coulomb) (`0x2727`)
+    @_alwaysEmitIntoClient
+    static var coulomb: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2727)
+    }
+
+    /// electric potential difference (volt) (`0x2728`)
+    @_alwaysEmitIntoClient
+    static var electricPotential: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2728)
+    }
+
+    /// capacitance (farad) (`0x2729`)
+    @_alwaysEmitIntoClient
+    static var capitance: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2729)
+    }
+
+    /// electric resistance (ohm) (`0x272A`)
+    @_alwaysEmitIntoClient
+    static var electricResistance: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x272A)
+    }
+
+    /// electric conductance (siemens) (`0x272B`)
+    @_alwaysEmitIntoClient
+    static var electricConductance: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x272B)
+    }
+
+    /// magnetic flux (weber) (`0x272C`)
+    @_alwaysEmitIntoClient
+    static var magneticFlux: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x272C)
+    }
+
+    /// magnetic flux density (tesla) (`0x272D`)
+    @_alwaysEmitIntoClient
+    static var magneticFluxDensity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x272D)
+    }
+
+    /// inductance (henry) (`0x272E`)
+    @_alwaysEmitIntoClient
+    static var inductance: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x272E)
+    }
+
+    /// Celsius temperature (degree Celsius) (`0x272F`)
+    @_alwaysEmitIntoClient
+    static var celsius: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x272F)
+    }
+
+    /// luminous flux (lumen) (`0x2730`)
+    @_alwaysEmitIntoClient
+    static var luminousFlux: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2730)
+    }
+
+    /// illuminance (lux) (`0x2731`)
+    @_alwaysEmitIntoClient
+    static var illuminance: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2731)
+    }
+
+    /// activity referred to a radionuclide (becquerel) (`0x2732`)
+    @_alwaysEmitIntoClient
+    static var becquerel: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2732)
+    }
+
+    /// absorbed dose (gray) (`0x2733`)
+    @_alwaysEmitIntoClient
+    static var absorbedDose: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2733)
+    }
+
+    /// dose equivalent (sievert) (`0x2734`)
+    @_alwaysEmitIntoClient
+    static var sievert: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2734)
+    }
+
+    /// catalytic activity (katal) (`0x2735`)
+    @_alwaysEmitIntoClient
+    static var katal: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2735)
+    }
+
+    /// dynamic viscosity (pascal second) (`0x2740`)
+    @_alwaysEmitIntoClient
+    static var pascalSecond: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2740)
+    }
+
+    /// moment of force (newton metre) (`0x2741`)
+    @_alwaysEmitIntoClient
+    static var newtonMetre: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2741)
+    }
+
+    /// surface tension (newton per metre) (`0x2742`)
+    @_alwaysEmitIntoClient
+    static var surfaceTension: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2742)
+    }
+
+    /// angular velocity (radian per second) (`0x2743`)
+    @_alwaysEmitIntoClient
+    static var angularVelocity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2743)
+    }
+
+    /// angular acceleration (radian per second squared) (`0x2744`)
+    @_alwaysEmitIntoClient
+    static var angularAcceleration: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2744)
+    }
+
+    /// heat flux density (watt per square metre) (`0x2745`)
+    @_alwaysEmitIntoClient
+    static var heatFluxDensity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2745)
+    }
+
+    /// heat capacity (joule per kelvin) (`0x2746`)
+    @_alwaysEmitIntoClient
+    static var heatCapacity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2746)
+    }
+
+    /// specific heat capacity (joule per kilogram kelvin) (`0x2747`)
+    @_alwaysEmitIntoClient
+    static var specificHeatCapacity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2747)
+    }
+
+    /// specific energy (joule per kilogram) (`0x2748`)
+    @_alwaysEmitIntoClient
+    static var specificEnergy: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2748)
+    }
+
+    /// thermal conductivity (watt per metre kelvin) (`0x2749`)
+    @_alwaysEmitIntoClient
+    static var thermalConductivity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2749)
+    }
+
+    /// energy density (joule per cubic metre) (`0x274A`)
+    @_alwaysEmitIntoClient
+    static var energyDensity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x274A)
+    }
+
+    /// electric field strength (volt per metre) (`0x274B`)
+    @_alwaysEmitIntoClient
+    static var electricFieldStrength: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x274B)
+    }
+
+    /// electric charge density (coulomb per cubic metre) (`0x274C`)
+    @_alwaysEmitIntoClient
+    static var electricChargeDensity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x274C)
+    }
+
+    /// surface charge density (coulomb per square metre) (`0x274D`)
+    @_alwaysEmitIntoClient
+    static var surfaceChargeDensity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x274D)
+    }
+
+    /// electric flux density (coulomb per square metre) (`0x274E`)
+    @_alwaysEmitIntoClient
+    static var electricFluxDensity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x274E)
+    }
+
+    /// permittivity (farad per metre) (`0x274F`)
+    @_alwaysEmitIntoClient
+    static var permittivity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x274F)
+    }
+
+    /// permeability (henry per metre) (`0x2750`)
+    @_alwaysEmitIntoClient
+    static var permeability: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2750)
+    }
+
+    /// molar energy (joule per mole) (`0x2751`)
+    @_alwaysEmitIntoClient
+    static var molarEnergy: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2751)
+    }
+
+    /// molar entropy (joule per mole kelvin) (`0x2752`)
+    @_alwaysEmitIntoClient
+    static var molarEntropy: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2752)
+    }
+
+    /// exposure (coulomb per kilogram) (`0x2753`)
+    @_alwaysEmitIntoClient
+    static var exposure: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2753)
+    }
+
+    /// absorbed dose rate (gray per second) (`0x2754`)
+    @_alwaysEmitIntoClient
+    static var absorbedDoseRate: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2754)
+    }
+
+    /// radiant intensity (watt per steradian) (`0x2755`)
+    @_alwaysEmitIntoClient
+    static var radradiantIntensityiance: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2755)
+    }
+
+    /// radiance (watt per square metre steradian) (`0x2756`)
+    @_alwaysEmitIntoClient
+    static var radiance: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2756)
+    }
+
+    /// catalytic activity concentration (katal per cubic metre) (`0x2757`)
+    @_alwaysEmitIntoClient
+    static var catalyticActivity: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2757)
+    }
+
+    /// time (minute) (`0x2760`)
+    @_alwaysEmitIntoClient
+    static var minute: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2760)
+    }
+
+    /// time (hour) (`0x2761`)
+    @_alwaysEmitIntoClient
+    static var hour: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2761)
+    }
+
+    /// time (day) (`0x2762`)
+    @_alwaysEmitIntoClient
+    static var day: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2762)
+    }
+
+    /// plane angle (degree) (`0x2763`)
+    @_alwaysEmitIntoClient
+    static var degree: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2763)
+    }
+
+    /// plane angle (minute) (`0x2764`)
+    @_alwaysEmitIntoClient
+    static var planeAngleMinute: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2764)
+    }
+
+    /// plane angle (second) (`0x2765`)
+    @_alwaysEmitIntoClient
+    static var planeAngleSecond: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2765)
+    }
+
+    /// area (hectare) (`0x2766`)
+    @_alwaysEmitIntoClient
+    static var hectare: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2766)
+    }
+
+    /// volume (litre) (`0x2767`)
+    @_alwaysEmitIntoClient
+    static var litre: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2767)
+    }
+
+    /// mass (tonne) (`0x2768`)
+    @_alwaysEmitIntoClient
+    static var tonne: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2768)
+    }
+
+    /// pressure (bar) (`0x2780`)
+    @_alwaysEmitIntoClient
+    static var bar: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2780)
+    }
+
+    /// pressure (millimetre of mercury) (`0x2781`)
+    @_alwaysEmitIntoClient
+    static var millimetreOfMercury: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2781)
+    }
+
+    /// length (ångström) (`0x2782`)
+    @_alwaysEmitIntoClient
+    static var ngstrm: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2782)
+    }
+
+    /// length (nautical mile) (`0x2783`)
+    @_alwaysEmitIntoClient
+    static var nauticalMile: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2783)
+    }
+
+    /// area (barn) (`0x2784`)
+    @_alwaysEmitIntoClient
+    static var barn: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2784)
+    }
+
+    /// velocity (knot) (`0x2785`)
+    @_alwaysEmitIntoClient
+    static var velocityKnot: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2785)
+    }
+
+    /// logarithmic radio quantity (neper) (`0x2786`)
+    @_alwaysEmitIntoClient
+    static var neper: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2786)
+    }
+
+    /// logarithmic radio quantity (bel) (`0x2787`)
+    @_alwaysEmitIntoClient
+    static var bel: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x2787)
+    }
+
+    /// length (yard) (`0x27A0`)
+    @_alwaysEmitIntoClient
+    static var yard: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27A0)
+    }
+
+    /// length (parsec) (`0x27A1`)
+    @_alwaysEmitIntoClient
+    static var parsec: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27A1)
+    }
+
+    /// length (inch) (`0x27A2`)
+    @_alwaysEmitIntoClient
+    static var inch: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27A2)
+    }
+
+    /// length (foot) (`0x27A3`)
+    @_alwaysEmitIntoClient
+    static var foot: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27A3)
+    }
+
+    /// length (mile) (`0x27A4`)
+    @_alwaysEmitIntoClient
+    static var mile: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27A4)
+    }
+
+    /// pressure (pound-force per square inch) (`0x27A5`)
+    @_alwaysEmitIntoClient
+    static var pressurePoundForce: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27A5)
+    }
+
+    /// velocity (kilometre per hour) (`0x27A6`)
+    @_alwaysEmitIntoClient
+    static var kilometrePerHour: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27A6)
+    }
+
+    /// velocity (mile per hour) (`0x27A7`)
+    @_alwaysEmitIntoClient
+    static var milePerHour: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27A7)
+    }
+
+    /// angular velocity (revolution per minute) (`0x27A8`)
+    @_alwaysEmitIntoClient
+    static var revolutionPerMinute: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27A8)
+    }
+
+    /// energy (gram calorie) (`0x27A9`)
+    @_alwaysEmitIntoClient
+    static var gramCalorie: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27A9)
+    }
+
+    /// energy (kilogram calorie) (`0x27AA`)
+    @_alwaysEmitIntoClient
+    static var kilogramCalorie: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27AA)
+    }
+
+    /// energy (kilowatt hour) (`0x27AB`)
+    @_alwaysEmitIntoClient
+    static var kilowattHour: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27AB)
+    }
+
+    /// thermodynamic temperature (degree Fahrenheit) (`0x27AC`)
+    @_alwaysEmitIntoClient
+    static var degreeFahrenheit: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27AC)
+    }
+
+    /// percentage (`0x27AD`)
+    @_alwaysEmitIntoClient
+    static var percentage: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27AD)
+    }
+
+    /// per mille (`0x27AE`)
+    @_alwaysEmitIntoClient
+    static var perMille: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27AE)
+    }
+
+    /// period (beats per minute) (`0x27AF`)
+    @_alwaysEmitIntoClient
+    static var beatsPerMinute: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27AF)
+    }
+
+    /// electric charge (ampere hours) (`0x27B0`)
+    @_alwaysEmitIntoClient
+    static var ampereHours: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27B0)
+    }
+
+    /// mass density (milligram per decilitre) (`0x27B1`)
+    @_alwaysEmitIntoClient
+    static var milligramPerDecilitre: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27B1)
+    }
+
+    /// mass density (millimole per litre) (`0x27B2`)
+    @_alwaysEmitIntoClient
+    static var millimolePerLitre: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27B2)
+    }
+
+    /// time (year) (`0x27B3`)
+    @_alwaysEmitIntoClient
+    static var year: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27B3)
+    }
+
+    /// time (month) (`0x27B4`)
+    @_alwaysEmitIntoClient
+    static var month: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27B4)
+    }
+
+    /// concentration (count per cubic metre) (`0x27B5`)
+    @_alwaysEmitIntoClient
+    static var concentration: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27B5)
+    }
+
+    /// irradiance (watt per square metre) (`0x27B6`)
+    @_alwaysEmitIntoClient
+    static var irrandiance: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27B6)
+    }
+
+    /// milliliter (per kilogram per minute) (`0x27B7`)
+    @_alwaysEmitIntoClient
+    static var millilitre: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27B7)
+    }
+
+    /// mass (pound) (`0x27B8`)
+    @_alwaysEmitIntoClient
+    static var pound: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27B8)
+    }
+
+    /// metabolic equivalent (`0x27B9`)
+    @_alwaysEmitIntoClient
+    static var metabolicEquivalent: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27B9)
+    }
+
+    /// step (per minute) (`0x27BA`)
+    @_alwaysEmitIntoClient
+    static var step: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27BA)
+    }
+
+    /// stroke (per minute) (`0x27BC`)
+    @_alwaysEmitIntoClient
+    static var stroke: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27BC)
+    }
+
+    /// pace (kilometre per minute) (`0x27BD`)
+    @_alwaysEmitIntoClient
+    static var pace: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27BD)
+    }
+
+    /// luminous efficacy (lumen per watt) (`0x27BE`)
+    @_alwaysEmitIntoClient
+    static var luminousEfficacy: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27BE)
+    }
+
+    /// luminous energy (lumen hour) (`0x27BF`)
+    @_alwaysEmitIntoClient
+    static var luminousEnergy: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27BF)
+    }
+
+    /// luminous exposure (lux hour) (`0x27C0`)
+    @_alwaysEmitIntoClient
+    static var luminousExposure: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27C0)
+    }
+
+    /// mass flow (gram per second) (`0x27C1`)
+    @_alwaysEmitIntoClient
+    static var massFlow: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27C1)
+    }
+
+    /// volume flow (litre per second) (`0x27C2`)
+    @_alwaysEmitIntoClient
+    static var volumeFlow: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27C2)
+    }
+
+    /// sound pressure (decibel) (`0x27C3`)
+    @_alwaysEmitIntoClient
+    static var soundPressure: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27C3)
+    }
+
+    /// parts per million (`0x27C4`)
+    @_alwaysEmitIntoClient
+    static var partsPerMillion: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27C4)
+    }
+
+    /// parts per billion (`0x27C5`)
+    @_alwaysEmitIntoClient
+    static var partsPerBillion: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27C5)
+    }
+
+    /// mass density rate ((milligram per decilitre) per minute) (`0x27C6`)
+    @_alwaysEmitIntoClient
+    static var massDensityRate: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27C6)
+    }
+
+    /// Electrical Apparent Energy (kilovolt ampere hour) (`0x27C7`)
+    @_alwaysEmitIntoClient
+    static var kilovoltAmpereHour: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27C7)
+    }
+
+    /// Electrical Apparent Power (volt ampere) (`0x27C8`)
+    @_alwaysEmitIntoClient
+    static var voltAmpere: UnitIdentifier {
+        return UnitIdentifier(rawValue: 0x27C8)
+    }
+
+}
+#endif

--- a/pico-w-ble-peripheral-sdk/Bluetooth/L2CAPSocket.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/L2CAPSocket.swift
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// L2CAP Socket protocol.
+public protocol L2CAPSocket {
+        
+    associatedtype Error: Swift.Error
+    
+    /// Socket address
+    var address: BluetoothAddress { get }
+    
+    /// Socket status
+    var status: L2CAPSocketStatus<Error> { get }
+    
+    /// Close socket.
+    func close()
+}
+
+public protocol L2CAPServer: L2CAPSocket {
+    
+    associatedtype Connection: L2CAPConnection
+    
+    /// Creates a new server,
+    static func lowEnergyServer(
+        address: BluetoothAddress,
+        isRandom: Bool,
+        backlog: Int
+    ) throws(Self.Error) -> Self
+    
+    func accept() throws(Self.Error) -> Connection
+}
+
+public protocol L2CAPConnection: L2CAPSocket {
+    
+    associatedtype Data: DataContainer
+    
+    /// Creates a new socket connected to the remote address specified.
+    static func lowEnergyClient(
+        address: BluetoothAddress,
+        destination: BluetoothAddress,
+        isRandom: Bool
+    ) throws(Self.Error) -> Self
+    
+    var destination: BluetoothAddress { get }
+    
+    /// Write to the socket.
+    func send(_ data: Data) throws(Self.Error)
+    
+    /// Reads from the socket.
+    func receive(_ bufferSize: Int) throws(Self.Error) -> Self.Data
+        
+    /// Attempts to change the socket's security level.
+    func setSecurityLevel(_ securityLevel: SecurityLevel) throws(Self.Error)
+    
+    /// Get security level
+    //var securityLevel: SecurityLevel { get throws(Self.Error) }
+    func securityLevel() throws(Self.Error) -> SecurityLevel
+}
+
+/// L2CAP Socket Status
+public struct L2CAPSocketStatus<Error: Swift.Error>: Sendable {
+    
+    /// Socket is ready for a write operation.
+    public var send: Bool
+    
+    /// Socket is ready for a read operation.
+    public var recieve: Bool
+    
+    /// Socket has a pending new connection.
+    public var accept: Bool
+    
+    /// Socket encountered an error.
+    public var error: Error?
+    
+    public init(
+        send: Bool = false,
+        recieve: Bool = false,
+        accept: Bool = false,
+        error: Error? = nil
+    ) {
+        self.send = send
+        self.recieve = recieve
+        self.accept = accept
+        self.error = error
+    }
+}
+
+extension L2CAPSocketStatus: Equatable where Error: Equatable { }
+
+extension L2CAPSocketStatus: Hashable where Error: Hashable { }

--- a/pico-w-ble-peripheral-sdk/Bluetooth/LowEnergyAdvertisingData.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/LowEnergyAdvertisingData.swift
@@ -1,0 +1,345 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+/// Bluetooth Low Energy Advertising Data.
+///
+/// ![Image](https://github.com/PureSwift/Bluetooth/raw/master/Assets/LowEnergyAdvertisingDataExample1.png)
+@frozen
+public struct LowEnergyAdvertisingData: Sendable {
+    
+    public typealias Element = UInt8
+    
+    // MARK: - ByteValue
+    
+    /// Raw Bluetooth Low Energy Advertising Data 31 byte value.
+    public typealias ByteValue = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+    
+    // MARK: - Properties
+    
+    public var length: UInt8 {
+        didSet { precondition(length <= 31, "LE Advertising Data can only less than or equal to 31 octets") }
+    }
+    
+    public var bytes: ByteValue
+    
+    // MARK: - Initialization
+    
+    public init(length: UInt8, bytes: ByteValue) {
+        
+        precondition(length <= 31, "LE Advertising Data can only less than or equal to 31 octets")
+        self.bytes = bytes
+        self.length = length
+    }
+    
+    public init() {
+        
+        self.length = 0
+        self.bytes = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    }
+}
+
+public extension LowEnergyAdvertisingData {
+    
+    static var capacity: Int { return 31 }
+}
+
+public extension LowEnergyAdvertisingData {
+    
+    /// Unsafe data access.
+    func withUnsafePointer <Result> (_ block: (UnsafePointer<UInt8>) throws -> Result) rethrows -> Result {
+        return try Swift.withUnsafePointer(to: bytes) {
+            try $0.withMemoryRebound(to: UInt8.self, capacity: LowEnergyAdvertisingData.capacity) {
+                try block($0)
+            }
+        }
+    }
+}
+
+public extension LowEnergyAdvertisingData {
+    
+    init<Data: DataContainer>(data: Data) {
+        self.init(data)
+    }
+    
+    init<C: Collection> (_ collection: C) where C.Element == UInt8 {
+        let length = collection.count
+        precondition(length <= 31)
+        self.init()
+        self.length = UInt8(length)
+        collection.enumerated().forEach {
+            self[$0.offset] = $0.element
+        }
+    }
+}
+
+public extension LowEnergyAdvertisingData {
+    
+    mutating func append(_ byte: UInt8) {
+        assert(count < 31)
+        self[count] = byte
+        self.length += 1
+    }
+    
+    static func += (data: inout LowEnergyAdvertisingData, byte: UInt8) {
+        data.append(byte)
+    }
+    
+    mutating func append <C: Collection> (contentsOf bytes: C) where C.Element == UInt8 {
+        assert(count + bytes.count <= LowEnergyAdvertisingData.capacity)
+        for (index, byte) in bytes.enumerated() {
+            self[count + index] = byte
+        }
+        self.length += UInt8(bytes.count)
+    }
+    
+    static func += <C: Collection> (data: inout LowEnergyAdvertisingData, bytes: C) where C.Element == UInt8 {
+        data.append(contentsOf: bytes)
+    }
+    
+    mutating func append(_ pointer: UnsafePointer<UInt8>, count: Int) {
+        assert(self.count + count <= LowEnergyAdvertisingData.capacity)
+        for index in 0 ..< count {
+            self[self.count + index] = pointer.advanced(by: index).pointee
+        }
+        self.length += UInt8(count)
+    }
+}
+
+// MARK: - Equatable
+
+extension LowEnergyAdvertisingData: Equatable {
+    
+    public static func == (lhs: LowEnergyAdvertisingData, rhs: LowEnergyAdvertisingData) -> Bool {
+        return lhs.length == rhs.length &&
+            lhs.bytes.0 == rhs.bytes.0 &&
+            lhs.bytes.1 == rhs.bytes.1 &&
+            lhs.bytes.2 == rhs.bytes.2 &&
+            lhs.bytes.3 == rhs.bytes.3 &&
+            lhs.bytes.4 == rhs.bytes.4 &&
+            lhs.bytes.5 == rhs.bytes.5 &&
+            lhs.bytes.6 == rhs.bytes.6 &&
+            lhs.bytes.7 == rhs.bytes.7 &&
+            lhs.bytes.8 == rhs.bytes.8 &&
+            lhs.bytes.9 == rhs.bytes.9 &&
+            lhs.bytes.10 == rhs.bytes.10 &&
+            lhs.bytes.11 == rhs.bytes.11 &&
+            lhs.bytes.12 == rhs.bytes.12 &&
+            lhs.bytes.13 == rhs.bytes.13 &&
+            lhs.bytes.14 == rhs.bytes.14 &&
+            lhs.bytes.15 == rhs.bytes.15 &&
+            lhs.bytes.16 == rhs.bytes.16 &&
+            lhs.bytes.17 == rhs.bytes.17 &&
+            lhs.bytes.18 == rhs.bytes.18 &&
+            lhs.bytes.19 == rhs.bytes.19 &&
+            lhs.bytes.20 == rhs.bytes.20 &&
+            lhs.bytes.21 == rhs.bytes.21 &&
+            lhs.bytes.22 == rhs.bytes.22 &&
+            lhs.bytes.23 == rhs.bytes.23 &&
+            lhs.bytes.24 == rhs.bytes.24 &&
+            lhs.bytes.25 == rhs.bytes.25 &&
+            lhs.bytes.26 == rhs.bytes.26 &&
+            lhs.bytes.27 == rhs.bytes.27 &&
+            lhs.bytes.28 == rhs.bytes.28 &&
+            lhs.bytes.29 == rhs.bytes.29 &&
+            lhs.bytes.30 == rhs.bytes.30
+    }
+}
+
+// MARK: - Hashable
+
+extension LowEnergyAdvertisingData: Hashable {
+    
+    public func hash(into hasher: inout Hasher) {
+        length.hash(into: &hasher)
+        withUnsafeBytes(of: bytes) { hasher.combine(bytes: $0) }
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension LowEnergyAdvertisingData: CustomStringConvertible {
+    
+    public var description: String {
+        return toHexadecimal()
+    }
+}
+
+// MARK: - ExpressibleByArrayLiteral
+
+extension LowEnergyAdvertisingData: ExpressibleByArrayLiteral {
+    
+    public init(arrayLiteral elements: UInt8...) {
+        precondition(elements.count <= 31)
+        self.init(elements)
+    }
+}
+
+// MARK: - Data
+
+#if canImport(Foundation)
+public extension LowEnergyAdvertisingData {
+    
+    /// Unsafe data access.
+    func withUnsafeData <Result> (_ block: (Data) throws -> Result) rethrows -> Result {
+        return try withUnsafePointer {
+            try block(Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: $0),
+                               count: count,
+                               deallocator: .none))
+        }
+    }
+}
+#endif
+
+// MARK: - Sequence
+
+extension LowEnergyAdvertisingData: Sequence {
+    
+    public func makeIterator() -> IndexingIterator<LowEnergyAdvertisingData> {
+        return IndexingIterator(_elements: self)
+    }
+}
+
+// MARK: - Collection
+
+extension LowEnergyAdvertisingData: MutableCollection {
+    
+    public var count: Int {
+        return Int(length)
+    }
+    
+    public func index(after index: Int) -> Int {
+        return index + 1
+    }
+    
+    public var startIndex: Int {
+        return 0
+    }
+    
+    public var endIndex: Int {
+        return count
+    }
+    
+    /// Get the byte at the specified index.
+    public subscript (index: Int) -> UInt8 {
+        
+        get {
+            
+            switch index {
+            case 0: return bytes.0
+            case 1: return bytes.1
+            case 2: return bytes.2
+            case 3: return bytes.3
+            case 4: return bytes.4
+            case 5: return bytes.5
+            case 6: return bytes.6
+            case 7: return bytes.7
+            case 8: return bytes.8
+            case 9: return bytes.9
+            case 10: return bytes.10
+            case 11: return bytes.11
+            case 12: return bytes.12
+            case 13: return bytes.13
+            case 14: return bytes.14
+            case 15: return bytes.15
+            case 16: return bytes.16
+            case 17: return bytes.17
+            case 18: return bytes.18
+            case 19: return bytes.19
+            case 20: return bytes.20
+            case 21: return bytes.21
+            case 22: return bytes.22
+            case 23: return bytes.23
+            case 24: return bytes.24
+            case 25: return bytes.25
+            case 26: return bytes.26
+            case 27: return bytes.27
+            case 28: return bytes.28
+            case 29: return bytes.29
+            case 30: return bytes.30
+            default:
+                fatalError("Invalid index")
+            }
+        }
+        
+        mutating set {
+            
+            switch index {
+            case 0: bytes.0 = newValue
+            case 1: bytes.1 = newValue
+            case 2: bytes.2 = newValue
+            case 3: bytes.3 = newValue
+            case 4: bytes.4 = newValue
+            case 5: bytes.5 = newValue
+            case 6: bytes.6 = newValue
+            case 7: bytes.7 = newValue
+            case 8: bytes.8 = newValue
+            case 9: bytes.9 = newValue
+            case 10: bytes.10 = newValue
+            case 11: bytes.11 = newValue
+            case 12: bytes.12 = newValue
+            case 13: bytes.13 = newValue
+            case 14: bytes.14 = newValue
+            case 15: bytes.15 = newValue
+            case 16: bytes.16 = newValue
+            case 17: bytes.17 = newValue
+            case 18: bytes.18 = newValue
+            case 19: bytes.19 = newValue
+            case 20: bytes.20 = newValue
+            case 21: bytes.21 = newValue
+            case 22: bytes.22 = newValue
+            case 23: bytes.23 = newValue
+            case 24: bytes.24 = newValue
+            case 25: bytes.25 = newValue
+            case 26: bytes.26 = newValue
+            case 27: bytes.27 = newValue
+            case 28: bytes.28 = newValue
+            case 29: bytes.29 = newValue
+            case 30: bytes.30 = newValue
+            default:
+                fatalError("Invalid index")
+            }
+        }
+    }
+}
+
+// MARK: - RandomAccessCollection
+
+extension LowEnergyAdvertisingData: RandomAccessCollection {
+        
+    public subscript(bounds: Range<Int>) -> Slice<LowEnergyAdvertisingData> {
+        return Slice<LowEnergyAdvertisingData>(base: self, bounds: bounds)
+    }
+}
+
+// MARK: - Codable
+
+#if !hasFeature(Embedded)
+extension LowEnergyAdvertisingData: Codable {
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let data = try container.decode(Data.self)
+        guard data.count <= LowEnergyAdvertisingData.capacity else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Invalid number of bytes (\(data.count)."))
+        }
+        self.init(data: data)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(Data(self))
+    }
+}
+#endif

--- a/pico-w-ble-peripheral-sdk/Bluetooth/SecurityLevel.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/SecurityLevel.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Bluetooth security level.
+public enum SecurityLevel: UInt8, Sendable {
+    
+    case sdp        = 0
+    case low        = 1
+    case medium     = 2
+    case high       = 3
+    case fips       = 4
+    
+    public init() { self = .sdp }
+}
+
+// MARK: - Comparable
+
+extension SecurityLevel: Comparable {
+    
+    public static func < (lhs: SecurityLevel, rhs: SecurityLevel) -> Bool {
+        return lhs.rawValue < rhs.rawValue
+    }
+}

--- a/pico-w-ble-peripheral-sdk/Bluetooth/UInt128.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/UInt128.swift
@@ -1,0 +1,595 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+// MARK: - ByteValue
+
+extension UInt128: ByteValue {
+    
+    public typealias ByteValue = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+        
+    public var bytes: ByteValue {
+      @_transparent
+      get {
+          unsafeBitCast(self, to: ByteValue.self)
+      }
+    
+      @_transparent
+      set {
+          self = .init(bytes: newValue)
+      }
+    }
+    
+    public init(bytes: ByteValue) {
+        self = unsafeBitCast(bytes, to: Self.self)
+    }
+}
+
+// MARK: - Data Convertible
+
+extension UInt128: DataConvertible {
+        
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == UInt128.length
+            else { return nil }
+        self.init(bytes: (data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15]))
+    }
+    
+    public func append<Data: DataContainer>(to data: inout Data) {
+        unsafeAppend(to: &data)
+    }
+    
+    /// Length of value when encoded into data.
+    public var dataLength: Int { Self.length }
+}
+
+// MARK: - UUID
+
+public extension UInt128 {
+    
+    init(uuid: UUID) {
+        /// UUID is always big endian
+        let bigEndian = UInt128(bytes: uuid.uuid)
+        self.init(bigEndian: bigEndian)
+    }
+}
+
+public extension UUID {
+    
+    init(_ value: UInt128) {
+        
+        // UUID is always stored in big endian bytes
+        let bytes = value.bigEndian.bytes
+        
+        self.init(bytes: (bytes.0,
+                          bytes.1,
+                          bytes.2,
+                          bytes.3,
+                          bytes.4,
+                          bytes.5,
+                          bytes.6,
+                          bytes.7,
+                          bytes.8,
+                          bytes.9,
+                          bytes.10,
+                          bytes.11,
+                          bytes.12,
+                          bytes.13,
+                          bytes.14,
+                          bytes.15))
+    }
+}
+
+// MARK: - Backwards compatibility
+
+internal extension UInt128 {
+    
+    var hexadecimal: String {
+        let bytes = self.bigEndian.bytes
+        return bytes.0.toHexadecimal()
+            + bytes.1.toHexadecimal()
+            + bytes.2.toHexadecimal()
+            + bytes.3.toHexadecimal()
+            + bytes.4.toHexadecimal()
+            + bytes.5.toHexadecimal()
+            + bytes.6.toHexadecimal()
+            + bytes.7.toHexadecimal()
+            + bytes.8.toHexadecimal()
+            + bytes.9.toHexadecimal()
+            + bytes.10.toHexadecimal()
+            + bytes.11.toHexadecimal()
+            + bytes.12.toHexadecimal()
+            + bytes.13.toHexadecimal()
+            + bytes.14.toHexadecimal()
+            + bytes.15.toHexadecimal()
+    }
+}
+
+#if canImport(Darwin)
+/// A 128-bit signed integer value type.
+@frozen
+public struct UInt128: Sendable {
+    
+#if _endian(little)
+  public var _low: UInt64
+  public var _high: UInt64
+#else
+  public var _high: UInt64
+  public var _low: UInt64
+#endif
+
+  @_transparent
+  public init(_low: UInt64, _high: UInt64) {
+    self._low = _low
+    self._high = _high
+  }
+  
+  // Allow conversion if type is available.
+  @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+  public var _value: Int128 {
+    @_transparent
+    get {
+      unsafeBitCast(self, to: Int128.self)
+    }
+
+    @_transparent
+    set {
+      self = Self(newValue)
+    }
+  }
+  
+  @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+  @_transparent
+  public init(_ _value: Int128) {
+    self = unsafeBitCast(_value, to: Self.self)
+  }
+
+  /// Creates a new instance with the same memory representation as the given
+  /// value.
+  ///
+  /// This initializer does not perform any range or overflow checking. The
+  /// resulting instance may not have the same numeric value as
+  /// `bitPattern`---it is only guaranteed to use the same pattern of bits in
+  /// its binary representation.
+  ///
+  /// - Parameter bitPattern: A value to use as the source of the new instance's
+  ///   binary representation.
+  @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+  @_transparent
+  public init(bitPattern: Int128) {
+    self.init(bitPattern)
+  }
+}
+
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+public extension Bluetooth.UInt128 {
+    
+    init(_ value: Swift.UInt128) {
+        self.init(_low: value._low, _high: value._high)
+    }
+}
+
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+public extension Swift.UInt128 {
+    
+    init(_ value: Bluetooth.UInt128) {
+        self.init(bitPattern: value._value)
+    }
+}
+
+// MARK: - Constants
+
+extension Bluetooth.UInt128 {
+  @_transparent
+  public static var zero: Self {
+      Self(_low: .min, _high: .min)
+  }
+
+  @_transparent
+  public static var min: Self {
+    zero
+  }
+
+  @_transparent
+  public static var max: Self {
+    Self(_low: .max, _high: .max)
+  }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+extension Bluetooth.UInt128: ExpressibleByIntegerLiteral {
+    
+    public typealias IntegerLiteralType = Swift.UInt128
+    
+    public init(integerLiteral value: Swift.UInt128) {
+        self.init(_low: value._low, _high: value._high)
+    }
+}
+
+// MARK: - Conversions
+
+extension Bluetooth.UInt128 {
+
+  @inlinable
+  public init?<T>(exactly source: T) where T: BinaryInteger {
+    guard let high = UInt64(exactly: source >> 64) else { return nil }
+    let low = UInt64(truncatingIfNeeded: source)
+    self.init(_low: low, _high: high)
+  }
+
+  @inlinable
+  public init<T>(_ source: T) where T: BinaryInteger {
+    guard let value = Self(exactly: source) else {
+      fatalError("value cannot be converted to UInt128 because it is outside the representable range")
+    }
+    self = value
+  }
+
+  @inlinable
+  public init<T>(clamping source: T) where T: BinaryInteger {
+    guard let value = Self(exactly: source) else {
+      self = source < .zero ? .zero : .max
+      return
+    }
+    self = value
+  }
+
+  @inlinable
+  public init<T>(truncatingIfNeeded source: T) where T: BinaryInteger {
+    let high = UInt64(truncatingIfNeeded: source >> 64)
+    let low = UInt64(truncatingIfNeeded: source)
+    self.init(_low: low, _high: high)
+  }
+
+  @_transparent
+  public init(_truncatingBits source: UInt) {
+    self.init(_low: UInt64(source), _high: .zero)
+  }
+}
+
+extension UInt128 {
+  @inlinable
+  public init?<T>(exactly source: T) where T: BinaryFloatingPoint {
+    let highAsFloat = (source * 0x1.0p-64).rounded(.towardZero)
+    guard let high = UInt64(exactly: highAsFloat) else { return nil }
+    guard let low = UInt64(
+      exactly: high == 0 ? source : source - 0x1.0p64*highAsFloat
+    ) else { return nil }
+    self.init(_low: low, _high: high)
+  }
+
+  @inlinable
+  public init<T>(_ source: T) where T: BinaryFloatingPoint {
+    guard let value = Self(exactly: source.rounded(.towardZero)) else {
+      fatalError("value cannot be converted to UInt128 because it is outside the representable range")
+    }
+    self = value
+  }
+}
+
+// MARK: - Equatable
+
+extension Bluetooth.UInt128: Equatable {
+    
+    public static func == (lhs: UInt128, rhs: UInt128) -> Bool {
+        return lhs._low == rhs._low
+            && lhs._high == rhs._high
+    }
+}
+
+// MARK: - Hashable
+
+extension Bluetooth.UInt128: Hashable {
+    
+    @inlinable
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_low)
+        hasher.combine(_high)
+    }
+}
+
+// MARK: - Comparable
+
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+extension Bluetooth.UInt128: Comparable {
+    
+    @_transparent
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        Swift.UInt128(lhs) < Swift.UInt128(rhs)
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension Bluetooth.UInt128: CustomStringConvertible {
+    
+    public var description: String {
+        if #available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *) {
+            return Swift.UInt128(self).description
+        } else {
+            return "0x" + hexadecimal
+        }
+    }
+}
+
+// MARK: - Numeric
+
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+extension UInt128: Numeric {
+  public typealias Magnitude = Self
+
+  @_transparent
+  public var magnitude: Self {
+    self
+  }
+}
+
+// MARK: - AdditiveArithmetic
+
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+extension UInt128: AdditiveArithmetic {
+  @_transparent
+  public static func + (a: Self, b: Self) -> Self {
+      Bluetooth.UInt128(Swift.UInt128(a) + Swift.UInt128(b))
+  }
+
+  @_transparent
+  public static func - (a: Self, b: Self) -> Self {
+      Bluetooth.UInt128(Swift.UInt128(a) - Swift.UInt128(b))
+  }
+}
+
+// MARK: - Multiplication and division
+
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+extension UInt128 {
+  @_transparent
+  public static func * (a: Self, b: Self) -> Self {
+      Bluetooth.UInt128(Swift.UInt128(a) * Swift.UInt128(b))
+  }
+
+  @_transparent
+  public static func *= (a: inout Self, b: Self) {
+    a = a * b
+  }
+
+  @_transparent
+  public static func /(a: Self, b: Self) -> Self {
+    a.dividedReportingOverflow(by: b).partialValue
+  }
+
+  @_transparent
+  public static func /=(a: inout Self, b: Self) {
+    a = a / b
+  }
+
+  @_transparent
+  public static func %(a: Self, b: Self) -> Self {
+    a.remainderReportingOverflow(dividingBy: b).partialValue
+  }
+
+  @_transparent
+  public static func %=(a: inout Self, b: Self) {
+    a = a % b
+  }
+}
+
+// MARK: - Overflow-reporting arithmetic
+
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+extension UInt128 {
+  @_transparent
+  public func addingReportingOverflow(
+    _ other: Self
+  ) -> (partialValue: Self, overflow: Bool) {
+      let (partialValue, overflow) = Swift.UInt128(self).addingReportingOverflow(.init(other))
+      return (Self(partialValue), overflow)
+  }
+
+  @_transparent
+  public func subtractingReportingOverflow(
+    _ other: Self
+  ) -> (partialValue: Self, overflow: Bool) {
+      let (partialValue, overflow) = Swift.UInt128(self).subtractingReportingOverflow(.init(other))
+      return (Self(partialValue), overflow)
+  }
+
+  @_transparent
+  public func multipliedReportingOverflow(
+    by other: Self
+  ) -> (partialValue: Self, overflow: Bool) {
+      let (partialValue, overflow) = Swift.UInt128(self).multipliedReportingOverflow(by: .init(other))
+      return (Self(partialValue), overflow)
+  }
+
+  @_transparent
+  public func dividedReportingOverflow(
+    by other: Self
+  ) -> (partialValue: Self, overflow: Bool) {
+    precondition(other != .zero, "Division by zero")
+      let (partialValue, overflow) = Swift.UInt128(self).dividedReportingOverflow(by: .init(other))
+      return (Self(partialValue), overflow)
+  }
+
+  @_transparent
+  public func remainderReportingOverflow(
+    dividingBy other: Self
+  ) -> (partialValue: Self, overflow: Bool) {
+    precondition(other != .zero, "Division by zero in remainder operation")
+      let (partialValue, overflow) = Swift.UInt128(self).remainderReportingOverflow(dividingBy: .init(other))
+      return (Self(partialValue), overflow)
+  }
+}
+
+// MARK: - BinaryInteger conformance
+
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+extension Bluetooth.UInt128: BinaryInteger {
+    
+    public typealias Words = Swift.UInt128.Words
+
+  @_transparent
+  public var words: Words {
+      Words(_value: .init(self))
+  }
+
+  @_transparent
+  public static func &=(a: inout Self, b: Self) {
+      a = Bluetooth.UInt128(Swift.UInt128(a) & Swift.UInt128(b))
+  }
+
+  @_transparent
+  public static func |=(a: inout Self, b: Self) {
+      a = Bluetooth.UInt128(Swift.UInt128(a) | Swift.UInt128(b))
+  }
+
+  @_transparent
+  public static func ^=(a: inout Self, b: Self) {
+      a = Bluetooth.UInt128(Swift.UInt128(a) ^ Swift.UInt128(b))
+  }
+
+  @_transparent
+  public static func &>>=(a: inout Self, b: Self) {
+      a = Bluetooth.UInt128(Swift.UInt128(a) &>> Swift.UInt128(b))
+  }
+
+  @_transparent
+  public static func &<<=(a: inout Self, b: Self) {
+      a = Bluetooth.UInt128(Swift.UInt128(a) &<< Swift.UInt128(b))
+  }
+
+  @_transparent
+  public var trailingZeroBitCount: Int {
+    _low == 0 ? 64 + _high.trailingZeroBitCount : _low.trailingZeroBitCount
+  }
+
+  @_transparent
+  public var _lowWord: UInt {
+      Swift.UInt128(self)._lowWord
+  }
+}
+
+// MARK: - FixedWidthInteger conformance
+
+@available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+extension UInt128: FixedWidthInteger, UnsignedInteger { }
+
+public extension UInt128 {
+    
+    @_transparent
+    static var bitWidth: Int { 128 }
+    
+    @_transparent
+    var nonzeroBitCount: Int {
+      _high.nonzeroBitCount &+ _low.nonzeroBitCount
+    }
+
+    @_transparent
+    var leadingZeroBitCount: Int {
+      _high == 0 ? 64 + _low.leadingZeroBitCount : _high.leadingZeroBitCount
+    }
+    
+    @_transparent
+    var byteSwapped: Self {
+      return Self(_low: _high.byteSwapped, _high: _low.byteSwapped)
+    }
+    
+    /// Creates an instance from its little-endian representation, changing the
+    /// byte order if necessary.
+    ///
+    /// - Parameter value: A value to use as the little-endian representation of
+    ///   the new instance.
+    init(littleEndian value: Self) {
+        #if _endian(little)
+        self = value
+        #else
+        self = value.byteSwapped
+        #endif
+    }
+    
+    /// Creates an instance from its big-endian representation, changing the byte
+    /// order if necessary.
+    ///
+    /// - Parameter value: A value to use as the big-endian representation of the
+    ///   new instance.
+    init(bigEndian value: Self) {
+        #if _endian(big)
+        self = value
+        #else
+        self = value.byteSwapped
+        #endif
+    }
+    
+    /// The little-endian representation of this value.
+    ///
+    /// If necessary, the byte order of this value is reversed from the typical
+    /// byte order of this address. On a little-endian platform, for any
+    /// address `x`, `x == x.littleEndian`.
+    var littleEndian: Self {
+        #if _endian(little)
+        return self
+        #else
+        return byteSwapped
+        #endif
+    }
+    
+    /// The big-endian representation of this value.
+    ///
+    /// If necessary, the byte order of this value is reversed from the typical
+    /// byte order of this address. On a big-endian platform, for any
+    /// address `x`, `x == x.bigEndian`.
+    var bigEndian: Self {
+        #if _endian(big)
+        return self
+        #else
+        return byteSwapped
+        #endif
+    }
+}
+
+// MARK: - Integer comparison type inference
+
+extension UInt128 {
+  // IMPORTANT: The following four apparently unnecessary overloads of
+  // comparison operations are necessary for literal comparands to be
+  // inferred as the desired type.
+  @_transparent @_alwaysEmitIntoClient
+  public static func != (lhs: Self, rhs: Self) -> Bool {
+    return !(lhs == rhs)
+  }
+
+    @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+  @_transparent @_alwaysEmitIntoClient
+  public static func <= (lhs: Self, rhs: Self) -> Bool {
+    return !(rhs < lhs)
+  }
+
+    @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+  @_transparent @_alwaysEmitIntoClient
+  public static func >= (lhs: Self, rhs: Self) -> Bool {
+    return !(lhs < rhs)
+  }
+
+    @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
+  @_transparent @_alwaysEmitIntoClient
+  public static func > (lhs: Self, rhs: Self) -> Bool {
+    return rhs < lhs
+  }
+}
+
+#else
+public typealias UInt128 = Swift.UInt128
+#endif

--- a/pico-w-ble-peripheral-sdk/Bluetooth/UInt24.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/UInt24.swift
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A 24 bit number stored according to host endianness.
+@frozen
+public struct UInt24: ByteValue, Comparable, Sendable {
+    
+    public typealias ByteValue = (UInt8, UInt8, UInt8)
+    
+    public static var bitWidth: Int { 24 }
+    
+    public var bytes: ByteValue
+    
+    public init(bytes: ByteValue = (0, 0, 0)) {
+        
+        self.bytes = bytes
+    }
+}
+
+public extension UInt24 {
+    
+    /// The minimum representable value in this type.
+    static var min: UInt24 { return UInt24(bytes: (.min, .min, .min)) }
+    
+    /// The maximum representable value in this type.
+    static var max: UInt24 { return UInt24(bytes: (.max, .max, .max)) }
+    
+    /// The value with all bits set to zero.
+    static var zero: UInt24 { return .min }
+}
+
+// MARK: - Hashable
+
+extension UInt24: Hashable {
+    
+    public func hash(into hasher: inout Hasher) {
+        Swift.withUnsafeBytes(of: bytes) { hasher.combine(bytes: $0) }
+    }
+}
+
+// MARK: - Data Convertible
+
+extension UInt24: DataConvertible {
+        
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == UInt24.length else { return nil }
+        self.init(bytes: (data[0], data[1], data[2]))
+    }
+}
+
+// MARK: - Byte Swap
+
+extension UInt24: ByteSwap {
+    
+    /// A representation of this integer with the byte order swapped.
+    public var byteSwapped: UInt24 {
+        return UInt24(bytes: (bytes.2, bytes.1, bytes.0))
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension UInt24: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral value: UInt32) {
+        self = UInt24(value)
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension UInt24: CustomStringConvertible {
+    
+    public var description: String {
+        UInt32(self).description
+    }
+}
+
+// MARK: - Integer Conversion
+
+public extension UInt24 {
+    
+    /// Initialize from a unsigned 32-bit integer.
+    init(_ value: UInt32) {
+        guard value <= UInt32(UInt24.max)
+            else { fatalError("Integer overflow") }
+        let bytes = value.bigEndian.bytes
+        self = UInt24(bigEndian: UInt24(bytes: (bytes.1, bytes.2, bytes.3)))
+    }
+}
+
+public extension UInt32 {
+    
+    /// Initialize from a unsigned 24-bit integer.
+    init(_ value: UInt24) {
+        let bytes = value.bigEndian.bytes
+        self = UInt32(bigEndian: UInt32(bytes: (0, bytes.0, bytes.1, bytes.2)))
+    }
+}
+
+// MARK: - Codable
+
+#if !hasFeature(Embedded)
+extension UInt24: Codable {
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(UInt32.self)
+        guard value <= UInt32(UInt24.max) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unable to decode \(value) as \(UInt24.self)"))
+        }
+        self.init(value)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        let value = UInt32(self)
+        try container.encode(value)
+    }
+}
+#endif

--- a/pico-w-ble-peripheral-sdk/Bluetooth/UInt256.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/UInt256.swift
@@ -1,0 +1,113 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A 256 bit number stored according to host endianness.
+@frozen
+public struct UInt256: ByteValue, Comparable, Sendable {
+    
+    public typealias ByteValue = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+    
+    public static var bitWidth: Int { 256 }
+    
+    public var bytes: ByteValue
+    
+    public init(bytes: ByteValue = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)) {
+        self.bytes = bytes
+    }
+}
+
+public extension UInt256 {
+    
+    /// The minimum representable value in this type.
+    static var min: UInt256 { return UInt256(bytes: (.min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min)) }
+    
+    /// The maximum representable value in this type.
+    static var max: UInt256 { return UInt256(bytes: (.max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max)) }
+    
+    /// The value with all bits set to zero.
+    static var zero: UInt256 { return .min }
+}
+
+// MARK: - Hashable
+
+extension UInt256: Hashable {
+    
+    public func hash(into hasher: inout Hasher) {
+        Swift.withUnsafeBytes(of: bytes) { hasher.combine(bytes: $0) }
+    }
+}
+
+// MARK: - Data Convertible
+
+extension UInt256: DataConvertible {
+        
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == Self.length else { return nil }
+        self.init(bytes: (data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15], data[16], data[17], data[18], data[19], data[20], data[21], data[22], data[23], data[24], data[25], data[26], data[27], data[28], data[29], data[30], data[31]))
+    }
+}
+
+// MARK: - Byte Swap
+
+extension UInt256: ByteSwap {
+    
+    /// A representation of this integer with the byte order swapped.
+    public var byteSwapped: UInt256 {
+        
+        return UInt256(bytes: (bytes.31,
+                               bytes.30,
+                               bytes.29,
+                               bytes.28,
+                               bytes.27,
+                               bytes.26,
+                               bytes.25,
+                               bytes.24,
+                               bytes.23,
+                               bytes.22,
+                               bytes.21,
+                               bytes.20,
+                               bytes.19,
+                               bytes.18,
+                               bytes.17,
+                               bytes.16,
+                               bytes.15,
+                               bytes.14,
+                               bytes.13,
+                               bytes.12,
+                               bytes.11,
+                               bytes.10,
+                               bytes.9,
+                               bytes.8,
+                               bytes.7,
+                               bytes.6,
+                               bytes.5,
+                               bytes.4,
+                               bytes.3,
+                               bytes.2,
+                               bytes.1,
+                               bytes.0))
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension UInt256: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral value: UInt64) {
+        // TODO: Implement `StaticBigInt`
+        let bytes = value.bigEndian.bytes
+        self = UInt256(bigEndian: UInt256(bytes: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, bytes.0, bytes.1, bytes.2, bytes.3, bytes.4, bytes.5, bytes.6, bytes.7)))
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension UInt256: CustomStringConvertible { }

--- a/pico-w-ble-peripheral-sdk/Bluetooth/UInt40.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/UInt40.swift
@@ -1,0 +1,107 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A 40 bit number stored according to host endianness.
+@frozen
+public struct UInt40: ByteValue, Comparable, Sendable {
+    
+    public typealias ByteValue = (UInt8, UInt8, UInt8, UInt8, UInt8)
+    
+    public static var bitWidth: Int { 40 }
+    
+    public var bytes: ByteValue
+    
+    public init(bytes: ByteValue = (0, 0, 0, 0, 0)) {
+        
+        self.bytes = bytes
+    }
+}
+
+public extension UInt40 {
+    
+    /// The minimum representable value in this type.
+    static var min: UInt40 { return UInt40(bytes: (.min, .min, .min, .min, .min)) }
+    
+    /// The maximum representable value in this type.
+    static var max: UInt40 { return UInt40(bytes: (.max, .max, .max, .max, .max)) }
+    
+    /// The value with all bits set to zero.
+    static var zero: UInt40 { return .min }
+}
+
+// MARK: - Hashable
+
+extension UInt40: Hashable {
+    
+    public func hash(into hasher: inout Hasher) {
+        Swift.withUnsafeBytes(of: bytes) { hasher.combine(bytes: $0) }
+    }
+}
+
+// MARK: - Data Convertible
+
+extension UInt40: DataConvertible {
+        
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == UInt40.length else { return nil }
+        self.init(bytes: (data[0], data[1], data[2], data[3], data[4]))
+    }
+}
+
+// MARK: - Byte Swap
+
+extension UInt40: ByteSwap {
+    
+    /// A representation of this integer with the byte order swapped.
+    public var byteSwapped: UInt40 {
+        return UInt40(bytes: (bytes.4, bytes.3, bytes.2, bytes.1, bytes.0))
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension UInt40: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral value: UInt64) {
+        self = UInt40(value)
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension UInt40: CustomStringConvertible {
+    
+    public var description: String {
+        UInt64(self).description
+    }
+}
+
+// MARK: - Integer Conversion
+
+public extension UInt40 {
+    
+    /// Initialize from a unsigned 64-bit integer.
+    init(_ value: UInt64) {
+        guard value <= UInt64(UInt40.max)
+            else { fatalError("Integer overflow") }
+        let bytes = value.bigEndian.bytes
+        self = UInt40(bigEndian: UInt40(bytes: (bytes.3, bytes.4, bytes.5, bytes.6, bytes.7)))
+    }
+}
+
+public extension UInt64 {
+    
+    /// Initialize from a unsigned 40-bit integer.
+    init(_ value: UInt40) {
+        let bytes = value.bigEndian.bytes
+        self = UInt64(bigEndian: UInt64(bytes: (0, 0, 0, bytes.0, bytes.1, bytes.2, bytes.3, bytes.4)))
+    }
+}

--- a/pico-w-ble-peripheral-sdk/Bluetooth/UInt48.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/UInt48.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@frozen
+public struct UInt48: ByteValue, Comparable, Sendable {
+ 
+    public typealias ByteValue = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+    
+    public static var bitWidth: Int { 48 }
+    
+    public var bytes: ByteValue
+    
+    public init(bytes: ByteValue = (0, 0, 0, 0, 0, 0)) {
+        self.bytes = bytes
+    }
+}
+
+public extension UInt48 {
+    
+    /// The minimum representable value in this type.
+    static var min: UInt48 { return UInt48(bytes: (.min, .min, .min, .min, .min, .min)) }
+    
+    /// The maximum representable value in this type.
+    static var max: UInt48 { return UInt48(bytes: (.max, .max, .max, .max, .max, .max)) }
+    
+    /// The value with all bits set to zero.
+    static var zero: UInt48 { return .min }
+}
+
+// MARK: - Hashable
+
+extension UInt48: Hashable {
+    
+    public func hash(into hasher: inout Hasher) {
+        Swift.withUnsafeBytes(of: bytes) { hasher.combine(bytes: $0) }
+    }
+}
+
+// MARK: - Data Convertible
+
+extension UInt48: DataConvertible {
+        
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == Self.length else { return nil }
+        self.init(bytes: (data[0], data[1], data[2], data[3], data[4], data[5]))
+    }
+}
+
+// MARK: - Byte Swap
+
+extension UInt48: ByteSwap {
+    
+    /// A representation of this integer with the byte order swapped.
+    public var byteSwapped: UInt48 {
+        return UInt48(bytes: (bytes.5, bytes.4, bytes.3, bytes.2, bytes.1, bytes.0))
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension UInt48: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral value: UInt64) {
+        self = UInt48(value)
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension UInt48: CustomStringConvertible {
+    
+    public var description: String {
+        UInt64(self).description
+    }
+}
+
+// MARK: - Integer Conversion
+
+public extension UInt48 {
+    
+    /// Initialize from a unsigned 64-bit integer.
+    init(_ value: UInt64) {
+        
+        guard value <= UInt64(UInt48.max)
+            else { fatalError("Integer overflow") }
+        
+        let bytes = value.bigEndian.bytes
+        
+        self = UInt48(bigEndian: UInt48(bytes: (bytes.2, bytes.3, bytes.4, bytes.5, bytes.6, bytes.7)))
+    }
+}
+
+public extension UInt64 {
+    
+    /// Initialize from a unsigned 40-bit integer.
+    init(_ value: UInt48) {
+        
+        let bytes = value.bigEndian.bytes
+        self = UInt64(bigEndian: UInt64(bytes: (0, 0, bytes.0, bytes.1, bytes.2, bytes.3, bytes.4, bytes.5)))
+    }
+}

--- a/pico-w-ble-peripheral-sdk/Bluetooth/UInt512.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/UInt512.swift
@@ -1,0 +1,146 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A 512 bit number stored according to host endianness.
+@frozen
+public struct UInt512: ByteValue, Comparable, Sendable {
+    
+    public typealias ByteValue = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+    
+    public static var bitWidth: Int { 512 }
+    
+    public var bytes: ByteValue
+    
+    public init(bytes: ByteValue = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)) {
+        
+        self.bytes = bytes
+    }
+}
+
+public extension UInt512 {
+    
+    /// The minimum representable value in this type.
+    static var min: UInt512 { return UInt512(bytes: (.min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min, .min)) }
+    
+    /// The maximum representable value in this type.
+    static var max: UInt512 { return UInt512(bytes: (.max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max, .max)) }
+    
+    /// The value with all bits set to zero.
+    static var zero: UInt512 { return .min }
+}
+
+// MARK: - Hashable
+
+extension UInt512: Hashable {
+    
+    public func hash(into hasher: inout Hasher) {
+        Swift.withUnsafeBytes(of: bytes) { hasher.combine(bytes: $0) }
+    }
+}
+
+// MARK: - Data Convertible
+
+extension UInt512: DataConvertible {
+        
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == Self.length else { return nil }
+        self.init(bytes: (data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15], data[16], data[17], data[18], data[19], data[20], data[21], data[22], data[23], data[24], data[25], data[26], data[27], data[28], data[29], data[30], data[31], data[32], data[33], data[34], data[35], data[36], data[37], data[38], data[39], data[40], data[41], data[42], data[43], data[44], data[45], data[46], data[47], data[48], data[49], data[50], data[51], data[52], data[53], data[54], data[55], data[56], data[57], data[58], data[59], data[60], data[61], data[62], data[63]))
+    }
+}
+
+// MARK: - Byte Swap
+
+extension UInt512: ByteSwap {
+    
+    /// A representation of this integer with the byte order swapped.
+    public var byteSwapped: UInt512 {
+        
+        return UInt512(bytes: (bytes.63,
+                               bytes.62,
+                               bytes.61,
+                               bytes.60,
+                               bytes.59,
+                               bytes.58,
+                               bytes.57,
+                               bytes.56,
+                               bytes.55,
+                               bytes.54,
+                               bytes.53,
+                               bytes.52,
+                               bytes.51,
+                               bytes.50,
+                               bytes.49,
+                               bytes.48,
+                               bytes.47,
+                               bytes.46,
+                               bytes.45,
+                               bytes.44,
+                               bytes.43,
+                               bytes.42,
+                               bytes.41,
+                               bytes.40,
+                               bytes.39,
+                               bytes.38,
+                               bytes.37,
+                               bytes.36,
+                               bytes.35,
+                               bytes.34,
+                               bytes.33,
+                               bytes.32,
+                               bytes.31,
+                               bytes.30,
+                               bytes.29,
+                               bytes.28,
+                               bytes.27,
+                               bytes.26,
+                               bytes.25,
+                               bytes.24,
+                               bytes.23,
+                               bytes.22,
+                               bytes.21,
+                               bytes.20,
+                               bytes.19,
+                               bytes.18,
+                               bytes.17,
+                               bytes.16,
+                               bytes.15,
+                               bytes.14,
+                               bytes.13,
+                               bytes.12,
+                               bytes.11,
+                               bytes.10,
+                               bytes.9,
+                               bytes.8,
+                               bytes.7,
+                               bytes.6,
+                               bytes.5,
+                               bytes.4,
+                               bytes.3,
+                               bytes.2,
+                               bytes.1,
+                               bytes.0))
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension UInt512: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral value: UInt64) {
+        // TODO: Implement `StaticBigInt`
+        let bytes = value.bigEndian.bytes
+        self = UInt512(bigEndian: UInt512(bytes: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, bytes.0, bytes.1, bytes.2, bytes.3, bytes.4, bytes.5, bytes.6, bytes.7)))
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension UInt512: CustomStringConvertible { }

--- a/pico-w-ble-peripheral-sdk/Bluetooth/Unit.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/Unit.swift
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Type that represents a unit of measurement defined by Bluetooth.
+public protocol BluetoothUnit: RawRepresentable {
+    
+    /// The unit of measurement type.
+    static var unitType: UnitIdentifier { get }
+}

--- a/pico-w-ble-peripheral-sdk/Bluetooth/UnitIdentifier.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/UnitIdentifier.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@frozen
+public struct UnitIdentifier: RawRepresentable, Equatable, Hashable, Sendable {
+    
+    public var rawValue: UInt16
+    
+    public init(rawValue: UInt16) {
+        self.rawValue = rawValue
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension UnitIdentifier: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral value: UInt16) {
+        self.init(rawValue: value)
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension UnitIdentifier: CustomStringConvertible {
+    
+    public var description: String {
+        let valueString = "0x" + rawValue.toHexadecimal()
+        #if !os(WASI) && !hasFeature(Embedded)
+        if let name = self.name {
+            return valueString + " " + "(" + name + ")"
+        } else {
+            return valueString
+        }
+        #else
+        return valueString
+        #endif
+    }
+}
+
+// MARK: - Definitions
+
+#if !os(WASI) && !hasFeature(Embedded)
+public extension UnitIdentifier {
+    
+    /// The name of the unit.
+    var name: String? {
+        return Self.unitIdentifiers[rawValue]?.name
+    }
+    
+    /// The Bluetooth type namespace of the unit.
+    var type: String? {
+        return Self.unitIdentifiers[rawValue]?.type
+    }
+}
+#endif

--- a/pico-w-ble-peripheral-sdk/Bluetooth/iBeacon.swift
+++ b/pico-w-ble-peripheral-sdk/Bluetooth/iBeacon.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+/**
+ Apple iBeacon
+ 
+ iBeacon is an exciting technology enabling new location awareness possibilities for apps. Leveraging Bluetooth Low Energy (BLE), a device with iBeacon technology can be used to establish a region around an object. This allows an iOS device to determine when it has entered or left the region, along with an estimation of proximity to a beacon . There are both hardware and software components to consider when using iBeacon technology, and this document will give an introduction to both, along with suggested uses and best practices to help ensure a highly effective deployment leading to an outstanding user experience.
+ 
+ Devices with iBeacon technology can be powered using coin cell batteries for a month or longer, or operate for months at a time using larger batteries, or can be powered externally for extended periods of time. iOS devices can also be configured to generate iBeacon advertisements, although this functionality is limited in scope. This would be appropriate for uses such as a Point Of Sale or kiosk application, or for an application that wants to become an iBeacon for a short time while someone is actively using the application.
+ 
+ - SeeAlso: [Getting Started with iBeacon](https://developer.apple.com/ibeacon/Getting-Started-with-iBeacon.pdf).
+ */
+@frozen
+public struct AppleBeacon: Equatable, Hashable, Sendable {
+    
+    #if !os(WASI)
+    /// The company that created this specification.
+    public static var companyIdentifier: CompanyIdentifier { return .apple }
+    #endif
+    
+    /// The unique ID of the beacons being targeted.
+    ///
+    /// Application developers should define a UUID specific to their app and deployment use case.
+    public var uuid: UUID
+    
+    /// The value identifying a group of beacons.
+    ///
+    /// Further specifies a specific iBeacon and use case.
+    /// For example, this could define a sub-region within a larger region defined by the UUID.
+    public var major: UInt16
+    
+    /// The value identifying a specific beacon within a group.
+    ///
+    /// Allows further subdivision of region or use case, specified by the application developer.
+    public var minor: UInt16
+    
+    /// The received signal strength indicator (RSSI) value (measured in decibels) for the device.
+    public var rssi: Int8
+    
+    public init(uuid: UUID,
+                major: UInt16 = 0,
+                minor: UInt16 = 0,
+                rssi: Int8) {
+        
+        self.uuid = uuid
+        self.major = major
+        self.minor = minor
+        self.rssi = rssi
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGAP/Decoder.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGAP/Decoder.swift
@@ -1,0 +1,292 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+/// GAP Data Decoder
+public struct GAPDataDecoder <Data: DataContainer> {
+    
+    // MARK: - Properties
+        
+    #if !hasFeature(Embedded)
+    /// Ignore unknown types.
+    public var ignoreUnknownType: Bool = false
+    
+    public var types = [GAPData.Type]() {
+        didSet {
+            dataTypes = [GAPDataType: GAPData.Type](minimumCapacity: types.count)
+            types.forEach { dataTypes[$0.dataType] = $0 }
+        }
+    }
+    
+    internal private(set) var dataTypes: [GAPDataType: GAPData.Type] = [:]
+    #endif
+    
+    // MARK: - Initialization
+    
+    /// Initialize with default data types.
+    public init() {
+        
+        #if !hasFeature(Embedded)
+        /// initialize with default precomputed values
+        self.types = Self.defaultTypes
+        self.dataTypes = Self.defaultDataTypes
+        #endif
+    }
+    
+    // MARK: - Methods
+    
+    #if !hasFeature(Embedded)
+    public func decode(from data: Data) throws(GAPDataDecoderError) -> [GAPData] {
+        return try decode(data: data, reserveCapacity: 3)
+    }
+    
+    @usableFromInline
+    internal func decode(data: Data, reserveCapacity capacity: Int) throws(GAPDataDecoderError) -> [GAPData] {
+        
+        guard data.isEmpty == false
+            else { return [] }
+        
+        var elements = [GAPData]()
+        elements.reserveCapacity(capacity)
+        
+        var offset = 0
+        try Self.decode(data: data, offset: &offset) { (type, slice, offset) throws(GAPDataDecoderError) in
+            if let gapType = dataTypes[type] {
+                guard let decodable = gapType.init(data: slice)
+                    else { throw .cannotDecode(type, offset: offset) }
+                elements.append(decodable)
+                return true
+            } else if ignoreUnknownType {
+                return true
+            } else {
+                throw .unknownType(type, offset: offset)
+            }
+        }
+        
+        return elements
+    }
+    
+    @usableFromInline
+    internal static func decode(data: Data, reserveCapacity capacity: Int = 3) throws(GAPDataDecoderError) -> [(GAPDataType, Data)] {
+        
+        guard data.isEmpty == false
+            else { return [] }
+        
+        var elements = [(GAPDataType, Data)]()
+        elements.reserveCapacity(capacity)
+        
+        var offset = 0
+        try decode(data: data, offset: &offset) { (type, data, offset) in
+            elements.append((type, data))
+            return true
+        }
+        
+        return elements
+    }
+    #endif
+    
+    @usableFromInline
+    internal static func decode(data: Data, offset: inout Int, _ block: (GAPDataType, Data, Int) throws(GAPDataDecoderError) -> (Bool)) throws(GAPDataDecoderError) {
+        
+        while offset < data.count {
+            
+            // get length
+            let length = Int(data[offset]) // 0
+            offset += 1
+            guard offset < data.count else {
+                if length == 0 {
+                    break // EOF
+                } else {
+                    throw .insufficientBytes(expected: offset + 1, actual: data.count)
+                }
+            }
+            
+            // get type
+            let type = GAPDataType(rawValue: data[offset]) // 1
+            
+            // ignore zeroed bytes
+            guard (type.rawValue == 0 && length == 0) == false
+                else { break }
+            
+            // get value
+            let slice: Data
+            
+            if length > 0 {
+                let dataRange = offset + 1 ..< offset + length // 2 ..< 2 + length
+                offset = dataRange.upperBound
+                guard offset <= data.count
+                    else { throw .insufficientBytes(expected: offset + 1, actual: data.count) }
+                
+                slice = data.subdata(in: dataRange)
+            } else {
+                slice = Data()
+            }
+            
+            // process and continue
+            guard try block(type, slice, offset) else { return }
+        }
+    }
+}
+
+internal extension GAPDataDecoder {
+    
+    static func decodeFirst<T: GAPData>(_ type: T.Type, _ offset: inout Int, _ data: Data) throws(GAPDataDecoderError) -> T? {
+        
+        var offset = 0
+        var value: T?
+        try decode(data: data, offset: &offset) { (dataType, slice, offset) throws(GAPDataDecoderError) in
+            guard dataType == T.dataType else { return true }
+            value = T.init(data: slice)
+            guard value != nil else {
+                throw .cannotDecode(dataType, offset: offset)
+            }
+            return false
+        }
+        return value
+    }
+    
+    static func decodeFirst<T: GAPData>(_ type: T.Type, from data: Data) throws(GAPDataDecoderError) -> T? {
+        
+        var offset = 0
+        return try decodeFirst(type, &offset, data)
+    }
+}
+
+public extension GAPDataDecoder {
+    
+    static func decode<T: GAPData>(_ type: T.Type, from data: Data) throws(GAPDataDecoderError) -> T {
+        
+        var offset = 0
+        guard let value = try decodeFirst(type, &offset, data) else {
+            throw .notFound(T.dataType)
+        }
+        return value
+    }
+    
+    static func decode<T0: GAPData, T1: GAPData>(_ type0: T0.Type, _ type1: T1.Type, from data: Data) throws(GAPDataDecoderError) -> (T0, T1) {
+        
+        var offset = 0
+        guard let value0 = try decodeFirst(type0, &offset, data) else {
+            throw .notFound(T0.dataType)
+        }
+        guard let value1 = try decodeFirst(type1, &offset, data) else {
+            throw .notFound(T1.dataType)
+        }
+        return (value0, value1)
+    }
+    
+    static func decode<T0: GAPData, T1: GAPData, T2: GAPData>(_ type0: T0.Type, _ type1: T1.Type, _ type2: T2.Type, from data: Data) throws(GAPDataDecoderError) -> (T0, T1, T2) {
+        
+        var offset = 0
+        guard let value0 = try decodeFirst(type0, &offset, data) else {
+            throw .notFound(T0.dataType)
+        }
+        guard let value1 = try decodeFirst(type1, &offset, data) else {
+            throw .notFound(T1.dataType)
+        }
+        guard let value2 = try decodeFirst(type2, &offset, data) else {
+            throw .notFound(T2.dataType)
+        }
+        return (value0, value1, value2)
+    }
+    
+    static func decode<T0: GAPData, T1: GAPData, T2: GAPData, T3: GAPData>(_ type0: T0.Type, _ type1: T1.Type, _ type2: T2.Type, _ type3: T3.Type, from data: Data) throws(GAPDataDecoderError) -> (T0, T1, T2, T3) {
+        
+        var offset = 0
+        guard let value0 = try decodeFirst(type0, &offset, data) else {
+            throw .notFound(T0.dataType)
+        }
+        guard let value1 = try decodeFirst(type1, &offset, data) else {
+            throw .notFound(T1.dataType)
+        }
+        guard let value2 = try decodeFirst(type2, &offset, data) else {
+            throw .notFound(T2.dataType)
+        }
+        guard let value3 = try decodeFirst(type3, &offset, data) else {
+            throw .notFound(T3.dataType)
+        }
+        return (value0, value1, value2, value3)
+    }
+}
+
+// MARK: - Supporting Types
+
+/// GAP Data Decoder Error
+public enum GAPDataDecoderError: Swift.Error, Sendable {
+    
+    case insufficientBytes(expected: Int, actual: Int)
+    case cannotDecode(GAPDataType, offset: Int)
+    case unknownType(GAPDataType, offset: Int)
+    case notFound(GAPDataType)
+}
+
+// MARK: - Constants
+
+#if !hasFeature(Embedded)
+internal extension GAPDataDecoder {
+    
+    static var defaultDataTypes: [GAPDataType: GAPData.Type] {
+        let defaultTypes = self.defaultTypes
+        var types = [GAPDataType: GAPData.Type](minimumCapacity: defaultTypes.count)
+        defaultTypes.forEach { types[$0.dataType] = $0 }
+        return types
+    }
+    
+    static var defaultTypes: [GAPData.Type] {
+        [
+            GAP3DInformation.self,
+            GAPAdvertisingInterval.self,
+            GAPAppearanceData.self,
+            GAPChannelMapUpdateIndication.self,
+            GAPClassOfDevice.self,
+            GAPCompleteListOf16BitServiceClassUUIDs.self,
+            GAPCompleteListOf32BitServiceClassUUIDs.self,
+            GAPCompleteListOf128BitServiceClassUUIDs.self,
+            GAPCompleteLocalName.self,
+            GAPFlags.self,
+            GAPIncompleteListOf16BitServiceClassUUIDs.self,
+            GAPIncompleteListOf32BitServiceClassUUIDs.self,
+            GAPIncompleteListOf128BitServiceClassUUIDs.self,
+            GAPIndoorPositioning.self,
+            GAPLEDeviceAddress.self,
+            GAPLERole.self,
+            GAPLESecureConnectionsConfirmation.self,
+            GAPLESecureConnectionsRandom.self,
+            //GAPLESupportedFeatures.self,
+            GAPListOf16BitServiceSolicitationUUIDs.self,
+            GAPListOf32BitServiceSolicitationUUIDs.self,
+            GAPListOf128BitServiceSolicitationUUIDs.self,
+            GAPManufacturerSpecificData<Data>.self,
+            GAPMeshBeacon.self,
+            GAPMeshMessage.self,
+            GAPPBADV<Data>.self,
+            GAPPublicTargetAddress.self,
+            GAPRandomTargetAddress.self,
+            GAPSecurityManagerOOBFlags.self,
+            GAPSecurityManagerTKValue.self,
+            GAPServiceData16BitUUID<Data>.self,
+            GAPServiceData32BitUUID<Data>.self,
+            GAPServiceData128BitUUID<Data>.self,
+            GAPShortLocalName.self,
+            GAPSimplePairingHashC.self,
+            GAPSimplePairingRandomizerR.self,
+            GAPSlaveConnectionIntervalRange.self,
+            GAPTransportDiscoveryData<Data>.self,
+            GAPTxPowerLevel.self,
+            GAPURI.self
+        ]
+    }
+}
+#endif
+

--- a/pico-w-ble-peripheral-sdk/BluetoothGAP/Encoder.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGAP/Encoder.swift
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+/// GAP Data Encoder
+public struct GAPDataEncoder <Data: DataContainer> {
+    
+    // MARK: - Methods
+    
+    #if !hasFeature(Embedded)
+    public static func encode(_ encodables: [GAPData]) -> Data {
+        let dataLengths = encodables.map { $0.dataLength }
+        let length = dataLengths.reduce(0, { $0 + $1 + 2 })
+        var data = Data()
+        data.reserveCapacity(length)
+        for (index, encodable) in encodables.enumerated() {
+            let length = dataLengths[index]
+            Self.encode(encodable, length: length, to: &data)
+        }
+        assert(data.count == length, "Invalid data length")
+        return data
+    }
+    #endif
+    
+    internal static func encode<T>(
+        _ value: T,
+        length: Int? = nil,
+        to data: inout Data
+    ) where T: GAPData {
+        let length = length ?? value.dataLength // try to use precalculated length
+        data += UInt8(length + 1)
+        data += T.dataType.rawValue
+        value.append(to: &data)
+    }
+}
+
+// Generic specializations
+
+public extension GAPDataEncoder {
+    
+    static func encode<T: GAPData>(_ value: T) -> Data {
+        var data = Data()
+        data.reserveCapacity(value.dataLength + 2)
+        Self.encode(value, to: &data)
+        return data
+    }
+    
+    static func encode<T0: GAPData, T1: GAPData>(_ value0: T0, _ value1: T1) -> Data {
+        var data = Data()
+        let length = value0.dataLength
+            + value1.dataLength
+            + (2 * 2)
+        data.reserveCapacity(length)
+        Self.encode(value0, to: &data)
+        Self.encode(value1, to: &data)
+        return data
+    }
+    
+    static func encode<T0: GAPData, T1: GAPData, T2: GAPData>(_ value0: T0, _ value1: T1, _ value2: T2) -> Data {
+        var data = Data()
+        let length = value0.dataLength
+            + value1.dataLength
+            + value2.dataLength
+            + (2 * 3)
+        data.reserveCapacity(length)
+        Self.encode(value0, to: &data)
+        Self.encode(value1, to: &data)
+        Self.encode(value2, to: &data)
+        return data
+    }
+    
+    static func encode<T0: GAPData, T1: GAPData, T2: GAPData, T3: GAPData>(_ value0: T0, _ value1: T1, _ value2: T2, _ value3: T3) -> Data {
+        var data = Data()
+        let length = value0.dataLength
+            + value1.dataLength
+            + value2.dataLength
+            + value3.dataLength
+            + (2 * 4)
+        data.reserveCapacity(length)
+        Self.encode(value0, to: &data)
+        Self.encode(value1, to: &data)
+        Self.encode(value2, to: &data)
+        Self.encode(value3, to: &data)
+        return data
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGAP/GAPCompleteLocalName.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGAP/GAPCompleteLocalName.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ GAP Complete Local Name
+ 
+ The Local Name data type shall be the same as, or a shortened version of, the local name assigned to the device. The Local Name data type value indicates if the name is complete or shortened. If the name is shortened, the complete name can be read using the remote name request procedure over BR/EDR or by reading the device name characteristic after the connection has been established using GATT.
+ */
+@frozen
+public struct GAPCompleteLocalName: GAPData, Equatable, Hashable {
+    
+    public static var dataType: GAPDataType { .completeLocalName }
+    
+    public var name: String
+    
+    public init(name: String) {
+        self.name = name
+    }
+}
+
+public extension GAPCompleteLocalName {
+    
+    init?<Data: DataContainer>(data: Data) {
+        
+        guard let rawValue = String(utf8: data)
+            else { return nil }
+        
+        self.init(name: rawValue)
+    }
+    
+    func append<Data: DataContainer>(to data: inout Data) {
+        data += name.utf8
+    }
+    
+    var dataLength: Int {
+        return name.utf8.count
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension GAPCompleteLocalName: CustomStringConvertible {
+    
+    public var description: String {
+        return name
+    }
+}
+
+// MARK: - ExpressibleByStringLiteral
+
+extension GAPCompleteLocalName: ExpressibleByStringLiteral {
+    
+    public init(stringLiteral value: String) {
+        self.init(name: value)
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGAP/GAPData.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGAP/GAPData.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: - Generic Access Profile Data
+
+/**
+Generic Access Profile
+
+- SeeAlso:
+[Generic Access Profile](https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile)
+*/
+public protocol GAPData: DataConvertible {
+    
+    /// Generic Access Profile data type.
+    static var dataType: GAPDataType { get }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGAP/GAPDataType.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGAP/GAPDataType.swift
@@ -1,0 +1,243 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Generic Access Profile Data Type
+///
+/// ​​Assigned numbers are used in GAP for inquiry response, EIR data type values, manufacturer-specific data,
+/// advertising data, low energy UUIDs and appearance characteristics, and class of device.
+///
+/// - SeeAlso:
+/// [Generic Access Profile](https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile)
+@frozen
+public struct GAPDataType: RawRepresentable, Equatable, Hashable, Sendable {
+    
+    public var rawValue: UInt8
+    
+    public init(rawValue: UInt8) {
+        
+        self.rawValue = rawValue
+    }
+}
+
+// MARK: - Defined Types
+
+public extension GAPDataType {
+    
+    /// Flags
+    ///
+    /// **Reference**:
+    ///
+    /// Bluetooth Core Specification Vol. 3, Part C, section 8.1.3 (v2.1 + EDR, 3.0 + HS and 4.0)
+    ///
+    /// Bluetooth Core Specification Vol. 3, Part C, sections 11.1.3 and 18.1 (v4.0)
+    ///
+    /// Core Specification Supplement, Part A, section 1.3
+    static let flags: GAPDataType = 0x01
+    
+    /// Incomplete List of 16-bit Service Class UUIDs
+    static let incompleteListOf16BitServiceClassUUIDs: GAPDataType = 0x02
+    
+    /// Complete List of 16-bit Service Class UUIDs
+    static let completeListOf16CitServiceClassUUIDs: GAPDataType = 0x03
+    
+    /// Incomplete List of 32-bit Service Class UUIDs
+    static let incompleteListOf32BitServiceClassUUIDs: GAPDataType = 0x04
+    
+    /// Complete List of 32-bit Service Class UUIDs
+    static let completeListOf32BitServiceClassUUIDs: GAPDataType = 0x05
+    
+    /// Incomplete List of 128-bit Service Class UUIDs
+    static let incompleteListOf128BitServiceClassUUIDs: GAPDataType = 0x06
+    
+    /// Complete List of 128-bit Service Class UUIDs
+    static let completeListOf128BitServiceClassUUIDs: GAPDataType = 0x07
+    
+    /// Shortened Local Name
+    static let shortLocalName: GAPDataType = 0x08
+    
+    /// Complete Local Name
+    static let completeLocalName: GAPDataType = 0x09
+    
+    /// TX Power Level
+    static let txPowerLevel: GAPDataType = 0x0A
+    
+    /// Class of Device
+    static let classOfDevice: GAPDataType = 0x0D
+    
+    /// Simple Pairing Hash C
+    static let simplePairingHashC: GAPDataType = 0x0E
+    
+    /// Simple Pairing Randomizer
+    static let simplePairingRandomizerR: GAPDataType = 0x0F
+    
+    /// Security Manager TK Value
+    static let securityManagerTKValue: GAPDataType = 0x10
+    
+    /// Security Manager Out of Band Flags
+    static let securityManagerOutOfBandFlags: GAPDataType = 0x11
+    
+    /// Slave Connection Interval Range
+    static let slaveConnectionIntervalRange: GAPDataType = 0x12
+    
+    /// List of 16-bit Service Solicitation UUIDs
+    static let listOf16BitServiceSolicitationUUIDs: GAPDataType = 0x14
+    
+    /// List of 128-bit Service Solicitation UUIDs
+    static let listOf128BitServiceSolicitationUUIDs: GAPDataType = 0x15
+    
+    /// Service Data - 16-bit UUID
+    static let serviceData16BitUUID: GAPDataType = 0x16
+    
+    /// Public Target Address
+    static let publicTargetAddress: GAPDataType = 0x17
+    
+    /// Random Target Address
+    static let randomTargetAddress: GAPDataType = 0x18
+    
+    /// Appearance
+    static let appearance: GAPDataType = 0x19
+    
+    /// Advertising Interval
+    static let advertisingInterval: GAPDataType = 0x1A
+    
+    /// LE Bluetooth Device Address
+    static let lowEnergyDeviceAddress: GAPDataType = 0x1B
+    
+    /// LE Role
+    static let lowEnergyRole: GAPDataType = 0x1C
+    
+    /// Simple Pairing Hash C-256
+    static let simplePairingHashC256: GAPDataType = 0x1D
+    
+    /// Simple Pairing Randomizer R-256
+    static let simplePairingRandomizerR256: GAPDataType = 0x1E
+    
+    /// List of 32-bit Service Solicitation UUIDs
+    static let listOf32BitServiceSolicitationUUIDs: GAPDataType = 0x1F
+    
+    /// Service Data - 32-bit UUID
+    static let serviceData32BitUUID: GAPDataType = 0x20
+    
+    /// Service Data - 128-bit UUID
+    static let serviceData128BitUUID: GAPDataType = 0x21
+    
+    /// LE Secure Connections Confirmation Value
+    static let lowEnergySecureConnectionsConfirmation: GAPDataType = 0x22
+    
+    /// LE Secure Connections Random Value
+    static let lowEnergySecureConnectionsRandom: GAPDataType = 0x23
+    
+    /// URI
+    static let uri: GAPDataType = 0x24
+    
+    /// Indoor Positioning
+    static let indoorPositioning: GAPDataType = 0x25
+    
+    /// Transport Discovery Data
+    static let transportDiscoveryData: GAPDataType = 0x26
+    
+    /// LE Supported Features
+    static let lowEnergySupportedFeatures: GAPDataType = 0x27
+    
+    /// Channel Map Update Indication
+    static let channelMapUpdateIndication: GAPDataType = 0x28
+    
+    /// PB-ADV
+    static let pbAdv: GAPDataType = 0x29
+    
+    /// Mesh Message
+    static let meshMessage: GAPDataType = 0x2A
+    
+    /// Mesh Beacon
+    static let meshBeacon: GAPDataType = 0x2B
+    
+    /// 3D Information Data
+    static let informationData3D: GAPDataType = 0x3D
+    
+    /// Manufacturer Specific Data
+    static let manufacturerSpecificData: GAPDataType = 0xFF
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension GAPDataType: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral value: UInt8) {
+        self.rawValue = value
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+#if hasFeature(Embedded)
+extension GAPDataType: CustomStringConvertible {
+    
+    public var description: String {
+        rawValue.description
+    }
+}
+#else
+extension GAPDataType: CustomStringConvertible {
+    
+    @inline(never)
+    public var description: String {
+        return name ?? "GAP Data Type (\(rawValue))"
+    }
+    
+    @inline(never)
+    public var name: String? {
+        let names: [GAPDataType: String] = [
+            .flags: "Flags",
+            .incompleteListOf16BitServiceClassUUIDs: "Incomplete List of 16-bit Service Class UUIDs",
+            .completeListOf16CitServiceClassUUIDs: "Complete List of 16-bit Service Class UUIDs",
+            .incompleteListOf32BitServiceClassUUIDs: "Incomplete List of 32-bit Service Class UUIDs",
+            .completeListOf32BitServiceClassUUIDs: "Complete List of 32-bit Service Class UUIDs",
+            .incompleteListOf128BitServiceClassUUIDs: "Incomplete List of 128-bit Service Class UUIDs",
+            .completeListOf128BitServiceClassUUIDs: "Complete List of 128-bit Service Class UUIDs",
+            .shortLocalName: "Shortened Local Name",
+            .completeLocalName: "Complete Local Name",
+            .txPowerLevel: "Tx Power Level",
+            .classOfDevice: "Class of Device",
+            .simplePairingHashC: "Simple Pairing Hash C",
+            .simplePairingRandomizerR: "Simple Pairing Randomizer R",
+            .securityManagerTKValue: "Security Manager TK Value",
+            .securityManagerOutOfBandFlags: "Security Manager Out of Band Flags",
+            .slaveConnectionIntervalRange: "Slave Connection Interval Range",
+            .listOf16BitServiceSolicitationUUIDs: "List of 16-bit Service Solicitation UUIDs",
+            .listOf32BitServiceSolicitationUUIDs: "List of 32-bit Service Solicitation UUIDs",
+            .listOf128BitServiceSolicitationUUIDs: "List of 128-bit Service Solicitation UUIDs",
+            .serviceData16BitUUID: "Service Data - 16-bit UUID",
+            .serviceData32BitUUID: "Service Data - 32-bit UUID",
+            .serviceData128BitUUID: "Service Data - 128-bit UUID",
+            .publicTargetAddress: "Public Target Address",
+            .randomTargetAddress: "Random Target Address",
+            .appearance: "Appearance",
+            .advertisingInterval: "Advertising Interval",
+            .lowEnergyDeviceAddress: "LE Bluetooth Device Address",
+            .lowEnergyRole: "LE Role",
+            .lowEnergySecureConnectionsConfirmation: "LE Secure Connections Confirmation Value",
+            .lowEnergySecureConnectionsRandom: "LE Secure Connections Random Value",
+            .uri: "URI",
+            .indoorPositioning: "Indoor Positioning",
+            .transportDiscoveryData: "Transport Discovery Data",
+            .lowEnergySupportedFeatures: "LE Supported Features",
+            .channelMapUpdateIndication: "Channel Map Update Indication",
+            .pbAdv: "PB-ADV",
+            .meshMessage: "Mesh Message",
+            .meshBeacon: "Mesh Beacon",
+            .informationData3D: "3D Information Data",
+            .manufacturerSpecificData: "Manufacturer Specific Data"
+        ]
+        return names[self]
+    }
+}
+
+#endif

--- a/pico-w-ble-peripheral-sdk/BluetoothGAP/GAPFlags.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGAP/GAPFlags.swift
@@ -1,0 +1,137 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ GAP Flag
+ 
+ The Flags data type contains one bit Boolean flags. The Flags data type shall be included when any of the Flag bits are non-zero and the advertising packet is connectable, otherwise the Flags data type may be omitted. All 0x00 octets after the last non-zero octet shall be omitted from the value transmitted.
+ 
+ - Note: If the Flags AD type is not present in a non-connectable advertisement, the Flags should be considered as unknown and no assumptions should be made by the scanner.
+ 
+ Flags used over the LE physical channel are:
+ 
+ • Limited Discoverable Mode
+ 
+ • General Discoverable Mode
+ 
+ • BR/EDR Not Supported
+ 
+ • Simultaneous LE and BR/EDR to Same Device Capable (Controller)
+ 
+ • Simultaneous LE and BR/EDR to Same Device Capable (Host)
+ 
+ The LE Limited Discoverable Mode and LE General Discoverable Mode flags shall be ignored when received over the BR/EDR physical channel. The ‘BR/ EDR Not Supported’ flag shall be set to 0 when sent over the BR/EDR physical channel.
+ 
+ The Flags field may be zero or more octets long. This allows the Flags field to be extended while using the minimum number of octets within the data packet.
+ */
+@frozen
+public struct GAPFlags: GAPData, Equatable, Hashable, OptionSet, Sendable {
+    
+    public static var dataType: GAPDataType { .flags }
+    
+    public var rawValue: UInt8
+    
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+}
+
+// MARK: - DataConvertible
+
+extension GAPFlags: DataConvertible {
+    
+    public init?<Data>(data: Data) where Data : DataContainer {
+        guard data.count == 1
+            else { return nil }
+        self.init(rawValue: data[0])
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += self.rawValue
+    }
+    
+    public var dataLength: Int {
+        1
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension GAPFlags: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral rawValue: RawValue) {
+        self.init(rawValue: rawValue)
+    }
+}
+
+// MARK: - ExpressibleByArrayLiteral
+
+extension GAPFlags: ExpressibleByArrayLiteral { }
+
+// MARK: - Constants
+
+public extension GAPFlags {
+    
+    /**
+    LE Limited Discoverable Mode
+ 
+     - Note: Limited Discoverable Mode is used to suggest that the device should have a high priority to scanning devices and often the advertising interval used when in this mode is faster than when in the General Discoverable Mode. A device will be in Limited Discoverable Mode for a limited time only and the core specification recommends this be no more than one minute. A device whose Flags field indicates it is not discoverable just means scanning devices should ignore it.
+     
+     - SeeAlso: [Bluetooth Advertising Works](https://blog.bluetooth.com/advertising-works-part-2)
+    */
+    static var lowEnergyLimitedDiscoverableMode: GAPFlags   { 0b00000001 }
+    
+    /// LE General Discoverable Mode
+    ///
+    /// Use general discoverable mode to advertise indefinitely.
+    static var lowEnergyGeneralDiscoverableMode: GAPFlags   { 0b00000010 }
+    
+    /// BR/EDR Not Supported.
+    ///
+    /// Bit 37 of LMP Feature Mask Definitions  (Page 0)
+    static var notSupportedBREDR: GAPFlags                  { 0b00000100 }
+    
+    /// Simultaneous LE and BR/EDR to Same Device Capable (Controller).
+    ///
+    /// Bit 49 of LMP Feature Mask Definitions (Page 0)
+    static var simultaneousController: GAPFlags             { 0b00001000 }
+    
+    /// Simultaneous LE and BR/EDR to Same Device Capable (Host).
+    ///
+    /// Bit 66 of LMP Feature Mask Definitions (Page 1)
+    static var simultaneousHost: GAPFlags                   { 0b00010000 }
+}
+
+// MARK: - CustomStringConvertible
+
+extension GAPFlags: CustomStringConvertible, CustomDebugStringConvertible {
+    
+    #if hasFeature(Embedded)
+    public var description: String {
+        "0x" + rawValue.toHexadecimal()
+    }
+    #else
+    @inline(never)
+    public var description: String {
+        let descriptions: [(GAPFlags, StaticString)] = [
+            (.lowEnergyLimitedDiscoverableMode, ".lowEnergyLimitedDiscoverableMode"),
+            (.lowEnergyGeneralDiscoverableMode, ".lowEnergyGeneralDiscoverableMode"),
+            (.notSupportedBREDR, ".notSupportedBREDR"),
+            (.simultaneousController, ".simultaneousController"),
+            (.simultaneousHost, ".simultaneousHost")
+        ]
+        return buildDescription(descriptions)
+    }
+    #endif
+
+    /// A textual representation of the file permissions, suitable for debugging.
+    public var debugDescription: String { self.description }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGAP/GAPManufacturerSpecificData.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGAP/GAPManufacturerSpecificData.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ The Manufacturer Specific data type is used for manufacturer specific data.
+ The first two data octets shall contain a company identifier code from the Assigned Numbers - Company Identifiers document.
+ The interpretation of any other octets within the data shall be defined by the manufacturer specified by the company identifier.
+ 
+ Size: 2 or more octets
+ The first 2 octets contain the Company Identifier Code followed by additional manufacturer specific data
+ */
+@frozen
+public struct GAPManufacturerSpecificData <AdditionalData: DataContainer> : GAPData, Equatable, Hashable {
+    
+    /// GAP Data Type
+    public static var dataType: GAPDataType { return .manufacturerSpecificData }
+    
+    /// Company Identifier
+    public var companyIdentifier: CompanyIdentifier
+    
+    /// Additional Data.
+    public var additionalData: AdditionalData
+    
+    /// Initialize with company identifier and additional data.
+    public init(companyIdentifier: CompanyIdentifier,
+                additionalData: AdditionalData = AdditionalData()) {
+        
+        self.companyIdentifier = companyIdentifier
+        self.additionalData = additionalData
+    }
+    
+    public init?<Data>(data: Data) where Data : DataContainer {
+        
+        guard data.count >= 2
+            else { return nil }
+        
+        self.companyIdentifier = CompanyIdentifier(rawValue: UInt16(littleEndian: UInt16(bytes: (data[0], data[1]))))
+        if data.count > 2 {
+            self.additionalData = AdditionalData(data[2 ..< data.count])
+        } else {
+            self.additionalData = AdditionalData()
+        }
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += self.companyIdentifier.rawValue.littleEndian
+        data += self.additionalData
+    }
+    
+    public var dataLength: Int {
+        return 2 + additionalData.count
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension GAPManufacturerSpecificData: CustomStringConvertible {
+    
+    public var description: String {
+        return "(\(companyIdentifier)) \(additionalData.toHexadecimal())"
+    }
+}
+
+// MARK: - DataConvertible
+
+extension GAPManufacturerSpecificData: DataConvertible {
+    
+    static func += <T: DataContainer> (data: inout T, value: GAPManufacturerSpecificData) {
+        value.append(to: &data)
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGAP/GAPShortLocalName.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGAP/GAPShortLocalName.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ GAP Shortened Local Name
+ 
+ The Local Name data type shall be the same as, or a shortened version of, the local name assigned to the device. The Local Name data type value indicates if the name is complete or shortened. If the name is shortened, the complete name can be read using the remote name request procedure over BR/EDR or by reading the device name characteristic after the connection has been established using GATT.
+ 
+ A shortened name shall only contain contiguous characters from the beginning of the full name. For example, if the device name is ‘BT_Device_Name’ then the shortened name could be ‘BT_Device’ or ‘BT_Dev’.
+ */
+@frozen
+public struct GAPShortLocalName: GAPData, Equatable, Hashable, Sendable {
+    
+    public static var dataType: GAPDataType { .shortLocalName }
+    
+    public var name: String
+    
+    public init(name: String) {
+        self.name = name
+    }
+}
+
+public extension GAPShortLocalName {
+    
+    init?<Data: DataContainer>(data: Data) {
+        
+        guard let rawValue = String(utf8: data)
+            else { return nil }
+        
+        self.init(name: rawValue)
+    }
+    
+    func append<Data: DataContainer>(to data: inout Data) {
+        data += name.utf8
+    }
+    
+    var dataLength: Int {
+        return name.utf8.count
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension GAPShortLocalName: CustomStringConvertible {
+    
+    public var description: String {
+        return name
+    }
+}
+
+// MARK: - ExpressibleByStringLiteral
+
+extension GAPShortLocalName: ExpressibleByStringLiteral {
+    
+    public init(stringLiteral value: String) {
+        self.init(name: value)
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGAP/iBeaconManufacturerData.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGAP/iBeaconManufacturerData.swift
@@ -1,0 +1,130 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+public extension AppleBeacon {
+    
+    init?<Data: DataContainer>(manufacturerData: GAPManufacturerSpecificData<Data>) {
+        
+        let data = manufacturerData.additionalData
+        
+        guard manufacturerData.companyIdentifier == Self.companyIdentifier,
+            data.count == Self.additionalDataLength
+            else { return nil }
+        
+        let dataType = data[0]
+        
+        guard dataType == Self.appleDataType
+            else { return nil }
+        
+        let length = data[1]
+        
+        guard length == Self.length
+            else { return nil }
+        
+        let uuid = UUID(UInt128(bigEndian: UInt128(data: data.subdata(in: 2 ..< 18))!))
+        let major = UInt16(bigEndian: UInt16(bytes: (data[18], data[19])))
+        let minor = UInt16(bigEndian: UInt16(bytes: (data[20], data[21])))
+        let rssi = Int8(bitPattern: data[22])
+        
+        self.init(uuid: uuid, major: major, minor: minor, rssi: rssi)
+    }
+}
+
+public extension GAPManufacturerSpecificData {
+    
+    init(beacon: AppleBeacon) {
+        var additionalData = AdditionalData()
+        additionalData.reserveCapacity(AppleBeacon.additionalDataLength)
+        beacon.appendAdditionalManufacturerData(to: &additionalData)
+        assert(additionalData.count == AppleBeacon.additionalDataLength)
+        self.init(
+            companyIdentifier: AppleBeacon.companyIdentifier,
+            additionalData: additionalData
+        )
+    }
+}
+
+internal extension AppleBeacon {
+        
+    /// Apple iBeacon data type.
+    static var appleDataType: UInt8 { 0x02 } // iBeacon
+    
+    /// The length of the TLV encoded data.
+    static var length: UInt8 { 0x15 } // length: 21 = 16 byte UUID + 2 bytes major + 2 bytes minor + 1 byte RSSI
+    
+    static var additionalDataLength: Int { return Int(length) + 2 }
+    
+    static func from(advertisingData: LowEnergyAdvertisingData) throws(GAPDataDecoderError) -> (beacon: AppleBeacon, flags: GAPFlags) {
+        let (flags, manufacturerData) = try GAPDataDecoder.decode(GAPFlags.self, AppleBeacon.ManufacturerData.self, from: advertisingData)
+        return (manufacturerData.beacon, flags)
+    }
+    
+    func appendAdditionalManufacturerData <T: DataContainer> (to data: inout T) {
+        
+        data += Self.appleDataType // tlvPrefix
+        data += Self.length
+        data += BluetoothUUID(uuid: uuid).bigEndian // uuidBytes
+        data += major.bigEndian
+        data += minor.bigEndian
+        data += UInt8(bitPattern: rssi)
+    }
+}
+
+public extension LowEnergyAdvertisingData {
+    
+    init(beacon: AppleBeacon,
+         flags: GAPFlags = [.lowEnergyGeneralDiscoverableMode, .notSupportedBREDR]) {
+        let manufacturerData = AppleBeacon.ManufacturerData(beacon) // storage on stack
+        self = GAPDataEncoder.encode(flags, manufacturerData)
+    }
+}
+
+internal extension AppleBeacon {
+    
+    struct ManufacturerData: GAPData {
+        
+        static var dataType: GAPDataType { .manufacturerSpecificData }
+        
+        internal let beacon: AppleBeacon
+        
+        init(_ beacon: AppleBeacon) {
+            self.beacon = beacon
+        }
+        
+        init?<Data>(data: Data) where Data : DataContainer {
+
+            guard let manufacturerData = GAPManufacturerSpecificData<Data>(data: data),
+                let beacon = AppleBeacon(manufacturerData: manufacturerData)
+                else { return nil }
+            
+            self.init(beacon)
+        }
+        
+        var dataLength: Int { return 2 + AppleBeacon.additionalDataLength }
+        
+        func append<Data>(to data: inout Data) where Data : DataContainer {
+            data += self
+        }
+    }
+}
+
+extension AppleBeacon.ManufacturerData: DataConvertible {
+    
+    @usableFromInline
+    static func += <Data>(data: inout Data, value: AppleBeacon.ManufacturerData) where Data : DataContainer {
+        data += GAPManufacturerSpecificData<Data>(companyIdentifier: AppleBeacon.companyIdentifier)
+        value.beacon.appendAdditionalManufacturerData(to: &data)
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTAttributePermissions.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTAttributePermissions.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// ATT attribute permission bitfield values. Permissions are grouped as
+/// "Access", "Encryption", "Authentication", and "Authorization". A bitmask of
+/// permissions is a byte that encodes a combination of these.
+@frozen
+public struct ATTAttributePermissions: OptionSet, Equatable, Hashable, Sendable {
+    
+    public var rawValue: UInt8
+    
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension ATTAttributePermissions: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral value: UInt8) {
+        self.rawValue = value
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension ATTAttributePermissions: CustomStringConvertible, CustomDebugStringConvertible {
+    
+    #if hasFeature(Embedded)
+    public var description: String {
+        "0x" + rawValue.toHexadecimal()
+    }
+    #else
+    @inline(never)
+    public var description: String {
+        let descriptions: [(ATTAttributePermissions, StaticString)] = [
+            (.read, ".read"),
+            (.write, ".write"),
+            (.readEncrypt, ".readEncrypt"),
+            (.writeEncrypt, ".writeEncrypt"),
+            (.readAuthentication, ".readAuthentication"),
+            (.writeAuthentication, ".writeAuthentication"),
+            (.authorized, ".authorized"),
+            (.noAuthorization, ".noAuthorization"),
+        ]
+        return buildDescription(descriptions)
+    }
+    #endif
+
+    /// A textual representation of the file permissions, suitable for debugging.
+    public var debugDescription: String { self.description }
+}
+
+// MARK: - Options
+
+public extension ATTAttributePermissions {
+    
+    // Access
+    static var read: ATTAttributePermissions                     { 0x01 }
+    static var write: ATTAttributePermissions                    { 0x02 }
+    
+    // Encryption
+    static var encrypt: ATTAttributePermissions                  { [.readEncrypt, .writeEncrypt] }
+    static var readEncrypt: ATTAttributePermissions              { 0x04 }
+    static var writeEncrypt: ATTAttributePermissions             { 0x08 }
+    
+    // The following have no effect on Darwin
+    
+    // Authentication
+    static var authentication: ATTAttributePermissions           { [.readAuthentication, .writeAuthentication] }
+    static var readAuthentication: ATTAttributePermissions       { 0x10 }
+    static var writeAuthentication: ATTAttributePermissions      { 0x20 }
+    
+    // Authorization
+    static var authorized: ATTAttributePermissions               { 0x40 }
+    static var noAuthorization: ATTAttributePermissions          { 0x80 }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTConnection.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTConnection.swift
@@ -1,0 +1,608 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Manages a Bluetooth connection using the ATT protocol.
+internal final class ATTConnection <Socket: L2CAPConnection> {
+    
+    public typealias Data = Socket.Data
+    
+    public typealias Error = ATTConnectionError<Socket.Error, Socket.Data>
+        
+    // MARK: - Properties
+    
+    /// Actual number of bytes for PDU ATT exchange.
+    public var maximumTransmissionUnit: ATTMaximumTransmissionUnit = .default
+    
+    internal var socket: Socket
+    
+    internal let log: ((String) -> ())?
+        
+    // MARK: - Private Properties
+    
+    /// There's a pending incoming request.
+    private var incomingRequest = false
+    
+    /// IDs for "send" ops.
+    private var nextSendOpcodeID: UInt = 0
+    
+    /// Pending request state.
+    private var pendingRequest: SendOperation?
+    
+    /// Pending indication state.
+    private var pendingIndication: SendOperation?
+    
+    /// Queued ATT protocol requests
+    private var requestQueue = [SendOperation]()
+    
+    /// Queued ATT protocol indications
+    private var indicationQueue = [SendOperation]()
+    
+    /// Queue of PDUs ready to send
+    private var writeQueue = [SendOperation]()
+    
+    /// List of registered callbacks.
+    private var notifyList = [ATTOpcode: Notification]()
+    
+    // MARK: - Initialization
+    
+    public init(
+        socket: Socket,
+        log: ((String) -> ())? = nil
+    ) {
+        self.socket = socket
+        self.log = log
+    }
+    
+    deinit {
+        socket.close()
+    }
+    
+    // MARK: - Methods
+    
+    public func run() throws(Error) {
+        // throw underlying error
+        if let error = socket.status.error {
+            throw .socket(error)
+        }
+        // read pending packets
+        while socket.status.recieve {
+            try read()
+        }
+        var didWrite = true
+        // write pending packets
+        while socket.status.send, didWrite {
+            didWrite = try write()
+        }
+    }
+    
+    /// Performs the actual IO for recieving data.
+    internal func read() throws(Error) {
+        
+        //log?("Attempt read")
+        
+        let bytesToRead = Int(self.maximumTransmissionUnit.rawValue)
+        let receivedData: Data
+        do {
+            receivedData = try socket.receive(bytesToRead) // will fail if not ready
+        }
+        catch {
+            throw .socket(error)
+        }
+        
+        //log?("Received data (\(receivedData.count) bytes)")
+        
+        // valid PDU data length
+        guard receivedData.count >= 1 // at least 1 byte for ATT opcode
+            else { throw .garbageResponse(receivedData) }
+        
+        let opcodeByte = receivedData[0]
+        
+        // valid opcode
+        guard let opcode = ATTOpcode(rawValue: opcodeByte)
+            else { throw .garbageResponse(receivedData) }
+        
+        //log?("Received opcode \(opcode)")
+        
+        // Act on the received PDU based on the opcode type
+        switch opcode.type {
+        case .response:
+            try handle(response: receivedData, opcode: opcode)
+        case .confirmation:
+            try handle(confirmation: receivedData, opcode: opcode)
+        case .request:
+            try handle(request: receivedData, opcode: opcode)
+        case .command,
+             .notification,
+             .indication:
+            // For all other opcodes notify the upper layer of the PDU and let them act on it.
+            try handle(notify: receivedData, opcode: opcode)
+        }
+    }
+    
+    /// Performs the actual IO for sending data.
+    @discardableResult
+    internal func write() throws(Error) -> Bool {
+        
+        //log?("Attempt write")
+        
+        guard let sendOperation = pickNextSendOpcode()
+            else { return false }
+        
+        //log?("Sending data... (\(sendOperation.data.count) bytes)")
+        
+        do {
+            try socket.send(sendOperation.data)
+        }
+        catch {
+            throw .socket(error)
+        }
+        let opcode = sendOperation.opcode
+        
+        //log?("Did write \(opcode)")
+        
+        /* Based on the operation type, set either the pending request or the
+        * pending indication. If it came from the write queue, then there is
+        * no need to keep it around.
+        */
+        switch opcode.type {
+        case .request:
+            pendingRequest = sendOperation
+        case .indication:
+            pendingRequest = sendOperation
+        case .response:
+            // Set `incomingRequest` to false to indicate that no request is pending
+            incomingRequest = false
+        case .command,
+             .notification,
+             .confirmation:
+            break
+        }
+        
+        return true
+    }
+    
+    // write all pending PDUs
+    private func writePending() {
+        // TODO: Wakeup writer
+        
+    }
+    
+    /// Registers a callback for an opcode and returns the ID associated with that callback.
+    public func register <T: ATTProtocolDataUnit> (_ callback: @escaping (T) -> ()) {
+                
+        // create notification
+        let opcode = T.attributeOpcode
+        let notify = Notification(callback)
+        
+        // add to queue
+        notifyList[opcode] = notify
+    }
+    
+    /// Unregisters the callback associated with the specified identifier.
+    ///
+    /// - Returns: Whether the callback was unregistered.
+    @discardableResult
+    public func unregister<T: ATTProtocolDataUnit>(_ type: T.Type) -> Bool {
+        
+        guard let index = notifyList.index(forKey: type.attributeOpcode)
+            else { return false }
+        notifyList.remove(at: index)
+        return true
+    }
+    
+    /// Registers all callbacks.
+    public func unregisterAll() {
+        notifyList.removeAll()
+    }
+    
+    /// Adds a PDU to the queue to send.
+    ///
+    /// - Returns: Identifier of queued send operation or `nil` if the PDU cannot be sent.
+    @discardableResult
+    public func queue <Request: ATTProtocolDataUnit> (
+        _ pdu: Request
+    ) -> UInt {
+        let attributeOpcode = Request.attributeOpcode
+        // Only request and indication PDUs should have response callbacks.
+        switch attributeOpcode.type {
+        case .request,
+             .indication: // Indication handles confirmation
+            assertionFailure("Missing response")
+        case .response,
+             .command,
+             .confirmation,
+             .notification:
+            break
+        }
+        let operation = SendOperation(
+            id: nextSendOpcodeID,
+            opcode: attributeOpcode,
+            data: encode(pdu)
+        )
+        return queue(operation)
+    }
+    
+    /// Adds a PDU to the queue to send.
+    ///
+    /// - Returns: Identifier of queued send operation or `nil` if the PDU cannot be sent.
+    @discardableResult
+    public func queue <Request: ATTProtocolDataUnit, Response: ATTProtocolDataUnit> (
+        _ request: Request,
+        response: @escaping ((Result<Response, ATTErrorResponse>) -> ())
+    ) -> UInt {
+        let attributeOpcode = Request.attributeOpcode
+        // Only request and indication PDUs should have response callbacks.
+        switch attributeOpcode.type {
+        case .request,
+             .indication: // Indication handles confirmation
+            break
+        case .response,
+             .command,
+             .confirmation,
+             .notification:
+            assertionFailure()
+        }
+        let operation = SendOperation(
+            id: nextSendOpcodeID,
+            opcode: attributeOpcode,
+            data: encode(request),
+            response: response
+        )
+        return queue(operation)
+    }
+    
+    // MARK: - Private Methods
+    
+    private func queue (
+        _ operation: SendOperation
+    ) -> UInt {
+        // increment ID
+        nextSendOpcodeID += 1
+        
+        // Add the op to the correct queue based on its type
+        switch operation.opcode.type {
+        case .request:
+            requestQueue.append(operation)
+        case .indication:
+            indicationQueue.append(operation)
+        case .response,
+             .command,
+             .confirmation,
+             .notification:
+            writeQueue.append(operation)
+        }
+        
+        writePending()
+        
+        return operation.id
+    }
+    
+    private func encode <T: ATTProtocolDataUnit> (_ request: T) -> Data {
+        
+        var data = Data(request)
+        /// MTU must be large enough to hold PDU.
+        if data.count > Int(maximumTransmissionUnit.rawValue) {
+            assertionFailure()
+            data = Data(data.prefix(Int(maximumTransmissionUnit.rawValue)))
+        }
+        
+        // TODO: Sign (encrypt) data
+        
+        return data
+    }
+    
+    private func handle(response data: Data, opcode: ATTOpcode) throws(Error) {
+        
+        // If no request is pending, then the response is unexpected. Disconnect the bearer.
+        guard let sendOperation = self.pendingRequest else {
+            throw .unexpectedResponse(data)
+        }
+        
+        // If the received response doesn't match the pending request, or if the request is malformed, 
+        // end the current request with failure.
+        
+        let requestOpcode: ATTOpcode
+        
+        // Retry for error response
+        if opcode == .errorResponse {
+            
+            guard let errorResponse = ATTErrorResponse(data: data)
+                else { throw .garbageResponse(data) }
+            
+            let (errorRequestOpcode, didRetry) = handle(errorResponse: errorResponse)
+            
+            requestOpcode = errorRequestOpcode
+            
+            writePending()
+            
+            /// Return if error response caused a retry
+            guard didRetry == false
+                else { return }
+            
+        } else {
+            
+            guard let mappedRequestOpcode = opcode.request
+                else { throw .unexpectedResponse(data) }
+            
+            requestOpcode = mappedRequestOpcode
+        }
+        
+        // clear current pending request
+        defer { self.pendingRequest = nil }
+        
+        /// Verify the received response belongs to the pending request
+        guard sendOperation.opcode == requestOpcode else {
+            throw ATTConnectionError.unexpectedResponse(data)
+        }
+        
+        // success!
+        try sendOperation.response(data)
+        
+        writePending()
+    }
+    
+    private func handle(confirmation data: Data, opcode: ATTOpcode) throws(Error) {
+        
+        // Disconnect the bearer if the confirmation is unexpected or the PDU is invalid.
+        guard let sendOperation = pendingIndication
+            else { throw .unexpectedResponse(data) }
+        
+        self.pendingIndication = nil
+        
+        // success!
+        try sendOperation.response(data)
+        
+        // send the remaining indications
+        if indicationQueue.isEmpty == false {
+            writePending()
+        }
+    }
+    
+    private func handle(request data: Data, opcode: ATTOpcode) throws(Error) {
+        
+        /*
+        * If a request is currently pending, then the sequential
+        * protocol was violated. Disconnect the bearer, which will
+        * promptly notify the upper layer via disconnect handlers.
+        */
+        
+        // Received request while another is pending.
+        guard incomingRequest == false
+            else { throw .unexpectedResponse(data) }
+        
+        incomingRequest = true
+        
+        // notify
+        try handle(notify: data, opcode: opcode)
+    }
+    
+    private func handle(notify data: Data, opcode: ATTOpcode) throws(Error) {
+        // handle notification
+        if let notification = self.notifyList[opcode] {
+            try notification.notification(data)
+        }
+        
+        // If this was a request and no handler was registered for it, respond with "Not Supported"
+        if self.notifyList[opcode] == nil && opcode.type == .request {
+            let errorResponse = ATTErrorResponse(
+                request: opcode,
+                attributeHandle: 0x00,
+                error: .requestNotSupported
+            )
+            let _ = queue(errorResponse)
+        }
+    }
+    
+    /// Handle the error reponse for a pending request and attempt to retry. 
+    ///
+    /// - Returns: The opcode of the request that errored 
+    /// and whether the request will be sent again.
+    private func handle(errorResponse: ATTErrorResponse) -> (opcode: ATTOpcode, didRetry: Bool) {
+        
+        let opcode = errorResponse.request
+        
+        guard let pendingRequest = self.pendingRequest
+            else { return (opcode, false)  }
+        
+        // Attempt to change security
+        guard changeSecurity(for: errorResponse.error)
+            else { return (opcode, false) }
+        
+        //print("Retrying operation \(pendingRequest)")
+        
+        self.pendingRequest = nil
+        
+        // Push operation back to request queue
+        requestQueue.insert(pendingRequest, at: 0)
+        
+        return (opcode, true)
+    }
+    
+    private func pickNextSendOpcode() -> SendOperation? {
+        
+        // See if any operations are already in the write queue
+        if let sendOpcode = writeQueue.popFirst() {
+            return sendOpcode
+        }
+        
+        // If there is no pending request, pick an operation from the request queue.
+        if pendingRequest == nil,
+            let sendOpcode = requestQueue.popFirst() {
+            return sendOpcode
+        }
+        
+        // There is either a request pending or no requests queued. 
+        // If there is no pending indication, pick an operation from the indication queue.
+        if pendingIndication == nil,
+            let sendOpcode = indicationQueue.popFirst() {
+            // can't send more indications until the last one is confirmed
+            pendingIndication = sendOpcode
+            return sendOpcode
+        }
+        
+        return nil
+    }
+    
+    /// Attempts to change security level based on an error response.
+    private func changeSecurity(for error: ATTError) -> Bool {
+        
+        let securityLevel: SecurityLevel
+        do { securityLevel = try socket.securityLevel() }
+        catch {
+            log?("Unable to get security level. \(error)")
+            return false
+        }
+        
+        // only change if security is Auto
+        guard securityLevel == .sdp
+            else { return false }
+        
+        // get security from IO
+        var newSecurityLevel: SecurityLevel
+        
+        if error == .insufficientEncryption,
+           securityLevel < .medium {
+            newSecurityLevel = .medium
+        } else if error == .insufficientAuthentication {
+            
+            if (securityLevel < .medium) {
+                newSecurityLevel = .medium
+            } else if (securityLevel < .high) {
+                newSecurityLevel = .high
+            } else if (securityLevel < .fips) {
+                newSecurityLevel = .fips
+            } else {
+                return false
+            }
+        } else {
+            return false
+        }
+        
+        // attempt to change security level on Socket IO
+        do { try socket.setSecurityLevel(newSecurityLevel) }
+        catch {
+            log?("Unable to set security level. \(error)")
+            return false
+        }
+        
+        return true
+    }
+}
+
+// MARK: - Supporting Types
+
+/// ATT Connection Error
+public enum ATTConnectionError<SocketError: Swift.Error, Data: DataContainer>: Error, Sendable {
+    
+    /// The received data could not be parsed correctly.
+    case garbageResponse(Data)
+    
+    /// Response is unexpected.
+    case unexpectedResponse(Data)
+    
+    /// Error ocurred at the socket layer.
+    case socket(SocketError)
+}
+
+internal typealias ATTResponse<Success: ATTProtocolDataUnit> = Result<Success, ATTErrorResponse>
+
+internal extension ATTConnection {
+    
+    struct SendOperation {
+        
+        /// The operation identifier.
+        let id: UInt
+        
+        /// The request data.
+        let data: Data
+        
+        /// The sent opcode
+        let opcode: ATTOpcode
+        
+        /// The response callback.
+        let response: ((Data) throws(ATTConnection.Error) -> ())
+        
+        init(
+            id: UInt,
+            opcode: ATTOpcode,
+            data: Data
+        ) {
+            self.id = id
+            self.opcode = opcode
+            self.data = data
+            self.response = { (data: Data) throws(ATTConnection.Error) -> () in
+                assertionFailure("Unexpected response")
+                throw .unexpectedResponse(data)
+            }
+        }
+        
+        init<Response: ATTProtocolDataUnit>(
+            id: UInt,
+            opcode: ATTOpcode,
+            data: Data,
+            response: @escaping ((Result<Response, ATTErrorResponse>) -> ())
+        ) {
+            self.id = id
+            self.opcode = opcode
+            self.data = data
+            self.response = { (data: Data) throws(ATTConnection.Error) -> () in
+                // invalid ATT code
+                guard let responseOpcode = data.first.flatMap(ATTOpcode.init(rawValue:))
+                    else { throw .garbageResponse(data) }
+                // response is error response
+                if responseOpcode == .errorResponse {
+                    guard let errorResponse = ATTErrorResponse(data: data)
+                        else { throw .garbageResponse(data) }
+                    response(.failure(errorResponse))
+                    return
+                } else if responseOpcode == opcode.response {
+                    // response is expected
+                    guard let value = Response.init(data: data) else {
+                        throw .garbageResponse(data)
+                    }
+                    response(.success(value))
+                    return
+                } else {
+                    // other ATT response
+                    throw .garbageResponse(data)
+                }
+            }
+        }
+    }
+    
+    struct Notification {
+                
+        let opcode: ATTOpcode
+        
+        let notification: (Data) throws(Error) -> ()
+        
+        init<T: ATTProtocolDataUnit>(
+            _ notification: @escaping (T) -> ()
+        ) {
+            self.opcode = T.attributeOpcode
+            self.notification = { (data: Data) throws(ATTConnection.Error) -> () in
+                guard let value = T.init(data: data) else {
+                    throw .garbageResponse(data)
+                }
+                notification(value)
+            }
+        }
+    }
+}
+
+internal extension Array {
+    
+    mutating func popFirst() -> Element? {
+        guard let first = self.first else { return nil }
+        self.removeFirst()
+        return first
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTError.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTError.swift
@@ -1,0 +1,233 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+/**
+ The possible errors returned by a GATT server (a remote peripheral) during Bluetooth low energy ATT transactions.
+ 
+ These error constants are based on the Bluetooth ATT error codes, defined in the Bluetooth 4.0 specification.
+ For more information about these errors, see the Bluetooth 4.0 specification, Volume 3, Part F, Section 3.4.1.1.
+ */
+@frozen
+public enum ATTError: UInt8, Error {
+    
+    /// Invalid Handle
+    ///
+    /// The attribute handle given was not valid on this server.
+    case invalidHandle                              = 0x01
+    
+    /// Read Not Permitted
+    ///
+    /// The attribute cannot be read.
+    case readNotPermitted                           = 0x02
+    
+    /// Write Not Permitted
+    ///
+    /// The attribute cannot be written.
+    case writeNotPermitted                          = 0x03
+    
+    /// Invalid PDU
+    ///
+    /// The attribute PDU was invalid.
+    case invalidPDU                                 = 0x04
+    
+    /// Insufficient Authentication
+    ///
+    /// The attribute requires authentication before it can be read or written.
+    case insufficientAuthentication                 = 0x05
+    
+    /// Request Not Supported
+    ///
+    /// Attribute server does not support the request received from the client.
+    case requestNotSupported                        = 0x06
+    
+    /// Invalid Offset
+    ///
+    /// Offset specified was past the end of the attribute.
+    case invalidOffset                              = 0x07
+    
+    /// Insufficient Authorization
+    ///
+    /// The attribute requires authorization before it can be read or written.
+    case insufficientAuthorization                  = 0x08
+    
+    /// Prepare Queue Full
+    ///
+    /// Too many prepare writes have been queued.
+    case prepareQueueFull                           = 0x09
+    
+    /// Attribute Not Found
+    ///
+    /// No attribute found within the given attribute handle range.
+    case attributeNotFound                          = 0x0A
+    
+    /// Attribute Not Long
+    ///
+    /// The attribute cannot be read or written using the *Read Blob Request*.
+    case attributeNotLong                           = 0x0B
+    
+    /// Insufficient Encryption Key Size
+    ///
+    /// The *Encryption Key Size* used for encrypting this link is insufficient.
+    case insufficientEncryptionKeySize              = 0x0C
+    
+    /// Invalid Attribute Value Length
+    ///
+    /// The attribute value length is invalid for the operation.
+    case invalidAttributeValueLength                = 0x0D
+    
+    /// Unlikely Error
+    ///
+    /// The attribute request that was requested has encountered an error that was unlikely,
+    /// and therefore could not be completed as requested.
+    case unlikelyError                              = 0x0E
+    
+    /// Insufficient Encryption
+    ///
+    /// The attribute requires encryption before it can be read or written.
+    case insufficientEncryption                     = 0x0F
+    
+    /// Unsupported Group Type
+    ///
+    /// The attribute type is not a supported grouping attribute as defined by a higher layer specification.
+    case unsupportedGroupType                       = 0x10
+    
+    /// Insufficient Resources
+    ///
+    /// Insufficient Resources to complete the request.
+    case insufficientResources                      = 0x11
+}
+
+// MARK: - CustomStringConvertible
+
+extension ATTError: CustomStringConvertible {
+    
+    public var description: String {
+        #if hasFeature(Embedded)
+        return "0x" + rawValue.toHexadecimal()
+        #else
+        return name
+        #endif
+    }
+}
+
+// MARK: - Description Values
+
+#if !hasFeature(Embedded)
+public extension ATTError {
+    
+    var name: String {
+        
+        switch self {
+        case .invalidHandle:
+            return "Invalid Handle"
+        case .readNotPermitted:
+            return "Read Not Permitted"
+        case .writeNotPermitted:
+            return "Write Not Permitted"
+        case .invalidPDU:
+            return "Invalid PDU"
+        case .insufficientAuthentication:
+            return "Insufficient Authentication"
+        case .requestNotSupported:
+            return "Request Not Supported"
+        case .invalidOffset:
+            return "Invalid Offset"
+        case .insufficientAuthorization:
+            return "Insufficient Authorization"
+        case .prepareQueueFull:
+            return "Prepare Queue Full"
+        case .attributeNotFound:
+            return "Attribute Not Found"
+        case .attributeNotLong:
+            return "Attribute Not Long"
+        case .insufficientEncryptionKeySize:
+            return "Insufficient Encryption Key Size"
+        case .invalidAttributeValueLength:
+            return "Invalid Attribute Value Length"
+        case .unlikelyError:
+            return "Unlikely Error"
+        case .insufficientEncryption:
+            return "Insufficient Encryption"
+        case .unsupportedGroupType:
+            return "Unsupported Group Type"
+        case .insufficientResources:
+            return "Insufficient Resources"
+        }
+    }
+    
+    var errorDescription: String {
+        
+        switch self {
+        case .invalidHandle:
+            return "The attribute handle given was not valid on this server."
+        case .readNotPermitted:
+            return "The attribute cannot be read."
+        case .writeNotPermitted:
+            return "The attribute cannot be written."
+        case .invalidPDU:
+            return "The attribute PDU was invalid."
+        case .insufficientAuthentication:
+            return "The attribute requires authentication before it can be read or written."
+        case .requestNotSupported:
+            return "Attribute server does not support the request received from the client."
+        case .invalidOffset:
+            return "Offset specified was past the end of the attribute."
+        case .insufficientAuthorization:
+            return "The attribute requires authorization before it can be read or written."
+        case .prepareQueueFull:
+            return "Too many prepare writes have been queued."
+        case .attributeNotFound:
+            return "No attribute found within the given attri- bute handle range."
+        case .attributeNotLong:
+            return "The attribute cannot be read using the Read Blob Request."
+        case .insufficientEncryptionKeySize:
+            return "The Encryption Key Size used for encrypting this link is insufficient."
+        case .invalidAttributeValueLength:
+            return "The attribute value length is invalid for the operation."
+        case .unlikelyError:
+            return "The attribute request that was requested has encountered an error that was unlikely, and therefore could not be completed as requested."
+        case .insufficientEncryption:
+            return "The attribute requires encryption before it can be read or written."
+        case .unsupportedGroupType:
+            return "The attribute type is not a supported grouping attribute as defined by a higher layer specification."
+        case .insufficientResources:
+            return "Insufficient Resources to complete the request."
+        }
+    }
+}
+#endif
+
+// MARK: - CustomNSError
+
+#if canImport(Foundation)
+extension ATTError: CustomNSError {
+    
+    public static var errorDomain: String {
+        return "org.pureswift.Bluetooth.ATTError"
+    }
+    
+    public var errorCode: Int {
+        return Int(rawValue)
+    }
+    
+    public var errorUserInfo: [String: Any] {
+        
+        return [
+            NSLocalizedDescriptionKey: name,
+            NSLocalizedFailureReasonErrorKey: errorDescription
+        ]
+    }
+}
+#endif

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTError.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTError.swift
@@ -114,17 +114,12 @@ public enum ATTError: UInt8, Error {
 extension ATTError: CustomStringConvertible {
     
     public var description: String {
-        #if hasFeature(Embedded)
-        return "0x" + rawValue.toHexadecimal()
-        #else
         return name
-        #endif
     }
 }
 
 // MARK: - Description Values
 
-#if !hasFeature(Embedded)
 public extension ATTError {
     
     var name: String {
@@ -167,6 +162,7 @@ public extension ATTError {
         }
     }
     
+    #if !hasFeature(Embedded)
     var errorDescription: String {
         
         switch self {
@@ -206,8 +202,8 @@ public extension ATTError {
             return "Insufficient Resources to complete the request."
         }
     }
+    #endif
 }
-#endif
 
 // MARK: - CustomNSError
 

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTErrorResponse.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTErrorResponse.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// The Error Response is used to state that a given request cannot be performed,
+/// and to provide the reason.
+///
+/// - Note: The Write Command does not generate an Error Response.
+@frozen
+public struct ATTErrorResponse: ATTProtocolDataUnit, Error, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .errorResponse }
+    
+    /// The request that generated this error response
+    public var request: ATTOpcode
+    
+    /// The attribute handle that generated this error response.
+    public var attributeHandle: UInt16
+    
+    /// The reason why the request has generated an error response.
+    public var error: ATTError
+    
+    public init(
+        request: ATTOpcode,
+        attributeHandle: UInt16,
+        error: ATTError
+    ) {
+        self.request = request
+        self.attributeHandle = attributeHandle
+        self.error = error
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTErrorResponse: DataConvertible {
+    
+    public static var length: Int { 5 }
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count == Self.length,
+            Self.validateOpcode(data),
+            let request = ATTOpcode(rawValue: data[1]),
+            let error = ATTError(rawValue: data[4])
+            else { return nil }
+        
+        let attributeHandle = UInt16(littleEndian: UInt16(bytes: (data[2], data[3])))
+        
+        self.init(request: request, attributeHandle: attributeHandle, error: error)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.request.rawValue
+        data += self.attributeHandle.littleEndian
+        data += self.error.rawValue
+    }
+    
+    public var dataLength: Int {
+        return Self.length
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTExecuteWriteRequest.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTExecuteWriteRequest.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Execute Write Request
+///
+/// The *Execute Write Request* is used to request the server to write or cancel the write
+/// of all the prepared values currently held in the prepare queue from this client.
+/// This request shall be handled by the server as an atomic operation.
+@frozen
+public enum ATTExecuteWriteRequest: UInt8, ATTProtocolDataUnit, Sendable, CaseIterable {
+    
+    public static var attributeOpcode: ATTOpcode {  .executeWriteRequest }
+    
+    /// Cancel all prepared writes.
+    case cancel = 0x00
+    
+    /// Immediately write all pending prepared values.
+    case write  = 0x01
+}
+
+extension ATTExecuteWriteRequest: DataConvertible {
+    
+    public static var length: Int { 2 }
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count == 2,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        self.init(rawValue: data[1])
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += [Self.attributeOpcode.rawValue, rawValue]
+    }
+    
+    public var dataLength: Int {
+        Self.length
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTExecuteWriteResponse.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTExecuteWriteResponse.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// The *Execute Write Response* is sent in response to a received *Execute Write Request*.
+@frozen
+public struct ATTExecuteWriteResponse: ATTProtocolDataUnit, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .executeWriteResponse }
+    
+    public init() { }
+}
+
+extension ATTExecuteWriteResponse: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count == 1,
+            Self.validateOpcode(data)
+            else { return nil }
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+    }
+    
+    public var dataLength: Int {
+        1
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTFindByTypeRequest.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTFindByTypeRequest.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Find By Type Value Request
+///
+/// The *Find By Type Value Request* is used to obtain the handles of attributes that
+/// have a 16-bit UUID attribute type and attribute value.
+/// This allows the range of handles associated with a given attribute to be discovered when
+/// the attribute type determines the grouping of a set of attributes.
+///
+/// - Note: Generic Attribute Profile defines grouping of attributes by attribute type.
+@frozen
+public struct ATTFindByTypeRequest<Value: DataContainer>: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .findByTypeRequest }
+    
+    /// First requested handle number
+    public var startHandle: UInt16
+    
+    /// Last requested handle number
+    public var endHandle: UInt16
+    
+    /// 2 octet UUID to find.
+    public var attributeType: UInt16
+    
+    /// Attribute value to find.
+    public var attributeValue: Value
+    
+    public init(
+        startHandle: UInt16,
+        endHandle: UInt16,
+        attributeType: UInt16,
+        attributeValue: Value
+    ) {
+        self.startHandle = startHandle
+        self.endHandle = endHandle
+        self.attributeType = attributeType
+        self.attributeValue = attributeValue
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTFindByTypeRequest: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count >= 7,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        let startHandle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+        let endHandle = UInt16(littleEndian: UInt16(bytes: (data[3], data[4])))
+        let attributeType = UInt16(littleEndian: UInt16(bytes: (data[5], data[6])))
+        let attributeValue: Value = data.suffixCheckingBounds(from: 7)
+        
+        self.init(
+            startHandle: startHandle,
+            endHandle: endHandle,
+            attributeType: attributeType,
+            attributeValue: attributeValue
+        )
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.startHandle.littleEndian
+        data += self.endHandle.littleEndian
+        data += self.attributeType.littleEndian
+        data += self.attributeValue
+    }
+    
+    public var dataLength: Int {
+        return 7 + attributeValue.count
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTFindByTypeResponse.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTFindByTypeResponse.swift
@@ -1,0 +1,130 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Find By Type Value Response
+///
+/// The *Find By Type Value Response* is sent in reply to a received *Find By Type Value Request*
+/// and contains information about this server.
+@frozen
+public struct ATTFindByTypeResponse: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .findByTypeResponse }
+    
+    /// A list of 1 or more Handle Informations.
+    public let handles: [HandlesInformation]
+    
+    public init?(handles: [HandlesInformation]) {
+        guard handles.isEmpty == false
+            else { return nil }
+        self.handles = handles
+    }
+    
+    internal init(_ handles: [HandlesInformation]) {
+        assert(handles.isEmpty == false, "Must have at least one element")
+        self.handles = handles
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTFindByTypeResponse: DataConvertible {
+    
+    /// Minimum length.
+    internal static var minimumLength: Int { 1 + HandlesInformation.length }
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count >= Self.minimumLength,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        let handleLength = HandlesInformation.length
+        
+        let handleBytesCount = data.count - 1
+        
+        guard handleBytesCount % handleLength == 0
+            else { return nil }
+        
+        let handleCount = handleBytesCount / handleLength
+        
+        let handleIndices = (0 ..< handleCount)
+        let handles = handleIndices.map { (index: Int) -> HandlesInformation in
+            let byteIndex = 1 + (index * handleLength)
+            return HandlesInformation(data.subdata(in: byteIndex ..< byteIndex + handleLength))
+        }
+        
+        self.init(handles: handles)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.handles
+    }
+    
+    public var dataLength: Int {
+        1 + (handles.count * HandlesInformation.length)
+    }
+}
+
+// MARK: - Supporting Types
+
+public extension ATTFindByTypeResponse {
+    
+    /// Handles Information
+    ///
+    /// For each handle that matches the attribute type and attribute value in the *Find By Type Value Request*
+    /// a *Handles Information* shall be returned.
+    /// The *Found Attribute Handle* shall be set to the handle of the attribute that has the exact attribute type
+    /// and attribute value from the *Find By Type Value Request*.
+    struct HandlesInformation: Equatable, Hashable, Sendable {
+        
+        /// Found Attribute Handle
+        public var foundAttribute: UInt16
+        
+        /// Group End Handle
+        public var groupEnd: UInt16
+        
+        public init(
+            foundAttribute: UInt16,
+            groupEnd: UInt16
+        ) {
+            self.foundAttribute = foundAttribute
+            self.groupEnd = groupEnd
+        }
+    }
+}
+
+extension ATTFindByTypeResponse.HandlesInformation: DataConvertible {
+    
+    public static var length: Int { 4 }
+    
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == Self.length else {
+            return nil
+        }
+        self.init(data)
+    }
+    
+    internal init<Data: DataContainer>(_ data: Data) {
+        assert(data.count == Self.length)
+        self.foundAttribute = UInt16(littleEndian: UInt16(bytes: (data[0], data[1])))
+        self.groupEnd = UInt16(littleEndian: UInt16(bytes: (data[2], data[3])))
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += foundAttribute.littleEndian
+        data += groupEnd.littleEndian
+    }
+    
+    public var dataLength: Int {
+        Self.length
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTFindInformationRequest.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTFindInformationRequest.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Find Information Request
+///
+/// The *Find Information Request* is used to obtain the mapping of attribute handles with their associated types.
+/// This allows a client to discover the list of attributes and their types on a server.
+@frozen
+public struct ATTFindInformationRequest: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .findInformationRequest }
+    
+    public var startHandle: UInt16
+    
+    public var endHandle: UInt16
+    
+    public init(
+        startHandle: UInt16,
+        endHandle: UInt16
+    ) {
+        self.startHandle = startHandle
+        self.endHandle = endHandle
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTFindInformationRequest: DataConvertible {
+    
+    public static var length: Int { 5 }
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count == Self.length,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        self.startHandle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+        self.endHandle = UInt16(littleEndian: UInt16(bytes: (data[3], data[4])))
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.startHandle.littleEndian
+        data += self.endHandle.littleEndian
+    }
+    
+    public var dataLength: Int {
+        Self.length
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTFindInformationResponse.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTFindInformationResponse.swift
@@ -1,0 +1,284 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Find Information Response
+///
+/// The *Find Information Response* is sent in reply to a received *Find Information Request*
+/// and contains information about this server.
+@frozen
+public struct ATTFindInformationResponse: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .findInformationResponse }
+    
+    /// The information data whose format is determined by the Format field.
+    public var attributeData: AttributeData
+    
+    public init(attributeData: AttributeData) {
+        
+        self.attributeData = attributeData
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTFindInformationResponse: DataConvertible {
+    
+    /// Length ranges from 6, to the maximum MTU size.
+    internal static var minimumLength: Int { return 6 }
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count >= Self.minimumLength,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        let formatByte = data[1]
+        let remainderData = data.subdata(in: 2 ..< data.count)
+        
+        guard let format = Format(rawValue: formatByte),
+            let attributeData = AttributeData(data: remainderData, format: format)
+            else { return nil }
+        
+        self.attributeData = attributeData
+    }
+    
+    public var dataLength: Int {
+        2 + attributeData.dataLength
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.attributeData.format.rawValue
+        data += self.attributeData
+    }
+}
+
+// MARK: - Supporting Types
+
+internal extension ATTFindInformationResponse {
+    
+    enum Format: UInt8 {
+        
+        /// A list of 1 or more handles with their 16-bit Bluetooth UUIDs.
+        case bit16      = 0x01
+        
+        /// A list of 1 or more handles with their 128-bit UUIDs.
+        case bit128     = 0x02
+        
+        public init?(uuid: BluetoothUUID) {
+            switch uuid {
+            case .bit16: self = .bit16
+            case .bit32: return nil
+            case .bit128: self = .bit128
+            }
+        }
+        
+        internal var length: Int {
+            switch self {
+            case .bit16: return 4
+            case .bit128: return 18
+            }
+        }
+    }
+}
+
+internal protocol FindInformationResponseAttribute {
+    
+    associatedtype UUID
+    
+    /// Attribute Format
+    static var format: ATTFindInformationResponse.Format { get }
+    
+    /// Attribute Handle
+    var handle: UInt16 { get }
+    
+    /// Attribute UUID
+    var uuid: UUID { get }
+    
+    init?<Data>(data: Data) where Data : DataContainer
+}
+
+public extension ATTFindInformationResponse {
+    
+    /// 16 Bit Attribute
+    struct Attribute16Bit: Equatable, Hashable, FindInformationResponseAttribute, Sendable {
+        
+        internal static var format: Format { .bit16 }
+        
+        /// Attribute Handle
+        public let handle: UInt16
+        
+        /// Attribute UUID
+        public let uuid: UInt16
+    }
+}
+
+extension ATTFindInformationResponse.Attribute16Bit: DataConvertible {
+    
+    public init?<Data>(data: Data) where Data : DataContainer {
+        guard data.count == Self.format.length else {
+            return nil
+        }
+        self.init(data)
+    }
+    
+    internal init<Data>(_ data: Data) where Data : DataContainer {
+        assert(data.count == Self.format.length)
+        let handle = UInt16(littleEndian: UInt16(bytes: (data[0], data[1])))
+        let uuid = UInt16(littleEndian: UInt16(bytes: (data[2], data[3])))
+        self.init(handle: handle, uuid: uuid)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += handle.littleEndian
+        data += uuid.littleEndian
+    }
+    
+    public var dataLength: Int {
+        Self.format.length
+    }
+}
+
+public extension ATTFindInformationResponse {
+    
+    /// 128 Bit Attribute
+    struct Attribute128Bit: Equatable, Hashable, FindInformationResponseAttribute, Sendable {
+        
+        internal static var format: Format { .bit128 }
+        
+        /// Attribute Handle
+        public let handle: UInt16
+        
+        /// Attribute UUID
+        public let uuid: UInt128
+    }
+}
+
+extension ATTFindInformationResponse.Attribute128Bit: DataConvertible {
+    
+    public init?<Data>(data: Data) where Data : DataContainer {
+        guard data.count == Self.format.length else {
+            return nil
+        }
+        self.init(data)
+    }
+    
+    internal init<Data>(_ data: Data) where Data : DataContainer {
+        assert(data.count == Self.format.length)
+        let handle = UInt16(littleEndian: UInt16(bytes: (data[0], data[1])))
+        let uuidBytes = data.subdata(in: 2 ..< 18)
+        assert(uuidBytes.count == UInt128.length)
+        let uuid = UInt128(littleEndian: UInt128(data: uuidBytes)!)
+        self.init(handle: handle, uuid: uuid)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += handle.littleEndian
+        data += uuid.littleEndian
+    }
+    
+    public var dataLength: Int {
+        Self.format.length
+    }
+}
+
+public extension ATTFindInformationResponse {
+    
+    /// Found Attribute Data.
+    enum AttributeData: Equatable, Hashable, Sendable {
+        
+        /// Handle and 16-bit Bluetooth UUID
+        case bit16([Attribute16Bit])
+        
+        /// Handle and 128-bit UUIDs
+        case bit128([Attribute128Bit])
+    }
+}
+
+extension ATTFindInformationResponse.AttributeData {
+    
+    /// The data's format.
+    internal var format: ATTFindInformationResponse.Format {
+        switch self {
+        case .bit16: return .bit16
+        case .bit128: return .bit128
+        }
+    }
+    
+    /// Number of items.
+    public var count: Int {
+        switch self {
+        case let .bit16(value): return value.count
+        case let .bit128(value): return value.count
+        }
+    }
+    
+    internal init?<Data: DataContainer>(data: Data, format: ATTFindInformationResponse.Format) {
+        switch format {
+        case .bit16:
+            guard let values = [ATTFindInformationResponse.Attribute16Bit](data: data) else {
+                return nil
+            }
+            self = .bit16(values)
+        case .bit128:
+            guard let values = [ATTFindInformationResponse.Attribute128Bit](data: data) else {
+                return nil
+            }
+            self = .bit128(values)
+        }
+    }
+}
+
+internal extension Array where Element: FindInformationResponseAttribute {
+    
+    init?<Data: DataContainer>(data: Data) {
+        let format = Element.format
+        let pairLength = format.length
+        
+        guard data.count % pairLength == 0
+            else { return nil }
+        
+        let pairCount = data.count / pairLength
+        var pairs = [Element]()
+        pairs.reserveCapacity(pairCount)
+        
+        for pairIndex in 0 ..< pairCount {
+            let byteIndex = pairIndex * pairLength
+            let pairBytes = data.subdata(in: byteIndex ..< byteIndex + pairLength)
+            guard let element = Element(data: pairBytes) else {
+                return nil
+            }
+            pairs.append(element)
+        }
+        self = pairs
+    }
+}
+
+extension ATTFindInformationResponse.AttributeData {
+    
+    static func += <T: DataContainer> (data: inout T, value: ATTFindInformationResponse.AttributeData) {
+        switch value {
+        case let .bit16(attributes):
+            data += attributes
+        case let .bit128(attributes):
+            data += attributes
+        }
+    }
+    
+    var dataLength: Int {
+        switch self {
+        case let .bit16(attributes):
+            return ATTFindInformationResponse.Format.bit16.length * attributes.count
+        case let .bit128(attributes):
+            return ATTFindInformationResponse.Format.bit128.length * attributes.count
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTHandleValueConfirmation.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTHandleValueConfirmation.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Handle Value Confirmation
+///
+/// The *Handle Value Confirmation* is sent in response to a received *Handle Value Indication*
+/// and confirms that the client has received an indication of the given attribute.
+@frozen
+public struct ATTHandleValueConfirmation: ATTProtocolDataUnit, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .handleValueConfirmation }
+    
+    public init() { }
+}
+
+extension ATTHandleValueConfirmation: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count == 1,
+            Self.validateOpcode(data)
+            else { return nil }
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+    }
+    
+    public var dataLength: Int { 1 }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTHandleValueIndication.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTHandleValueIndication.swift
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Handle Value Indication
+///
+/// A server can send an indication of an attribute’s value.
+@frozen
+public struct ATTHandleValueIndication<Value: DataContainer>: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .handleValueIndication }
+    
+    /// The handle of the attribute.
+    public var handle: UInt16
+    
+    /// The handle of the attribute.
+    public var value: Value
+    
+    public init(handle: UInt16, value: Value) {
+        
+        self.handle = handle
+        self.value = value
+    }
+}
+
+public extension ATTHandleValueIndication {
+    
+    init(attribute: GATTDatabase<Value>.Attribute, maximumTransmissionUnit: ATTMaximumTransmissionUnit) {
+        
+        // If the attribue value is longer than (ATT_MTU-3) octets,
+        // then only the first (ATT_MTU-3) octets of this attribute value
+        // can be sent in a indication.
+        let dataSize = Int(maximumTransmissionUnit.rawValue) - 3
+        
+        let value: Value
+        
+        if attribute.value.count > dataSize {
+            value = Value(attribute.value.prefix(dataSize))
+        } else {
+            value = attribute.value
+        }
+        
+        self.init(handle: attribute.handle, value: value)
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTHandleValueIndication: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count >= 3,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        self.handle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+        self.value = data.suffixCheckingBounds(from: 3)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += handle.littleEndian
+        data += value
+    }
+    
+    public var dataLength: Int {
+        3 + value.count
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTHandleValueNotification.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTHandleValueNotification.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Handle Value Notification
+///
+/// A server can send a notification of an attribute’s value at any time.
+@frozen
+public struct ATTHandleValueNotification<Value: DataContainer>: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .handleValueNotification }
+    
+    /// The handle of the attribute.
+    public var handle: UInt16
+    
+    /// The handle of the attribute.
+    public var value: Value
+    
+    public init(handle: UInt16, value: Value) {
+        self.handle = handle
+        self.value = value
+    }
+}
+
+public extension ATTHandleValueNotification {
+    
+    init(attribute: GATTDatabase<Value>.Attribute, maximumTransmissionUnit: ATTMaximumTransmissionUnit) {
+        
+        // If the attribue value is longer than (ATT_MTU-3) octets,
+        // then only the first (ATT_MTU-3) octets of this attribute value
+        // can be sent in a notification.
+        let dataSize = Int(maximumTransmissionUnit.rawValue) - 3
+        
+        let value: Value
+        
+        if attribute.value.count > dataSize {
+            value = Value(attribute.value.prefix(dataSize))
+        } else {
+            value = attribute.value
+        }
+        
+        self.init(handle: attribute.handle, value: value)
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTHandleValueNotification: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+    
+        guard data.count >= 3,
+              Self.validateOpcode(data)
+            else { return nil }
+    
+        self.handle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+        self.value = data.suffixCheckingBounds(from: 3)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.handle.littleEndian
+        data += self.value
+    }
+    
+    public var dataLength: Int {
+        3 + value.count
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTMaximumTransmissionUnit.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTMaximumTransmissionUnit.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// ATT Maximum Transmission Unit
+@frozen
+public struct ATTMaximumTransmissionUnit: RawRepresentable, Equatable, Hashable, Sendable {
+    
+    public let rawValue: UInt16
+    
+    public init?(rawValue: UInt16) {
+        
+        guard rawValue <= ATTMaximumTransmissionUnit.max.rawValue,
+            rawValue >= ATTMaximumTransmissionUnit.min.rawValue
+            else { return nil }
+        
+        self.rawValue = rawValue
+    }
+    
+    fileprivate init(_ unsafe: UInt16) {
+        self.rawValue = unsafe
+    }
+}
+
+private extension ATTMaximumTransmissionUnit {
+    
+    var isValid: Bool {
+        return (ATTMaximumTransmissionUnit.min.rawValue ... ATTMaximumTransmissionUnit.max.rawValue).contains(rawValue)
+    }
+}
+
+public extension ATTMaximumTransmissionUnit {
+    
+    static var `default`: ATTMaximumTransmissionUnit { ATTMaximumTransmissionUnit(23) }
+    
+    static var min: ATTMaximumTransmissionUnit { .default }
+    
+    static var max: ATTMaximumTransmissionUnit { ATTMaximumTransmissionUnit(517) }
+    
+    init(
+        server: UInt16,
+        client: UInt16
+    ) {
+        let mtu = Swift.min(Swift.max(Swift.min(client, server), ATTMaximumTransmissionUnit.default.rawValue), ATTMaximumTransmissionUnit.max.rawValue)
+        self.init(mtu)
+        assert(isValid)
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension ATTMaximumTransmissionUnit: CustomStringConvertible {
+    
+    public var description: String {
+        return rawValue.description
+    }
+}
+
+// MARK: - Comparable
+
+extension ATTMaximumTransmissionUnit: Comparable {
+    
+    public static func < (lhs: ATTMaximumTransmissionUnit, rhs: ATTMaximumTransmissionUnit) -> Bool {
+        return lhs.rawValue < rhs.rawValue
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTMaximumTransmissionUnitRequest.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTMaximumTransmissionUnitRequest.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Exchange MTU Request
+///
+/// The *Exchange MTU Request* is used by the client to inform the server of the client’s maximum receive MTU
+/// size and request the server to respond with its maximum receive MTU size.
+///
+/// - Note: This request shall only be sent once during a connection by the client.
+/// The *Client Rx MTU* parameter shall be set to the maximum size of the attribute protocol PDU that the client can receive.
+@frozen
+public struct ATTMaximumTransmissionUnitRequest: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    /// 0x02 = Exchange MTU Request
+    public static var attributeOpcode: ATTOpcode { .maximumTransmissionUnitRequest }
+    
+    /// Client Rx MTU
+    ///
+    /// Client receive MTU size
+    public var clientMTU: UInt16
+    
+    public init(clientMTU: UInt16) {
+        self.clientMTU = clientMTU
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTMaximumTransmissionUnitRequest: DataConvertible {
+    
+    public static var length: Int { 3 }
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count == Self.length,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        self.clientMTU = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.clientMTU.littleEndian
+    }
+    
+    public var dataLength: Int {
+        Self.length
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTMaximumTransmissionUnitResponse.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTMaximumTransmissionUnitResponse.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+///  Exchange MTU Response
+///
+/// The *Exchange MTU Response* is sent in reply to a received *Exchange MTU Request*.
+@frozen
+public struct ATTMaximumTransmissionUnitResponse: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    /// 0x03 = Exchange MTU Response
+    public static var attributeOpcode: ATTOpcode { return .maximumTransmissionUnitResponse }
+    
+    /// Server Rx MTU
+    ///
+    /// Attribute server receive MTU size
+    public var serverMTU: UInt16
+    
+    public init(serverMTU: UInt16) {
+        self.serverMTU = serverMTU
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTMaximumTransmissionUnitResponse: DataConvertible {
+    
+    public static var length: Int { 3 }
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count == Self.length,
+            Self.validateOpcode(data)
+            else { return nil }
+                
+        self.serverMTU = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.serverMTU.littleEndian
+    }
+    
+    public var dataLength: Int {
+        Self.length
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTOpcode.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTOpcode.swift
@@ -1,0 +1,165 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// ATT protocol opcodes.
+public enum ATTOpcode: UInt8, Sendable, CaseIterable {
+    
+    /// Error response
+    case errorResponse                              = 0x01
+    
+    // Exchange MTU
+    
+    /// Maximum Transmission Unit Request
+    case maximumTransmissionUnitRequest             = 0x02
+    
+    /// Maximum Transmission Unit Response
+    case maximumTransmissionUnitResponse            = 0x03
+    
+    // Find Information
+    case findInformationRequest                     = 0x04
+    case findInformationResponse                    = 0x05
+    
+    // Find By Type Value
+    case findByTypeRequest                          = 0x06
+    case findByTypeResponse                         = 0x07
+    
+    // Read By Type
+    case readByTypeRequest                          = 0x08
+    case readByTypeResponse                         = 0x09
+    
+    // Read
+    case readRequest                                = 0x0a
+    case readResponse                               = 0x0b
+    
+    // Read Blob
+    case readBlobRequest                            = 0x0c
+    case readBlobResponse                           = 0x0d
+    
+    // Read Multiple
+    case readMultipleRequest                        = 0x0e
+    case readMultipleResponse                       = 0x0f
+    
+    // Read By Group Type
+    case readByGroupTypeRequest                     = 0x10
+    case readByGroupTypeResponse                    = 0x11
+    
+    // Write
+    case writeRequest                               = 0x12
+    case writeResponse                              = 0x13
+    case writeCommand                               = 0x52
+    case signedWriteCommand                         = 0xD2
+    
+    // Prepare Write
+    case preparedWriteRequest                       = 0x16
+    case preparedWriteResponse                      = 0x17
+    
+    // Execute Write
+    case executeWriteRequest                        = 0x18
+    case executeWriteResponse                       = 0x19
+    
+    // Handle Value
+    case handleValueNotification                    = 0x1B
+    case handleValueIndication                      = 0x1D
+    case handleValueConfirmation                    = 0x1E
+}
+
+// MARK: - Opcode Type
+
+/// ATT protocol opcode categories.
+@frozen
+public enum ATTOpcodeType {
+    
+    case request
+    case response
+    case command
+    case indication
+    case notification
+    case confirmation
+}
+
+public extension ATTOpcode {
+    
+    /// Specifies the opcode category.
+    var type: ATTOpcodeType {
+        
+        switch self {
+        case .errorResponse:                    return .response
+        case .maximumTransmissionUnitRequest:   return .request
+        case .maximumTransmissionUnitResponse:  return .response
+        case .findInformationRequest:           return .request
+        case .findInformationResponse:          return .response
+        case .findByTypeRequest:                return .request
+        case .findByTypeResponse:               return .response
+        case .readByTypeRequest:                return .request
+        case .readByTypeResponse:               return .response
+        case .readRequest:                      return .request
+        case .readResponse:                     return .response
+        case .readBlobRequest:                  return .request
+        case .readBlobResponse:                 return .response
+        case .readMultipleRequest:              return .request
+        case .readMultipleResponse:             return .response
+        case .readByGroupTypeRequest:           return .request
+        case .readByGroupTypeResponse:          return .response
+        case .writeRequest:                     return .request
+        case .writeResponse:                    return .response
+        case .writeCommand:                     return .command
+        case .signedWriteCommand:               return .command
+        case .preparedWriteRequest:             return .request
+        case .preparedWriteResponse:            return .response
+        case .executeWriteRequest:              return .request
+        case .executeWriteResponse:             return .response
+        case .handleValueNotification:          return .notification
+        case .handleValueIndication:            return .indication
+        case .handleValueConfirmation:          return .confirmation
+        }
+    }
+    
+    /// Get the equivalent response for the current request opcode (if applicable).
+    var response: ATTOpcode? {
+        return Self.responsesByRequest[self]
+    }
+    
+    /// Get the equivalent request for the current response opcode (if applicable).
+    var request: ATTOpcode? {
+        return Self.requestsByResponse[self]
+    }
+}
+
+private extension ATTOpcode {
+    
+    // swiftlint:disable comma
+    static let requestResponseMap: [(request: ATTOpcode,  response: ATTOpcode)] = [
+        (maximumTransmissionUnitRequest,     maximumTransmissionUnitResponse),
+        (findInformationRequest,             findInformationResponse),
+        (findByTypeRequest,                  findByTypeResponse),
+        (readByTypeRequest,                  readByTypeResponse),
+        (readRequest,                        readResponse),
+        (readBlobRequest,                    readBlobResponse),
+        (readMultipleRequest,                readMultipleResponse),
+        (readByGroupTypeRequest,             readByGroupTypeResponse),
+        (writeRequest,                       writeResponse),
+        (preparedWriteRequest,               preparedWriteResponse),
+        (executeWriteRequest,                executeWriteResponse)
+    ]
+    // swiftlint:enable comma
+    
+    static let responsesByRequest: [ATTOpcode: ATTOpcode] = {
+        var dictionary = [ATTOpcode: ATTOpcode](minimumCapacity: requestResponseMap.count)
+        requestResponseMap.forEach { dictionary[$0.request] = $0.response }
+        return dictionary
+    }()
+    
+    static let requestsByResponse: [ATTOpcode: ATTOpcode] = {
+        var dictionary = [ATTOpcode: ATTOpcode](minimumCapacity: requestResponseMap.count)
+        requestResponseMap.forEach { dictionary[$0.response] = $0.request }
+        return dictionary
+    }()
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTOpcode.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTOpcode.swift
@@ -71,6 +71,17 @@ public enum ATTOpcode: UInt8, Sendable, CaseIterable {
     case handleValueConfirmation                    = 0x1E
 }
 
+// MARK: - CustomStringConvertible
+
+#if hasFeature(Embedded)
+extension ATTOpcode: CustomStringConvertible {
+    
+    public var description: String {
+        "0x" + rawValue.toHexadecimal()
+    }
+}
+#endif
+
 // MARK: - Opcode Type
 
 /// ATT protocol opcode categories.

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTPrepareWriteRequest.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTPrepareWriteRequest.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Prepare Write Request
+///
+/// The *Prepare Write Request* is used to request the server to prepare to write the value of an attribute.
+/// The server will respond to this request with a *Prepare Write Response*,
+/// so that the client can verify that the value was received correctly.
+@frozen
+public struct ATTPrepareWriteRequest<Value: DataContainer>: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .preparedWriteRequest }
+    
+    /// The handle of the attribute to be written.
+    public var handle: UInt16
+    
+    /// The offset of the first octet to be written.
+    public var offset: UInt16
+    
+    /// The value of the attribute to be written.
+    public var partValue: Value
+    
+    public init(handle: UInt16,
+                offset: UInt16,
+                partValue: Value) {
+        
+        self.handle = handle
+        self.offset = offset
+        self.partValue = partValue
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTPrepareWriteRequest: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count >= 5,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        self.handle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+        self.offset = UInt16(littleEndian: UInt16(bytes: (data[3], data[4])))
+        self.partValue = data.suffixCheckingBounds(from: 5)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.handle.littleEndian
+        data += self.offset.littleEndian
+        data += self.partValue
+    }
+    
+    public var dataLength: Int {
+        return 5 + partValue.count
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTPrepareWriteResponse.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTPrepareWriteResponse.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Prepare Write Response
+/// The *Prepare Write Response* is sent in response to a received *Prepare Write Request*
+/// and acknowledges that the value has been successfully received and placed in the prepare write queue.
+@frozen
+public struct ATTPrepareWriteResponse <Value: DataContainer> : ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .preparedWriteResponse }
+    
+    /// The handle of the attribute to be written.
+    public var handle: UInt16
+    
+    /// The offset of the first octet to be written.
+    public var offset: UInt16
+    
+    /// The value of the attribute to be written.
+    public var partValue: Value
+    
+    public init(
+        handle: UInt16,
+        offset: UInt16,
+        partValue: Value
+    ) {
+        self.handle = handle
+        self.offset = offset
+        self.partValue = partValue
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTPrepareWriteResponse: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count >= 5,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        self.handle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+        self.offset = UInt16(littleEndian: UInt16(bytes: (data[3], data[4])))
+        self.partValue = data.suffixCheckingBounds(from: 5)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.handle.littleEndian
+        data += self.offset.littleEndian
+        data += self.partValue
+    }
+    
+    public var dataLength: Int {
+        5 + partValue.count
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTProtocolDataUnit.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTProtocolDataUnit.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: - Protocol Definition
+
+/// Data packet for the ATT protocol.
+public protocol ATTProtocolDataUnit: DataConvertible {
+    
+    /// The PDU's attribute opcode.
+    static var attributeOpcode: ATTOpcode { get }
+}
+
+internal extension ATTProtocolDataUnit {
+    
+    static func validateOpcode<Data: DataContainer>(_ data: Data) -> Bool {
+        return data.first == attributeOpcode.rawValue
+    }
+}
+
+// MARK: - Supporting Types
+
+internal protocol ATTAttributeDataList: ATTProtocolDataUnit {
+    
+    associatedtype AttributeData: ATTAttributeData
+    
+    static var headerLength: Int { get }
+}
+
+internal protocol ATTAttributeData: DataConvertible { }
+
+extension ATTAttributeDataList {
+    
+    static var headerLength: Int { return 2 }
+}
+
+internal extension ATTAttributeDataList where AttributeData: DataConvertible {
+    
+    static func validate(_ attributeData: [AttributeData]) -> Bool {
+        
+        // must have at least one item
+        guard let valueLength = attributeData.first?.dataLength
+            else { return false }
+        
+        for attributeData in attributeData {
+            // all items must have same length
+            guard attributeData.dataLength == valueLength
+                else { return false }
+        }
+        return true
+    }
+    
+    static func dataLength <T: Collection> (for attributes: T) -> Int where T.Element == AttributeData {
+        assert(attributes.isEmpty == false)
+        return attributes.reduce(headerLength, { $0 + $1.dataLength })
+    }
+    
+    static func append <Data: DataContainer> (_ data: inout Data, _ attributeData: [AttributeData]) {
+        data += attributeOpcode.rawValue
+        data += UInt8(attributeData[0].dataLength)
+        data += attributeData
+    }
+}
+
+internal extension ATTAttributeDataList {
+
+    static func from<Data: DataContainer>(data: Data) -> [AttributeData]? {
+        
+        guard data.count > headerLength,
+            validateOpcode(data)
+            else { return nil }
+        
+        let attributeDataLength = Int(data[1])
+        
+        let attributeDataByteCount = data.count - headerLength
+        
+        guard attributeDataByteCount % attributeDataLength == 0
+            else { return nil }
+        
+        let attributeDataCount = attributeDataByteCount / attributeDataLength
+        
+        guard attributeDataCount >= 1
+            else { return nil }
+        
+        var attributeData = [AttributeData]()
+        attributeData.reserveCapacity(attributeDataCount)
+        
+        for index in 0 ..< attributeDataCount {
+            
+            let byteIndex = headerLength + (index * attributeDataLength)
+            
+            let attributeBytes = data.subdata(in: byteIndex ..< byteIndex + attributeDataLength)
+            
+            guard let attribute = AttributeData(data: attributeBytes)
+                else { return nil }
+            
+            attributeData.append(attribute)
+        }
+        
+        return attributeData
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadBlobRequest.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadBlobRequest.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Read Blob Request
+///
+/// The *Read Blob Request* is used to request the server to read part of the value of an attribute
+/// at a given offset and return a specific part of the value in a *Read Blob Response*.
+@frozen
+public struct ATTReadBlobRequest: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .readBlobRequest }
+    
+    /// The handle of the attribute to be read.
+    public var handle: UInt16
+    
+    /// The offset of the first octet to be read.
+    public var offset: UInt16
+    
+    public init(handle: UInt16,
+                offset: UInt16) {
+        
+        self.handle = handle
+        self.offset = offset
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTReadBlobRequest: DataConvertible {
+    
+    public static var length: Int { 5 }
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count == Self.length,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        self.handle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+        self.offset = UInt16(littleEndian: UInt16(bytes: (data[3], data[4])))
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.handle.littleEndian
+        data += self.offset.littleEndian
+    }
+    
+    public var dataLength: Int {
+        Self.length
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadBlobResponse.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadBlobResponse.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Read Blob Response
+///
+/// The *Read Blob Response* is sent in reply to a received *Read Blob Request*
+/// and contains part of the value of the attribute that has been read.
+@frozen
+public struct ATTReadBlobResponse<Value: DataContainer>: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .readBlobResponse }
+    
+    /// Part of the value of the attribute with the handle given.
+    ///
+    ///
+    /// The part attribute value shall be set to part of the value of the attribute identified
+    /// by the attribute handle and the value offset in the request.
+    public var partAttributeValue: Value
+    
+    public init(partAttributeValue: Value) {
+        self.partAttributeValue = partAttributeValue
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTReadBlobResponse: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count >= 1,
+            Self.validateOpcode(data)
+            else { return nil }
+        self.partAttributeValue = data.suffixCheckingBounds(from: 1)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.partAttributeValue
+    }
+    
+    public var dataLength: Int {
+        1 + partAttributeValue.count
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadByGroupTypeRequest.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadByGroupTypeRequest.swift
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Read by Group Type Request
+///
+/// The *Read By Group Type Request* is used to obtain the values of attributes where the attribute type is known,
+/// the type of a grouping attribute as defined by a higher layer specification, but the handle is not known.
+@frozen
+public struct ATTReadByGroupTypeRequest: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .readByGroupTypeRequest }
+    
+    /// First requested handle number.
+    public var startHandle: UInt16
+    
+    /// Last requested handle number.
+    public var endHandle: UInt16
+    
+    /// Attribute Group Type
+    ///
+    /// 2 or 16 octet UUID
+    public var type: BluetoothUUID
+    
+    public init(
+        startHandle: UInt16,
+        endHandle: UInt16,
+        type: BluetoothUUID
+    ) {
+        assert(type.dataLength != 4, "Cannot use 32-bit UUID")
+        self.startHandle = startHandle
+        self.endHandle = endHandle
+        self.type = type
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTReadByGroupTypeRequest: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard let length = Length(rawValue: data.count),
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        self.startHandle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+        self.endHandle = UInt16(littleEndian: UInt16(bytes: (data[3], data[4])))
+        
+        switch length {
+        case .uuid16:
+            let value = UInt16(littleEndian: UInt16(bytes: (data[5], data[6])))
+            self.type = .bit16(value)
+        case .uuid128:
+            self.type = BluetoothUUID(littleEndian: BluetoothUUID(data: data.subdata(in: 5 ..< 21))!)
+        }
+    }
+    
+    public var dataLength: Int {
+        return length.rawValue
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.startHandle.littleEndian
+        data += self.endHandle.littleEndian
+        data += self.type.littleEndian
+    }
+}
+
+// MARK: - Supporting Types
+
+fileprivate extension ATTReadByGroupTypeRequest {
+    
+    enum Length: Int {
+        
+        case uuid16     = 7
+        case uuid128    = 21
+    }
+    
+    var length: Length {
+        
+        switch type {
+        case .bit16:
+            return .uuid16
+        case .bit128:
+            return .uuid128
+        case .bit32:
+            assertionFailure("")
+            return .uuid128
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadByGroupTypeResponse.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadByGroupTypeResponse.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Read By Group Type Response
+///
+/// The *Read By Group Type Response* is sent in reply to a received *Read By Group Type Request*
+/// and contains the handles and values of the attributes that have been read.
+///
+/// - Note: The *Read Blob Request* would be used to read the remaining octets of a long attribute value.
+@frozen
+public struct ATTReadByGroupTypeResponse<Value: DataContainer>: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .readByGroupTypeResponse }
+    
+    /// A list of Attribute Data
+    public let attributeData: [AttributeData]
+    
+    public init?(attributeData: [AttributeData]) {
+        guard Self.validate(attributeData)
+            else { return nil }
+        self.attributeData = attributeData
+    }
+    
+    internal init(_ unsafe: [AttributeData]) {
+        self.attributeData = unsafe
+    }
+}
+
+extension ATTReadByGroupTypeResponse: ATTAttributeDataList { }
+
+// MARK: - DataConvertible
+
+extension ATTReadByGroupTypeResponse: DataConvertible {
+        
+    public init?<Data: DataContainer>(data: Data) {
+        guard let attributeData = ATTReadByGroupTypeResponse.from(data: data)
+            else { return nil }
+        self.attributeData = attributeData
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        Self.append(&data, self.attributeData)
+    }
+    
+    public var dataLength: Int {
+        Self.dataLength(for: attributeData)
+    }
+}
+
+// MARK: - Supporting Types
+
+public extension ATTReadByGroupTypeResponse {
+    
+    struct AttributeData: Equatable, Hashable, Sendable, ATTAttributeData {
+        
+        /// Attribute Handle
+        public var attributeHandle: UInt16
+        
+        /// End Group Handle
+        public var endGroupHandle: UInt16
+        
+        /// Attribute Value
+        public var value: Value
+        
+        public init(
+            attributeHandle: UInt16,
+            endGroupHandle: UInt16,
+            value: Value
+        ) {
+            self.attributeHandle = attributeHandle
+            self.endGroupHandle = endGroupHandle
+            self.value = value
+        }
+    }
+}
+
+extension ATTReadByGroupTypeResponse.AttributeData: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count >= 4
+            else { return nil }
+        
+        self.attributeHandle = UInt16(littleEndian: UInt16(bytes: (data[0], data[1])))
+        self.endGroupHandle = UInt16(littleEndian: UInt16(bytes: (data[2], data[3])))
+        self.value = data.suffixCheckingBounds(from: 4)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += attributeHandle.littleEndian
+        data += endGroupHandle.littleEndian
+        data += value
+    }
+    
+    public var dataLength: Int {
+        4 + value.count
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadByTypeRequest.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadByTypeRequest.swift
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Read By Type Request
+///
+/// The *Read By Type Request* is used to obtain the values of attributes where the
+/// attribute type is known but the handle is not known.
+@frozen
+public struct ATTReadByTypeRequest: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .readByTypeRequest }
+    
+    /// First requested handle number
+    public var startHandle: UInt16
+    
+    /// Last requested handle number
+    public var endHandle: UInt16
+    
+    /// 2 or 16 octet UUID
+    public var attributeType: BluetoothUUID
+    
+    public init(
+        startHandle: UInt16,
+        endHandle: UInt16,
+        attributeType: BluetoothUUID
+    ) {
+        assert(attributeType.dataLength != 4, "32-bit UUID not supported")
+        self.startHandle = startHandle
+        self.endHandle = endHandle
+        self.attributeType = attributeType
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTReadByTypeRequest: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard let length = Length(rawValue: data.count),
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        self.startHandle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+        self.endHandle = UInt16(littleEndian: UInt16(bytes: (data[3], data[4])))
+        
+        switch length {
+        case .uuid16:
+            let value = UInt16(littleEndian: UInt16(bytes: (data[5], data[6])))
+            self.attributeType = .bit16(value)
+        case .uuid128:
+            self.attributeType = BluetoothUUID(littleEndian: BluetoothUUID(data: data.subdata(in: 5 ..< length.rawValue))!)
+        }
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.startHandle.littleEndian
+        data += self.endHandle.littleEndian
+        data += self.attributeType.littleEndian
+    }
+    
+    public var dataLength: Int {
+        length.rawValue
+    }
+}
+
+// MARK: - Supporting Types
+
+internal extension ATTReadByTypeRequest {
+    
+    enum Length: Int {
+        
+        case uuid16     = 7
+        case uuid128    = 21
+    }
+    
+    private var length: Length {
+        switch attributeType {
+        case .bit16:
+            return .uuid16
+        case .bit128:
+            return .uuid128
+        case .bit32:
+            fatalError() // Do not allow 32-bit UUID for Blueooth LE
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadByTypeResponse.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadByTypeResponse.swift
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Read By Type Response
+///
+/// The *Read By Type Response* is sent in reply to a received *Read By Type Request*
+/// and contains the handles and values of the attributes that have been read.
+@frozen
+public struct ATTReadByTypeResponse <Value: DataContainer>: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .readByTypeResponse }
+    
+    /// A list of Attribute Data.
+    public let attributeData: [AttributeData]
+    
+    public init?(attributeData: [AttributeData]) {
+        
+        guard Self.validate(attributeData)
+            else { return nil }
+        
+        self.attributeData = attributeData
+    }
+    
+    internal init(_ unsafe: [AttributeData]) {
+        self.attributeData = unsafe
+    }
+}
+
+extension ATTReadByTypeResponse: ATTAttributeDataList { }
+
+// MARK: - DataConvertible
+
+extension ATTReadByTypeResponse: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        guard let attributeData = ATTReadByTypeResponse.from(data: data)
+            else { return nil }
+        self.attributeData = attributeData
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        Self.append(&data, self.attributeData)
+    }
+    
+    public var dataLength: Int {
+        Self.dataLength(for: attributeData)
+    }
+}
+
+// MARK: - Supporting Types
+
+public extension ATTReadByTypeResponse {
+    
+    /// Attribute handle and value pair.
+    struct AttributeData: Equatable, Hashable, Sendable, ATTAttributeData {
+        
+        /// Attribute Handle
+        public let handle: UInt16
+        
+        /// Attribute Value
+        public let value: Value
+        
+        public init(handle: UInt16, value: Value) {
+            self.handle = handle
+            self.value = value
+        }
+    }
+}
+
+extension ATTReadByTypeResponse.AttributeData: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count >= 2
+            else { return nil }
+        
+        self.handle = UInt16(littleEndian: UInt16(bytes: (data[0], data[1])))
+        self.value = data.suffixCheckingBounds(from: 2)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += handle.littleEndian
+        data += value
+    }
+    
+    public var dataLength: Int {
+        2 + value.count
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadMultipleRequest.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadMultipleRequest.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Read Multiple Request
+///
+/// The *Read Multiple Request* is used to request the server to read two or more values
+/// of a set of attributes and return their values in a *Read Multiple Response*.
+///
+/// Only values that have a known fixed size can be read, with the exception of the last value that can have a variable length.
+/// The knowledge of whether attributes have a known fixed size is defined in a higher layer specification.
+@frozen
+public struct ATTReadMultipleRequest: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .readMultipleRequest }
+    
+    /// The handles of the attributes to read.
+    public let handles: [UInt16]
+    
+    public init?(handles: [UInt16]) {
+        guard handles.count >= 2
+            else { return nil }
+        self.handles = handles
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTReadMultipleRequest: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count >= 5,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        let handleCount = (data.count - 1) / 2
+        
+        guard (data.count - 1) % 2 == 0
+            else { return nil }
+        
+        // preallocate handle buffer
+        let handles = (0 ..< handleCount).map { index in
+            let handleIndex = 1 + (index * 2)
+            return UInt16(littleEndian: UInt16(bytes: (data[handleIndex], data[handleIndex + 1])))
+        }
+        
+        self.init(handles: handles)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.handles
+    }
+    
+    public var dataLength: Int {
+        1 + (2 * handles.count)
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadMultipleResponse.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadMultipleResponse.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Read Multiple Response
+///
+/// The read response is sent in reply to a received *Read Multiple Request* and
+/// contains the values of the attributes that have been read.
+@frozen
+public struct ATTReadMultipleResponse<Values: DataContainer>: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { return .readMultipleResponse }
+    
+    public var values: Values
+    
+    public init(values: Values) {
+        self.values = values
+    }
+}
+
+extension ATTReadMultipleResponse: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        guard Self.validateOpcode(data)
+            else { return nil }
+        self.values = data.suffixCheckingBounds(from: 1)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.values
+    }
+    
+    public var dataLength: Int {
+        1 + values.count
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadRequest.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadRequest.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Read Request
+///
+/// The *Read Request* is used to request the server to read the value of an attribute
+/// and return its value in a *Read Response*.
+@frozen
+public struct ATTReadRequest: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .readRequest }
+    
+    /// The handle of the attribute to read.
+    public var handle: UInt16
+    
+    public init(handle: UInt16) {
+        self.handle = handle
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTReadRequest: DataConvertible {
+    
+    public static var length: Int { 3 }
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count == Self.length,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        self.handle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.handle.littleEndian
+    }
+    
+    public var dataLength: Int {
+        Self.length
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadResponse.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTReadResponse.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Read Response
+///
+/// The *Read Response* is sent in reply to a received *Read Request* and contains
+/// the value of the attribute that has been read.
+///
+/// - Note: The *Read Blob Request* would be used to read the remaining octets of a long attribute value.
+@frozen
+public struct ATTReadResponse<Value: DataContainer>: ATTProtocolDataUnit, Equatable {
+    
+    public static var attributeOpcode: ATTOpcode { return .readResponse }
+    
+    /// The value of the attribute with the handle given.
+    public var attributeValue: Value
+    
+    public init(attributeValue: Value) {
+        self.attributeValue = attributeValue
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTReadResponse: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count >= 1,
+            Self.validateOpcode(data)
+            else { return nil }
+        self.attributeValue = data.suffixCheckingBounds(from: 1)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.attributeValue
+    }
+    
+    public var dataLength: Int {
+        return 1 + attributeValue.count
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTSignedWriteCommand.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTSignedWriteCommand.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Signed Write Command
+///
+/// The Signed Write Command is used to request the server to write the value of an attribute with an authentication signature,
+/// typically into a control-point attribute.
+@frozen
+public struct ATTSignedWriteCommand<Value: DataContainer>: ATTProtocolDataUnit {
+    
+    public typealias Signature = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+    
+    public static var attributeOpcode: ATTOpcode { .signedWriteCommand }
+    
+    /// The handle of the attribute to be set.
+    public var handle: UInt16
+    
+    /// The value to be written to the attribute
+    public var value: Value
+    
+    /// Authentication signature for the Attribute Upload, Attribute Handle and Attribute Value Parameters.
+    public var signature: Signature
+    
+    public init(
+        handle: UInt16,
+        value: Value,
+        signature: Signature
+    ) {
+        self.handle = handle
+        self.value = value
+        self.signature = signature
+    }
+}
+
+extension ATTSignedWriteCommand: DataConvertible {
+    
+    /// Minimum length
+    internal static var minimumLength: Int { 15 }
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count >= Self.minimumLength,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        self.handle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+        
+        if data.count > Self.minimumLength {
+            self.value = Value(data[3 ..< data.count - 12])
+            
+        } else {
+            self.value = Value()
+        }
+        
+        self.signature = (data[data.count - 12],
+                          data[data.count - 11],
+                          data[data.count - 10],
+                          data[data.count - 9],
+                          data[data.count - 8],
+                          data[data.count - 7],
+                          data[data.count - 6],
+                          data[data.count - 5],
+                          data[data.count - 4],
+                          data[data.count - 3],
+                          data[data.count - 2],
+                          data[data.count - 1])
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += handle.littleEndian
+        data += value
+        data += signature
+    }
+    
+    public var dataLength: Int {
+        Self.minimumLength + value.count
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTWriteCommand.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTWriteCommand.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Write Command
+///
+/// The *Write Command* is used to request the server to write the value of an attribute, typically into a control-point attribute.
+@frozen
+public struct ATTWriteCommand<Value: DataContainer>: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .writeCommand }
+    
+    /// The handle of the attribute to be set.
+    public var handle: UInt16
+    
+    /// The value of be written to the attribute.
+    public var value: Value
+    
+    public init(
+        handle: UInt16,
+        value: Value
+    ) {
+        self.handle = handle
+        self.value = value
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTWriteCommand: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count >= 3,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        self.handle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+        self.value = data.suffixCheckingBounds(from: 3)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+        data += self.handle.littleEndian
+        data += self.value
+    }
+    
+    public var dataLength: Int {
+        return 3 + value.count
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTWriteRequest.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTWriteRequest.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Write Request
+///
+/// The *Write Request* is used to request the server to write the value of an attribute
+/// and acknowledge that this has been achieved in a *Write Response*.
+@frozen
+public struct ATTWriteRequest<Value: DataContainer>: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .writeRequest }
+    
+    /// The handle of the attribute to be written.
+    public var handle: UInt16
+    
+    /// The value to be written to the attribute.
+    public var value: Value
+    
+    public init(
+        handle: UInt16,
+        value: Value
+    ) {
+        self.handle = handle
+        self.value = value
+    }
+}
+
+extension ATTWriteRequest: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+
+        guard data.count >= 3,
+            Self.validateOpcode(data)
+            else { return nil }
+        
+        self.handle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+        self.value = data.suffixCheckingBounds(from: 3)
+    }
+    
+    public var dataLength: Int {
+        return 3 + value.count
+    }
+    
+    public func append<Data: DataContainer>(to data: inout Data) {
+        data += Self.attributeOpcode.rawValue
+        data += self.handle.littleEndian
+        data += self.value
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTWriteResponse.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/ATTWriteResponse.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Write Response
+///
+/// The *Write Response* is sent in reply to a valid *Write Request*
+/// and acknowledges that the attribute has been successfully written.
+@frozen
+public struct ATTWriteResponse: ATTProtocolDataUnit, Sendable {
+    
+    public static var attributeOpcode: ATTOpcode { .writeResponse }
+    
+    public init() { }
+}
+
+extension ATTWriteResponse: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count == 1,
+            Self.validateOpcode(data)
+            else { return nil }
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += Self.attributeOpcode.rawValue
+    }
+    
+    public var dataLength: Int { 1 }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTAttributes.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTAttributes.swift
@@ -1,0 +1,122 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// GATT Attribute
+@frozen
+public enum GATTAttribute <Data: DataContainer>: Equatable, Hashable, Sendable {
+    
+    case service(Service)
+    case include(Include)
+    case characteristic(Characteristic)
+    case descriptor(Descriptor)
+}
+
+public extension GATTAttribute {
+    
+    typealias Permissions = ATTAttributePermissions
+    
+    /// GATT Service
+    struct Service: Equatable, Hashable, Sendable {
+        
+        public var uuid: BluetoothUUID
+        
+        public var isPrimary: Bool
+        
+        public var characteristics: [Characteristic]
+        
+        public var includedServices: [Include]
+        
+        public init(
+            uuid: BluetoothUUID,
+            isPrimary: Bool = true,
+            characteristics: [Characteristic] = [],
+            includedServices: [Include] = []
+        ) {
+            self.uuid = uuid
+            self.characteristics = characteristics
+            self.isPrimary = isPrimary
+            self.includedServices = includedServices
+        }
+    }
+    
+    /// GATT Include Declaration
+    struct Include: Equatable, Hashable, Sendable {
+        
+        /// Included service handle
+        public var serviceHandle: UInt16
+        
+        /// End group handle
+        public var endGroupHandle: UInt16
+        
+        /// Included Service UUID
+        public var serviceUUID: BluetoothUUID
+        
+        public init(
+            serviceHandle: UInt16,
+            endGroupHandle: UInt16,
+            serviceUUID: BluetoothUUID
+        ) {
+            self.serviceHandle = serviceHandle
+            self.endGroupHandle = endGroupHandle
+            self.serviceUUID = serviceUUID
+        }
+    }
+    
+    /// GATT Characteristic
+    struct Characteristic: Equatable, Hashable, Sendable {
+        
+        public typealias Properties = GATTCharacteristicProperties
+        
+        public var uuid: BluetoothUUID
+        
+        public var value: Data
+        
+        public var permissions: Permissions
+        
+        public var properties: Properties
+        
+        public var descriptors: [Descriptor]
+        
+        public init(
+            uuid: BluetoothUUID,
+            value: Data = Data(),
+            permissions: Permissions = [.read],
+            properties: Properties = [.read],
+            descriptors: [Descriptor] = []
+        ) {
+            self.uuid = uuid
+            self.value = value
+            self.permissions = permissions
+            self.descriptors = descriptors
+            self.properties = properties
+        }
+    }
+    
+    /// GATT Characteristic Descriptor
+    struct Descriptor: Equatable, Hashable, Sendable {
+                
+        public var uuid: BluetoothUUID
+        
+        public var value: Data
+        
+        public var permissions: Permissions
+        
+        public init(
+            uuid: BluetoothUUID = BluetoothUUID(),
+            value: Data = Data(),
+            permissions: Permissions = [.read]
+        ) {
+            self.uuid = uuid
+            self.value = value
+            self.permissions = permissions
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTCharacteristicProperties.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTCharacteristicProperties.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// GATT Characteristic Properties Bitfield values
+public struct GATTCharacteristicProperties: OptionSet, Hashable, Sendable {
+    
+    public var rawValue: UInt8
+    
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension GATTCharacteristicProperties: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral value: UInt8) {
+        self.rawValue = value
+    }
+}
+
+// MARK: CustomStringConvertible
+
+extension GATTCharacteristicProperties: CustomStringConvertible, CustomDebugStringConvertible {
+    
+    #if hasFeature(Embedded)
+    public var description: String {
+        "0x" + rawValue.toHexadecimal()
+    }
+    #else
+    @inline(never)
+    public var description: String {
+        let descriptions: [(GATTCharacteristicProperties, StaticString)] = [
+            (.broadcast,            ".broadcast"),
+            (.read,                 ".read"),
+            (.write,                ".write"),
+            (.notify,               ".notify"),
+            (.indicate,             ".indicate"),
+            (.signedWrite,          ".signedWrite"),
+            (.extendedProperties,   ".extendedProperties")
+        ]
+        return buildDescription(descriptions)
+    }
+    #endif
+
+    /// A textual representation of the file permissions, suitable for debugging.
+    public var debugDescription: String { self.description }
+}
+
+// MARK: - Options
+
+public extension GATTCharacteristicProperties {
+    
+    static var broadcast: GATTCharacteristicProperties            { 0x01 }
+    static var read: GATTCharacteristicProperties                 { 0x02 }
+    static var writeWithoutResponse: GATTCharacteristicProperties { 0x04 }
+    static var write: GATTCharacteristicProperties                { 0x08 }
+    static var notify: GATTCharacteristicProperties               { 0x10 }
+    static var indicate: GATTCharacteristicProperties             { 0x20 }
+    
+    /// Characteristic supports write with signature
+    static var signedWrite: GATTCharacteristicProperties          { 0x40 } // BT_GATT_CHRC_PROP_AUTH
+    
+    static var extendedProperties: GATTCharacteristicProperties   { 0x80 }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTClientCharacteristicConfiguration.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTClientCharacteristicConfiguration.swift
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// GATT Client Characteristic Configuration Descriptor
+///
+/// The Client Characteristic Configuration descriptor defines how the characteristic may be
+/// configured by a specific client.
+///
+/// This descriptor shall be persistent across connections for bonded devices.
+/// The Client Characteristic Configuration descriptor is unique for each client.
+/// A client may read and write this descriptor to determine and set the configuration for that client.
+/// Authentication and authorization may be required by the server to write this descriptor.
+/// The default value for the Client Characteristic Configuration descriptor is `0x00`.
+/// Upon connection of non-binded clients, this descriptor is set to the default value.
+@frozen
+public struct GATTClientCharacteristicConfiguration: GATTDescriptor, OptionSet, Hashable, Sendable {
+    
+    public static var uuid: BluetoothUUID { .clientCharacteristicConfiguration }
+    
+    public var rawValue: UInt16
+    
+    public init(rawValue: UInt16) {
+        self.rawValue = rawValue
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension GATTClientCharacteristicConfiguration: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral rawValue: RawValue) {
+        self.init(rawValue: rawValue)
+    }
+}
+
+// MARK: - DataConvertible
+
+extension GATTClientCharacteristicConfiguration: DataConvertible {
+    
+    public static var length: Int { 2 }
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard data.count == Self.length
+            else { return nil }
+        
+        let rawValue = UInt16(littleEndian: UInt16(bytes: (data[0], data[1])))
+        self.init(rawValue: rawValue)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += rawValue.littleEndian
+    }
+    
+    public var dataLength: Int { Self.length }
+}
+
+// MARK: - Options
+
+public extension GATTClientCharacteristicConfiguration {
+    
+    /// Notifications enabled
+    static var notify: GATTClientCharacteristicConfiguration { 0b01 }
+    
+    /// Indications enabled
+    static var indicate: GATTClientCharacteristicConfiguration { 0b10 }
+}
+
+// MARK: - CustomStringConvertible
+
+extension GATTClientCharacteristicConfiguration: CustomStringConvertible, CustomDebugStringConvertible {
+    
+    #if hasFeature(Embedded)
+    public var description: String {
+        "0x" + rawValue.toHexadecimal()
+    }
+    #else
+    @inline(never)
+    public var description: String {
+        let descriptions: [(GATTClientCharacteristicConfiguration, StaticString)] = [
+            (.notify, ".notify"),
+            (.indicate, ".indicate")
+        ]
+        return buildDescription(descriptions)
+    }
+    #endif
+
+    /// A textual representation of the file permissions, suitable for debugging.
+    public var debugDescription: String { self.description }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTDatabase.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTDatabase.swift
@@ -1,0 +1,711 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// GATT Database
+public struct GATTDatabase<Data: DataContainer>: Equatable, Hashable, Sendable {
+    
+    // MARK: - Internal Properties
+    
+    internal private(set) var attributeGroups = [AttributeGroup]()
+    
+    /// Do not access directly, use `newHandle()`
+    internal private(set) var lastHandle: UInt16 = 0x0000
+    
+    // MARK: - Initialization
+    
+    /// Initialize empty database.
+    public init() { }
+    
+    /// Initialize database with the specified services.
+    public init(services: [GATTAttribute<Data>.Service]) {
+        services.forEach { add(service: $0) }
+    }
+    
+    // MARK: - Computed Properties
+    
+    /// Whether the database contains any attributes. 
+    public var isEmpty: Bool {
+        return attributeGroups.isEmpty
+    }
+    
+    /// Attribute representation of the database.
+    internal var attributes: [Attribute] {
+        let attributeCount = self.count
+        var attributes = [Attribute]()
+        attributes.reserveCapacity(attributeCount)
+        attributeGroups.forEach { attributes += $0.attributes }
+        assert(attributes.count == attributeCount)
+        return attributes
+    }
+    
+    /// Number of attributes in the database.
+    public var count: Int {
+        return attributeGroups.reduce(0) { $0 + $1.attributes.count }
+    }
+    
+    /// Returns the last attribute in the database.
+    public var first: Attribute? {
+        return attributeGroups.first?.attributes.first
+    }
+    
+    /// Returns the last attribute in the database.
+    public var last: Attribute? {
+        return attributeGroups.last?.attributes.last
+    }
+    
+    /// Whether the database contains an attribute with the specified handle.
+    public func contains(handle: UInt16) -> Bool {
+        for group in attributeGroups {
+            for attribute in group.attributes {
+                guard attribute.handle == handle
+                    else { continue }
+                return true
+            }
+        }
+        return false
+    }
+    
+    // MARK: - Methods
+    
+    @discardableResult
+    public mutating func add(service: GATTAttribute<Data>.Service) -> UInt16 {
+        var includedServicesHandles = [UInt16]()
+        var characteristicDeclarationHandles = [UInt16]()
+        var characteristicValueHandles = [UInt16]()
+        var descriptorHandles = [[UInt16]]()
+        return add(
+            service: service,
+            includedServicesHandles: &includedServicesHandles,
+            characteristicDeclarationHandles: &characteristicDeclarationHandles,
+            characteristicValueHandles: &characteristicValueHandles,
+            descriptorHandles: &descriptorHandles
+        )
+    }
+    
+    @discardableResult
+    public mutating func add(
+        service: GATTAttribute<Data>.Service,
+        includedServicesHandles: inout [UInt16],
+        characteristicDeclarationHandles: inout [UInt16],
+        characteristicValueHandles: inout [UInt16],
+        descriptorHandles: inout [[UInt16]]
+    ) -> UInt16 {
+        
+        let serviceAttribute = ServiceAttribute(
+            handle: self.newHandle(),
+            uuid: service.uuid,
+            isPrimary: service.isPrimary
+        )
+        
+        var attributes = [serviceAttribute.attribute]
+        let descriptorsCount = service.characteristics.reduce(0, { $0 + $1.descriptors.count })
+        let attributeCount = 1 + service.includedServices.count + (service.characteristics.count * 2) + descriptorsCount
+        attributes.reserveCapacity(attributeCount)
+        
+        includedServicesHandles.reserveCapacity(service.includedServices.count)
+        for includedService in service.includedServices {
+            let handle = self.newHandle()
+            let includedServiceAttribute = IncludedServiceAttribute(
+                include: includedService,
+                handle: handle
+            )
+            attributes.append(includedServiceAttribute.attribute)
+        }
+        assert(includedServicesHandles.count == service.includedServices.count)
+        
+        characteristicDeclarationHandles.reserveCapacity(service.characteristics.count)
+        characteristicValueHandles.reserveCapacity(service.characteristics.count)
+        
+        for characteristic in service.characteristics {
+            
+            let declarationHandle = self.newHandle()
+            characteristicDeclarationHandles.append(declarationHandle)
+            
+            let valueHandle = self.newHandle()
+            characteristicValueHandles.append(valueHandle)
+            
+            let declarationAttribute = CharacteristicDeclarationAttribute(
+                handle: declarationHandle,
+                valueHandle: valueHandle,
+                uuid: characteristic.uuid,
+                properties: characteristic.properties
+            )
+            
+            let valueAttribute = CharacteristicValueAttribute(
+                handle: valueHandle,
+                value: characteristic.value,
+                uuid: characteristic.uuid,
+                permissions: characteristic.permissions
+            )
+            
+            attributes += [declarationAttribute.attribute, valueAttribute.attribute]
+            
+            var characteristicDescriptorHandles = [UInt16]()
+            characteristicDescriptorHandles.reserveCapacity(characteristic.descriptors.count)
+            for descriptor in characteristic.descriptors {
+                let descriptorHandle = self.newHandle()
+                let descriptorAttribute = DescriptorAttribute(
+                    descriptor: descriptor,
+                    handle: descriptorHandle
+                )
+                characteristicDescriptorHandles.append(descriptorHandle)
+                attributes.append(descriptorAttribute.attribute)
+            }
+            descriptorHandles.append(characteristicDescriptorHandles)
+            assert(characteristicDescriptorHandles.count == characteristic.descriptors.count)
+        }
+        
+        assert(descriptorHandles.count == service.characteristics.count)
+        assert(attributes.count == attributeCount)
+        
+        attributeGroups.append(AttributeGroup(attributes: attributes))
+        return serviceAttribute.handle
+    }
+    
+    /// Clear the database.
+    public mutating func removeAll() {
+        self.attributeGroups = []
+    }
+    
+    /// Remove the Service with the specified handl.
+    public mutating func remove(service handle: UInt16) {
+        
+        guard let serviceIndex = attributeGroups.firstIndex(where: { $0.serviceAttribute.handle == handle })
+            else { fatalError("Service with handle doesnt exist") }
+        
+        attributeGroups.remove(at: serviceIndex)
+    }
+    
+    /// Write the value to attribute specified by the handle.
+    public mutating func write(_ value: Data, forAttribute handle: UInt16) {
+        self[handle: handle].value = value
+    }
+    
+    /// The handle of the service at the specified index.
+    public func serviceHandles(at index: Int) -> (start: UInt16, end: UInt16) {
+        let service = attributeGroups[index]
+        return (service.startHandle, service.endHandle)
+    }
+    
+    // MARK: - Subscripting
+    
+    /// The attribute at the specified index.
+    public subscript(index: Int) -> GATTDatabase.Attribute {
+        var cursor = 0
+        for group in attributeGroups {
+            for attribute in group.attributes {
+                guard cursor == index else {
+                    cursor += 1
+                    continue
+                }
+                assert(self.attributes[index] == attribute)
+                return attribute
+            }
+        }
+        fatalError("Invalid attribute index")
+    }
+    
+    /// The attribute with the specified handle.
+    public private(set) subscript(handle handle: UInt16) -> GATTDatabase.Attribute {
+        
+        get {
+            for group in attributeGroups {
+                for attribute in group.attributes {
+                    guard attribute.handle != handle
+                        else { return attribute }
+                }
+            }
+            
+            fatalError("Invalid handle")
+        }
+        
+        mutating set {
+            
+            for (groupIndex, group) in attributeGroups.enumerated() {
+                for (attributeIndex, attribute) in group.attributes.enumerated() {
+                    guard attribute.handle != handle else {
+                        attributeGroups[groupIndex].attributes[attributeIndex] = newValue
+                        return
+                    }
+                }
+            }
+            
+            fatalError("Invalid handle")
+        }
+    }
+    
+    // MARK: - Private Methods
+    
+    private mutating func newHandle() -> UInt16 {
+        // starts at 0x0001
+        lastHandle += 1
+        return lastHandle
+    }
+}
+
+// MARK: - ExpressibleByArrayLiteral
+
+extension GATTDatabase: ExpressibleByArrayLiteral {
+    
+    public init(arrayLiteral elements: GATTAttribute<Data>.Service...) {
+        self.init(services: elements)
+    }
+}
+
+// MARK: - Sequence
+
+extension GATTDatabase: Sequence {
+    
+    public typealias Element = GATTDatabase.Attribute
+    
+    public func makeIterator() -> IndexingIterator<GATTDatabase> {
+        return IndexingIterator(_elements: self)
+    }
+}
+
+// MARK: - Collection
+
+extension GATTDatabase: Collection {
+    
+    public func index(after index: Int) -> Int {
+        return index + 1
+    }
+    
+    public var startIndex: Int {
+        return 0
+    }
+    
+    public var endIndex: Int {
+        return count
+    }
+}
+
+// MARK: - RandomAccessCollection
+
+extension GATTDatabase: RandomAccessCollection {
+    
+    public subscript(bounds: Range<Int>) -> Slice<GATTDatabase> {
+        return Slice<GATTDatabase>(base: self, bounds: bounds)
+    }
+}
+
+// MARK: - Supporting Types
+
+public extension GATTDatabase {
+    
+    /// ATT Attribute
+    struct Attribute: Equatable, Hashable, Sendable {
+        
+        public typealias Permissions = ATTAttributePermissions
+        
+        public let handle: UInt16
+        
+        public let uuid: BluetoothUUID
+        
+        public let permissions: Permissions
+        
+        public var value: Data
+        
+        /// Defualt initializer
+        public init(
+            handle: UInt16,
+            uuid: BluetoothUUID,
+            value: Data = Data(),
+            permissions: Permissions = []
+        ) {
+            self.handle = handle
+            self.uuid = uuid
+            self.value = value
+            self.permissions = permissions
+        }
+    }
+}
+
+// MARK: - Private Supporting Types
+
+internal extension GATTDatabase {
+    
+    /// Internal Representation of a GATT Service. 
+    ///
+    ///- Note: For use with `GATTDatabase` only.
+    struct AttributeGroup: Equatable, Hashable, Sendable {
+        
+        var attributes: [Attribute]
+        
+        var startHandle: UInt16 {
+            return attributes[0].handle
+        }
+        
+        var endHandle: UInt16 {
+            return attributes.last!.handle
+        }
+        
+        var serviceAttribute: Attribute {
+            return attributes[0]
+        }
+        
+        var service: GATTAttribute<Data>.Service? {
+            
+            guard let serviceAttribute = ServiceAttribute(attribute: self.serviceAttribute)
+                else { return nil }
+            
+            var service = GATTAttribute<Data>.Service(
+                uuid: serviceAttribute.uuid,
+                isPrimary: serviceAttribute.isPrimary
+            )
+            
+            guard attributes.count > 1
+                else { return service }
+            
+            var characteristicValueHandles = Set<UInt16>()
+            
+            for attribute in attributes.suffix(from: 1) {
+                
+                if attribute.uuid == .include {
+                    
+                    guard let includeAttribute = IncludedServiceAttribute(attribute: attribute)
+                        else { return nil }
+                    
+                    let include = GATTAttribute<Data>.Include(serviceHandle: includeAttribute.serviceHandle,
+                                               endGroupHandle: includeAttribute.endGroupHandle,
+                                               serviceUUID: includeAttribute.uuid)
+                    
+                    service.includedServices.append(include)
+                    
+                } else if attribute.uuid == .characteristic {
+                    
+                    guard let characteristicAttribute = CharacteristicDeclarationAttribute(attribute: attribute)
+                        else { return nil }
+                    
+                    let valueHandle = characteristicAttribute.valueHandle
+                    
+                    characteristicValueHandles.insert(valueHandle)
+                    
+                    guard let valueAttribute = attributes.first(where: { $0.handle == valueHandle })
+                        else { return nil }
+                    
+                    let characteristicValueAttribute = CharacteristicValueAttribute(attribute: valueAttribute)
+                    
+                    let characteristic = GATTAttribute<Data>.Characteristic(uuid: characteristicAttribute.uuid,
+                                                             value: characteristicValueAttribute.value,
+                                                             permissions: characteristicValueAttribute.permissions, properties: characteristicAttribute.properties, descriptors: [])
+                    
+                    service.characteristics.append(characteristic)
+                    
+                } else if characteristicValueHandles.contains(attribute.handle) {
+                    
+                    continue
+                    
+                } else {
+                    
+                    let descriptorAttribute = DescriptorAttribute(attribute: attribute)
+                    
+                    let descriptor = GATTAttribute<Data>.Descriptor(
+                        uuid: descriptorAttribute.uuid,
+                        value: descriptorAttribute.value,
+                        permissions: descriptorAttribute.permissions
+                    )
+                    
+                    guard service.characteristics.isEmpty == false
+                        else { return nil }
+                    
+                    let lastIndex = service.characteristics.count - 1
+                    service.characteristics[lastIndex].descriptors.append(descriptor)
+                }
+            }
+            
+            return service
+        }
+    }
+    
+    struct ServiceAttribute: Equatable, Hashable, Sendable {
+        
+        /// Attribute Handle
+        var handle: UInt16
+        
+        /// Service UUID
+        var uuid: BluetoothUUID
+        
+        /// Primary or Secondary Service
+        var isPrimary: Bool
+        
+        init(handle: UInt16, uuid: BluetoothUUID, isPrimary: Bool) {
+            
+            self.handle = handle
+            self.uuid = uuid
+            self.isPrimary = isPrimary
+        }
+        
+        init?(attribute: Attribute) {
+            
+            assert(attribute.permissions == [.read], "Invalid attribute permissions")
+            
+            guard let serviceUUIDLittleEndian = BluetoothUUID(data: attribute.value)
+                else { return nil }
+            
+            let serviceUUID = BluetoothUUID(littleEndian: serviceUUIDLittleEndian)
+            
+            let isPrimary: Bool
+            
+            switch attribute.uuid {
+            case .primaryService:
+                isPrimary = true
+            case .secondaryService:
+                isPrimary = false
+            default:
+                return nil // invalid uuid
+            }
+            
+            self.handle = attribute.handle
+            self.uuid = serviceUUID
+            self.isPrimary = isPrimary
+        }
+        
+        var attribute: Attribute {
+            
+            let serviceUUID: BluetoothUUID = isPrimary ? .primaryService : .secondaryService
+            
+            return Attribute(
+                handle: handle,
+                uuid: serviceUUID,
+                value: Data(self.uuid.littleEndian),
+                permissions: [.read]
+            )
+        }
+    }
+    
+    struct IncludedServiceAttribute {
+        
+        static var uuid: BluetoothUUID { .include }
+        
+        /// Attribute Handle
+        var handle: UInt16
+        
+        /// Included Service UUID
+        var uuid: BluetoothUUID
+        
+        /// Included service handle
+        var serviceHandle: UInt16
+        
+        /// End group handle
+        var endGroupHandle: UInt16
+        
+        init(handle: UInt16, uuid: BluetoothUUID, serviceHandle: UInt16, endGroupHandle: UInt16) {
+            
+            self.handle = handle
+            self.uuid = uuid
+            self.serviceHandle = serviceHandle
+            self.endGroupHandle = endGroupHandle
+        }
+        
+        init(include: GATTAttribute<Data>.Include, handle: UInt16) {
+            
+            self.handle = handle
+            self.serviceHandle = include.serviceHandle
+            self.endGroupHandle = include.endGroupHandle
+            self.uuid = include.serviceUUID
+        }
+        
+        init?(attribute: Attribute) {
+            
+            guard attribute.uuid == Self.uuid,
+                let _ = Length(rawValue: attribute.value.count)
+                else { return nil }
+            
+            assert(attribute.permissions == [.read], "Invalid attribute permissions")
+            
+            let serviceHandle = UInt16(littleEndian: UInt16(bytes: (attribute.value[0], attribute.value[1])))
+            let endGroupHandle = UInt16(littleEndian: UInt16(bytes: (attribute.value[2], attribute.value[3])))
+            let uuid = BluetoothUUID(littleEndian: BluetoothUUID(data: Data(attribute.value.suffix(from: 4)))!)
+            
+            self.serviceHandle = serviceHandle
+            self.endGroupHandle = endGroupHandle
+            self.uuid = uuid
+            self.handle = attribute.handle
+        }
+        
+        var attribute: Attribute {
+            
+            var data = Data()
+            data.reserveCapacity(4 + uuid.dataLength)
+            data += serviceHandle.littleEndian
+            data += endGroupHandle.littleEndian
+            data += uuid.littleEndian
+            
+            return Attribute(handle: handle,
+                             uuid: Self.uuid,
+                             value: data,
+                             permissions: [.read])
+        }
+        
+        enum Length: Int {
+            
+            case bit16 = 6
+            case bit128 = 20
+        }
+    }
+    
+    struct CharacteristicDeclarationAttribute: Equatable, Hashable, Sendable {
+        
+        static var uuid: BluetoothUUID { .characteristic }
+        
+        typealias Properties = GATTAttribute<Data>.Characteristic.Properties
+        
+        /// Characteristic UUID
+        var uuid: BluetoothUUID
+        
+        /// Characteristic Properties
+        var properties: Properties
+        
+        /// Attribute Handle
+        var handle: UInt16
+        
+        /// Characteristic Value Handle
+        var valueHandle: UInt16
+        
+        init(
+            handle: UInt16,
+            valueHandle: UInt16,
+            uuid: BluetoothUUID,
+            properties: Properties
+        ) {
+            self.handle = handle
+            self.valueHandle = valueHandle
+            self.uuid = uuid
+            self.properties = properties
+        }
+        
+        init?(attribute: Attribute) {
+            
+            guard attribute.uuid == Self.uuid,
+                let length = Length(rawValue: attribute.value.count)
+                else { return nil }
+            
+            assert(attribute.permissions == [.read], "Invalid attribute permissions")
+            
+            let properties = Properties(rawValue: attribute.value[0])
+            let valueHandle = UInt16(littleEndian: UInt16(bytes: (attribute.value[1], attribute.value[2])))
+            let uuid = BluetoothUUID(littleEndian: BluetoothUUID(data: attribute.value.subdata(in: 3 ..< length.rawValue))!)
+            
+            self.uuid = uuid
+            self.properties = properties
+            self.valueHandle = valueHandle
+            self.handle = attribute.handle
+        }
+        
+        var attribute: Attribute {
+            
+            var data = Data()
+            data.reserveCapacity(3 + uuid.dataLength)
+            data += properties.rawValue
+            data += valueHandle.littleEndian
+            data += uuid.littleEndian
+            
+            return Attribute(
+                handle: handle,
+                uuid: Self.uuid,
+                value: data,
+                permissions: [.read]
+            )
+        }
+        
+        private enum Length: Int {
+            
+            case bit16 = 5
+            case bit128 = 19
+        }
+    }
+    
+    struct CharacteristicValueAttribute: Equatable, Hashable, Sendable {
+        
+        typealias Permissions = ATTAttributePermissions
+        
+        /// Characteristic UUID
+        var uuid: BluetoothUUID
+        
+        /// Characteristic Value Data
+        var value: Data
+        
+        /// Characteristic Value Permissions
+        var permissions: Permissions
+        
+        /// Attribute Handle
+        var handle: UInt16
+        
+        init(handle: UInt16,
+             value: Data,
+             uuid: BluetoothUUID,
+             permissions: Permissions) {
+            
+            self.handle = handle
+            self.value = value
+            self.uuid = uuid
+            self.permissions = permissions
+        }
+        
+        init(attribute: Attribute) {
+            
+            self.uuid = attribute.uuid
+            self.value = attribute.value
+            self.permissions = attribute.permissions
+            self.handle = attribute.handle
+        }
+        
+        var attribute: Attribute {
+            
+            return Attribute(handle: handle,
+                             uuid: uuid,
+                             value: value,
+                             permissions: permissions)
+        }
+    }
+    
+    struct DescriptorAttribute: Equatable, Hashable, Sendable {
+        
+        typealias Permissions = ATTAttributePermissions
+        
+        /// Attribute Handle
+        var handle: UInt16
+        
+        /// Descriptor UUID
+        var uuid: BluetoothUUID
+        
+        /// Descriptor Value
+        var value: Data
+        
+        /// Descriptor Permissions
+        var permissions: Permissions
+        
+        init(descriptor: GATTAttribute<Data>.Descriptor, handle: UInt16) {
+            
+            self.handle = handle
+            self.uuid = descriptor.uuid
+            self.value = descriptor.value
+            self.permissions = descriptor.permissions
+        }
+        
+        init(attribute: Attribute) {
+            
+            self.uuid = attribute.uuid
+            self.value = attribute.value
+            self.permissions = attribute.permissions
+            self.handle = attribute.handle
+        }
+        
+        var attribute: Attribute {
+            
+            return Attribute(handle: handle,
+                             uuid: uuid,
+                             value: value,
+                             permissions: permissions)
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTDescriptor.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTDescriptor.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// GATT Characteristic Descriptor
+public protocol GATTDescriptor: DataConvertible {
+    
+    /// Bluetooth UUID of the descriptor.
+    static var uuid: BluetoothUUID { get }
+    
+    /// Decode from data.
+    init?<Data: DataContainer>(data: Data)
+    
+    /// Encode to data.
+    func append<Data: DataContainer>(to data: inout Data)
+}
+
+public extension GATTAttribute.Descriptor {
+    
+    init<Descriptor: GATTDescriptor>(
+        _ descriptor: Descriptor,
+        permissions: ATTAttributePermissions = [.read]
+    ) {
+        self.init(
+            uuid: Descriptor.uuid,
+            value: Data(descriptor),
+            permissions: permissions
+        )
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTServer.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTServer.swift
@@ -1,0 +1,873 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// GATT Server
+///
+/// - Note: Doesn't support concurrency to enable building for Embedded Swift.
+public final class GATTServer <Socket: L2CAPConnection> {
+    
+    public typealias Data = Socket.Data
+    
+    public typealias Error = ATTConnectionError<Socket.Error, Socket.Data>
+    
+    // MARK: - Properties
+        
+    public var maximumTransmissionUnit: ATTMaximumTransmissionUnit {
+        self.connection.maximumTransmissionUnit
+    }
+    
+    public let preferredMaximumTransmissionUnit: ATTMaximumTransmissionUnit
+    
+    public let maximumPreparedWrites: Int
+    
+    public var database: GATTDatabase<Data>
+    
+    internal let log: ((String) -> ())?
+    
+    public var callback = Callback()
+    
+    internal var connection: ATTConnection<Socket>
+    
+    internal private(set) var preparedWrites = [PreparedWrite]()
+    
+    // MARK: - Initialization
+    
+    public init(
+        socket: Socket,
+        maximumTransmissionUnit: ATTMaximumTransmissionUnit = .default,
+        maximumPreparedWrites: Int = 50,
+        database: GATTDatabase<Data> = GATTDatabase<Data>(),
+        log: ((String) -> ())?
+    ) {
+        // set initial MTU and register handlers
+        self.maximumPreparedWrites = maximumPreparedWrites
+        self.preferredMaximumTransmissionUnit = maximumTransmissionUnit
+        self.database = database
+        self.connection = ATTConnection(
+            socket: socket,
+            log: log
+        )
+        self.log = log
+        // register handlers
+        self.registerATTHandlers()
+    }
+    
+    deinit {
+        connection.socket.close()
+    }
+    
+    // MARK: - Methods
+    
+    public func run() throws(ATTConnectionError<Socket.Error, Socket.Data>) {
+        try connection.run()
+    }
+    
+    /// Update the value of a characteristic attribute.
+    public func writeValue(_ value: Data, forCharacteristic handle: UInt16) {
+        database.write(value, forAttribute: handle)
+        didWriteAttribute(handle, isLocalWrite: true)
+    }
+    
+    /// Update the value of a characteristic attribute.
+    public func writeValue(_ value: Data, forCharacteristic uuid: BluetoothUUID) {
+        guard let attribute = database.first(where: { $0.uuid == uuid })
+            else { fatalError("Invalid uuid") }
+        writeValue(value, forCharacteristic: attribute.handle)
+    }
+    
+    // MARK: - Private Methods
+    
+    private func registerATTHandlers() {
+        
+        // Exchange MTU
+        connection.register { self.exchangeMTU($0) }
+        
+        // Read By Group Type
+        connection.register { self.readByGroupType($0) }
+        
+        // Read By Type
+        connection.register { self.readByType($0) }
+        
+        // Find Information
+        connection.register { self.findInformation($0) }
+        
+        // Find By Type Value
+        connection.register { self.findByTypeValue($0) }
+        
+        // Write Request
+        connection.register { self.writeRequest($0) }
+        
+        // Write Command
+        connection.register { self.writeCommand($0) }
+        
+        // Read Request
+        connection.register { self.readRequest($0) }
+        
+        // Read Blob Request
+        connection.register { self.readBlobRequest($0) }
+        
+        // Read Multiple Request
+        connection.register { self.readMultipleRequest($0) }
+        
+        // Prepare Write Request
+        connection.register { self.prepareWriteRequest($0) }
+        
+        // Execute Write Request
+        connection.register { self.executeWriteRequest($0) }
+    }
+    
+    private func errorResponse(_ opcode: ATTOpcode, _ error: ATTError, _ handle: UInt16 = 0) {
+        log?("Error \(error) - \(opcode) (\(handle))")
+        let response = ATTErrorResponse(request: opcode, attributeHandle: handle, error: error)
+        connection.queue(response)
+    }
+    
+    private func fatalErrorResponse(_ message: String, _ opcode: ATTOpcode, _ handle: UInt16 = 0, line: UInt = #line) -> Never {
+        do {
+            errorResponse(opcode, .unlikelyError, handle)
+            let _ = try connection.write()
+        }
+        catch { log?("Could not send .unlikelyError to client. \(error)") }
+        
+        // crash
+        fatalError()
+    }
+    
+    /// Respond to a client-initiated PDU message.
+    private func respond <T: ATTProtocolDataUnit> (_ response: T) {
+        log?("Response: \(response)")
+        connection.queue(response)
+    }
+    
+    /// Send a server-initiated PDU message.
+    private func send(
+        _ indication: ATTHandleValueIndication<Data>,
+        response: @escaping (Result<ATTHandleValueConfirmation, ATTErrorResponse>) -> ()
+    ) {
+        log?("Indication: \(indication)")
+        self.connection.queue(indication, response: response)
+    }
+    
+    /// Send a server-initiated PDU message.
+    private func send(_ notification: ATTHandleValueNotification<Data>) {
+        log?("Notification: \(notification)")
+        connection.queue(notification)
+    }
+    
+    private func checkPermissions(
+        _ permissions: ATTAttributePermissions,
+        _ attribute: GATTDatabase<Data>.Attribute
+    ) -> ATTError? {
+        
+        guard attribute.permissions != permissions else { return nil }
+        
+        // check permissions
+        if permissions.contains(.read) && !attribute.permissions.contains(.read) {
+            return .readNotPermitted
+        }
+        
+        if permissions.contains(.write) && !attribute.permissions.contains(.write) {
+            return .writeNotPermitted
+        }
+        
+        // check security
+        let security: SecurityLevel
+        do { security = try connection.socket.securityLevel() }
+        catch {
+            log?("Unable to get security level. \(error)")
+            security = .sdp
+        }
+        
+        if attribute.permissions.contains(.readAuthentication)
+            || attribute.permissions.contains(.writeAuthentication)
+            && security < .high {
+            
+            return .insufficientAuthentication
+        }
+        
+        if attribute.permissions.contains(.readEncrypt)
+            || attribute.permissions.contains(.writeEncrypt)
+            && security < .medium {
+            
+            return .insufficientEncryption
+        }
+        
+        return nil
+    }
+    
+    /// Handler for Write Request and Command
+    private func handleWriteRequest(
+        opcode: ATTOpcode,
+        handle: UInt16,
+        value: Data,
+        shouldRespond: Bool
+    ) {
+        
+        /// Conditionally respond
+        func doResponse( _ block: @autoclosure () -> ()) {
+            if shouldRespond {
+                block()
+            }
+        }
+        
+        log?("Write \(shouldRespond ? "Request" : "Command") (\(handle)) \(value)")
+        
+        // no attributes, impossible to write
+        guard database.attributes.isEmpty == false else {
+            doResponse(errorResponse(opcode, .invalidHandle, handle))
+            return
+        }
+        
+        // validate handle
+        guard database.contains(handle: handle) else {
+            errorResponse(opcode, .invalidHandle, handle)
+            return
+        }
+        
+        // get attribute
+        let attribute = database[handle: handle]
+        
+        // validate permissions
+        if let error = checkPermissions([.write, .writeAuthentication, .writeEncrypt], attribute) {
+            doResponse(errorResponse(opcode, error, handle))
+            return
+        }
+        
+        // validate application errors with write callback
+        if let error = callback.willWrite?(attribute.uuid, handle, attribute.value, value) {
+            doResponse(errorResponse(opcode, error, handle))
+            return
+        }
+        
+        database.write(value, forAttribute: handle)
+        doResponse(respond(ATTWriteResponse()))
+        didWriteAttribute(handle)
+    }
+    
+    private func didWriteAttribute(_ attributeHandle: UInt16, isLocalWrite: Bool = false) {
+        
+        let (group, attribute) = database.attributeGroup(for: attributeHandle)
+        assert(attribute.handle == attributeHandle)
+        
+        guard let service = group.service,
+            let characteristic = service.characteristics.first(where: { $0.uuid == attribute.uuid })
+            else { return }
+        
+        // notify connected client if write is from server and not client write request
+        if isLocalWrite {
+            
+            // Client configuration
+            if let clientConfigurationDescriptor = characteristic.descriptors.first(where: { $0.uuid == .clientCharacteristicConfiguration }) {
+                
+                guard let descriptor = GATTClientCharacteristicConfiguration(data: clientConfigurationDescriptor.value)
+                    else { return }
+                
+                // notify
+                if descriptor.contains(.notify) {
+                    let notification = ATTHandleValueNotification(
+                        attribute: attribute,
+                        maximumTransmissionUnit: connection.maximumTransmissionUnit
+                    )
+                    send(notification)
+                }
+                
+                // indicate
+                if descriptor.contains(.indicate) {
+                    let indication = ATTHandleValueIndication(
+                        attribute: attribute,
+                        maximumTransmissionUnit: connection.maximumTransmissionUnit
+                    )
+                    send(indication) { result in
+                        switch result {
+                        case .success(let confirmation):
+                            self.log?("Confirmation: \(confirmation)")
+                        case .failure(let error):
+                            self.log?("Confirmation error: \(error)")
+                        }
+                    }
+                }
+            }
+            
+        } else {
+            
+            // writes from central should not notify clients (at least not this connected central)
+            callback.didWrite?(attribute.uuid, attribute.handle, attribute.value)
+        }
+    }
+    
+    private func handleReadRequest(
+        opcode: ATTOpcode,
+        handle: UInt16,
+        offset: UInt16 = 0,
+        isBlob: Bool = false
+    ) -> Data? {
+        
+        let maximumTransmissionUnit = self.connection.maximumTransmissionUnit
+        
+        // no attributes
+        guard database.attributes.isEmpty == false else {
+            errorResponse(opcode, .invalidHandle, handle)
+            return nil
+        }
+        
+        // validate handle
+        guard database.contains(handle: handle) else {
+            errorResponse(opcode, .invalidHandle, handle)
+            return nil
+        }
+        
+        // get attribute
+        let attribute = database[handle: handle]
+        
+        // validate permissions
+        if let error = checkPermissions([.read, .readAuthentication, .readEncrypt], attribute) {
+            errorResponse(opcode, error, handle)
+            return nil
+        }
+        
+        // Verify attribute value size for blob reading
+        //
+        // If the Characteristic Value is not longer than (ATT_MTU – 1) an Error Response with
+        // the Error Code set to Attribute Not Long shall be received on the first Read Blob Request.
+        guard isBlob == false || attribute.value.count > (Int(maximumTransmissionUnit.rawValue) - 1) else {
+            errorResponse(opcode, .attributeNotLong, handle)
+            return nil
+        }
+        
+        // check boundary
+        guard offset <= UInt16(attribute.value.count) else {
+            errorResponse(opcode, .invalidOffset, handle)
+            return nil
+        }
+        
+        var value: Data
+        
+        // Guard against invalid access if offset equals to value length
+        if offset == UInt16(attribute.value.count) {
+            value = Data()
+        } else if offset > 0 {
+            value = Data(attribute.value.suffix(from: Int(offset)))
+        } else {
+            value = attribute.value
+        }
+        
+        // adjust value for MTU
+        value = Data(value.prefix(Int(maximumTransmissionUnit.rawValue) - 1))
+        
+        // validate application errors with read callback
+        if let error = callback.willRead?(attribute.uuid, handle, value, Int(offset)) {
+            errorResponse(opcode, error, handle)
+            return nil
+        }
+        
+        return value
+    }
+    
+    // MARK: Callbacks
+    
+    private func exchangeMTU(_ pdu: ATTMaximumTransmissionUnitRequest) {
+        let serverMTU = preferredMaximumTransmissionUnit.rawValue
+        let finalMTU = ATTMaximumTransmissionUnit(server: serverMTU, client: pdu.clientMTU)
+        // Respond with the server MTU (not final MTU)
+        connection.queue(ATTMaximumTransmissionUnitResponse(serverMTU: serverMTU))
+        // Set MTU
+        connection.maximumTransmissionUnit = finalMTU
+        log?("MTU Exchange (\(pdu.clientMTU) -> \(serverMTU))")
+    }
+    
+    private func readByGroupType(_ pdu: ATTReadByGroupTypeRequest) {
+        typealias AttributeData = ATTReadByGroupTypeResponse<Data>.AttributeData
+        log?("Read by Group Type (\(pdu.startHandle) - \(pdu.endHandle))")
+        // validate handles
+        guard pdu.startHandle != 0 && pdu.endHandle != 0 else {
+            errorResponse(ATTReadByGroupTypeRequest.attributeOpcode, .invalidHandle)
+            return
+        }
+        guard pdu.startHandle <= pdu.endHandle else {
+            errorResponse(ATTReadByGroupTypeRequest.attributeOpcode, .invalidHandle, pdu.startHandle)
+            return
+        }
+        // GATT defines that only the Primary Service and Secondary Service group types
+        // can be used for the "Read By Group Type" request. Return an error if any other group type is given.
+        guard pdu.type == .primaryService || pdu.type == .secondaryService else {
+            errorResponse(ATTReadByGroupTypeRequest.attributeOpcode, .unsupportedGroupType, pdu.startHandle)
+            return
+        }
+        let attributeData = database.readByGroupType(handle: (pdu.startHandle, pdu.endHandle), type: pdu.type)
+        guard let firstAttribute = attributeData.first else {
+            errorResponse(ATTReadByGroupTypeRequest.attributeOpcode, .attributeNotFound, pdu.startHandle)
+            return
+        }
+        
+        let mtu = Int(connection.maximumTransmissionUnit.rawValue)
+        let valueLength = firstAttribute.value.count
+        let response: ATTReadByGroupTypeResponse<Data>
+        
+        // truncate for MTU if first handle is too large
+        if ATTReadByGroupTypeResponse<Data>([firstAttribute]).dataLength > mtu {
+            let maxLength = min(min(mtu - 6, 251), valueLength)
+            let truncatedAttribute = AttributeData(
+                attributeHandle: firstAttribute.attributeHandle,
+                endGroupHandle: firstAttribute.endGroupHandle,
+                value: Data(firstAttribute.value.prefix(maxLength))
+            )
+            response = ATTReadByGroupTypeResponse([truncatedAttribute])
+        } else {
+            var count = 1
+            // respond with results that are the same length
+            if attributeData.count > 1 {
+                for (index, attribute) in attributeData.suffix(from: 1).enumerated() {
+                    let newCount = index + 1
+                    guard attribute.value.count == valueLength,
+                        ATTReadByGroupTypeResponse.dataLength(for: attributeData.prefix(newCount)) <= mtu
+                        else { break }
+                    count = newCount
+                }
+            }
+            
+            let limitedAttributes = Array(attributeData.prefix(count))
+            response = ATTReadByGroupTypeResponse(limitedAttributes)
+        }
+        
+        assert(response.dataLength <= mtu)
+        
+        respond(response)
+    }
+    
+    private func readByType(_ pdu: ATTReadByTypeRequest) {
+        typealias AttributeData = ATTReadByTypeResponse<Data>.AttributeData
+        log?("Read by Type (\(pdu.attributeType)) (\(pdu.startHandle) - \(pdu.endHandle))")
+        guard pdu.startHandle != 0 && pdu.endHandle != 0
+            else { errorResponse(ATTReadByTypeRequest.attributeOpcode, .invalidHandle); return }
+        
+        guard pdu.startHandle <= pdu.endHandle
+            else { errorResponse(ATTReadByTypeRequest.attributeOpcode, .invalidHandle, pdu.startHandle); return }
+        
+        let attributeData = database
+            .readByType(handle: (pdu.startHandle, pdu.endHandle), type: pdu.attributeType)
+            .map { AttributeData(handle: $0.handle, value: $0.value) }
+        
+        guard let firstAttribute = attributeData.first
+            else { errorResponse(ATTReadByTypeRequest.attributeOpcode, .attributeNotFound, pdu.startHandle); return }
+        
+        let mtu = Int(connection.maximumTransmissionUnit.rawValue)
+        
+        let valueLength = firstAttribute.value.count
+        
+        let response: ATTReadByTypeResponse<Data>
+        
+        // truncate data for MTU if first handle is too large
+        if ATTReadByTypeResponse<Data>([firstAttribute]).dataLength > mtu {
+            
+            let maxLength = min(min(mtu - 4, 253), firstAttribute.value.count)
+            
+            let truncatedAttribute = AttributeData(handle: firstAttribute.handle,
+                                                   value: Data(firstAttribute.value.prefix(maxLength)))
+            
+            response = ATTReadByTypeResponse([truncatedAttribute])
+            
+        } else {
+            
+            var count = 1
+            
+            // respond with results that are the same length
+            if attributeData.count > 1 {
+                
+                for (index, attribute) in attributeData.suffix(from: 1).enumerated() {
+                    
+                    let newCount = index + 1
+                    
+                    guard attribute.value.count == valueLength,
+                        ATTReadByTypeResponse.dataLength(for: attributeData.prefix(newCount)) <= mtu
+                        else { break }
+                    
+                    count = newCount
+                }
+            }
+            
+            let limitedAttributes = Array(attributeData.prefix(count))
+            
+            response = ATTReadByTypeResponse(limitedAttributes)
+        }
+        
+        assert(response.dataLength <= mtu)
+        
+        respond(response)
+    }
+    
+    private func findInformation(_ pdu: ATTFindInformationRequest) {
+        
+        typealias AttributeData = ATTFindInformationResponse.AttributeData
+        
+        typealias Format = ATTFindInformationResponse.Format
+        
+        let opcode = ATTFindInformationRequest.attributeOpcode
+        
+        log?("Find Information (\(pdu.startHandle) - \(pdu.endHandle))")
+        
+        guard pdu.startHandle != 0 && pdu.endHandle != 0
+            else { errorResponse(opcode, .invalidHandle); return }
+        
+        guard pdu.startHandle <= pdu.endHandle
+            else { errorResponse(opcode, .invalidHandle, pdu.startHandle); return }
+        
+        let attributes = database.findInformation(handle: (pdu.startHandle, pdu.endHandle))
+        
+        guard attributes.isEmpty == false
+            else { errorResponse(opcode, .attributeNotFound, pdu.startHandle); return }
+        
+        guard let format = Format(uuid: attributes[0].uuid)
+            else { errorResponse(opcode, .unlikelyError, pdu.startHandle); return }
+        
+        var bit16Pairs = [ATTFindInformationResponse.Attribute16Bit]()
+        var bit128Pairs = [ATTFindInformationResponse.Attribute128Bit]()
+        
+        for (index, attribute) in attributes.enumerated() {
+            
+            // truncate if bigger than MTU
+            let encodedLength = 2 + ((index + 1) * format.length)
+            
+            guard encodedLength <= Int(connection.maximumTransmissionUnit.rawValue)
+                else { break }
+            
+            var mismatchedType = false
+            
+            // encode attribute
+            switch (attribute.uuid, format) {
+            case let (.bit16(type), .bit16):
+                bit16Pairs.append(ATTFindInformationResponse.Attribute16Bit(handle: attribute.handle, uuid: type))
+            case let (.bit128(type), .bit128):
+                bit128Pairs.append(ATTFindInformationResponse.Attribute128Bit(handle: attribute.handle, uuid: type))
+            default:
+                mismatchedType = true // mismatching types
+            }
+            
+            // stop enumerating
+            guard mismatchedType == false
+                else { break }
+        }
+        
+        let attributeData: AttributeData
+        
+        switch format {
+        case .bit16: attributeData = .bit16(bit16Pairs)
+        case .bit128: attributeData = .bit128(bit128Pairs)
+        }
+        
+        let response = ATTFindInformationResponse(attributeData: attributeData)
+        respond(response)
+    }
+    
+    private func findByTypeValue(_ pdu: ATTFindByTypeRequest<Data>) {
+        
+        typealias Handle = ATTFindByTypeResponse.HandlesInformation
+        
+        log?("Find By Type Value (\(pdu.startHandle) - \(pdu.endHandle)) (\(pdu.attributeType))")
+        
+        guard pdu.startHandle != 0 && pdu.endHandle != 0
+            else { errorResponse(ATTFindByTypeRequest<Data>.attributeOpcode, .invalidHandle); return }
+        
+        guard pdu.startHandle <= pdu.endHandle
+            else { errorResponse(ATTFindByTypeRequest<Data>.attributeOpcode, .invalidHandle, pdu.startHandle); return }
+        
+        let handles = database.findByTypeValue(handle: (pdu.startHandle, pdu.endHandle),
+                                               type: pdu.attributeType,
+                                               value: pdu.attributeValue)
+        
+        guard handles.isEmpty == false
+            else { errorResponse(ATTFindByTypeRequest<Data>.attributeOpcode, .attributeNotFound, pdu.startHandle); return }
+        
+        let response = ATTFindByTypeResponse(handles)
+        respond(response)
+    }
+    
+    private func writeRequest(_ pdu: ATTWriteRequest<Data>) {
+        let opcode = ATTWriteRequest<Data>.attributeOpcode
+        handleWriteRequest(opcode: opcode, handle: pdu.handle, value: pdu.value, shouldRespond: true)
+    }
+    
+    private func writeCommand(_ pdu: ATTWriteCommand<Data>) {
+        let opcode = ATTWriteCommand<Data>.attributeOpcode
+        handleWriteRequest(opcode: opcode, handle: pdu.handle, value: pdu.value, shouldRespond: false)
+    }
+    
+    private func readRequest(_ pdu: ATTReadRequest) {
+        let opcode = ATTReadRequest.attributeOpcode
+        log?("Read (\(pdu.handle))")
+        if let value = handleReadRequest(opcode: opcode, handle: pdu.handle) {
+            respond(ATTReadResponse(attributeValue: value))
+        }
+    }
+    
+    private func readBlobRequest(_ pdu: ATTReadBlobRequest) {
+        let opcode = ATTReadBlobRequest.attributeOpcode
+        log?("Read Blob (\(pdu.handle))")
+        if let value = handleReadRequest(opcode: opcode, handle: pdu.handle, offset: pdu.offset, isBlob: true) {
+            respond(ATTReadBlobResponse(partAttributeValue: value))
+        }
+    }
+    
+    private func readMultipleRequest(_ pdu: ATTReadMultipleRequest) {
+        let opcode = ATTReadMultipleRequest.attributeOpcode
+        log?("Read Multiple Request \(pdu.handles)")
+        
+        // no attributes, impossible to read
+        guard database.attributes.isEmpty == false
+            else { errorResponse(opcode, .invalidHandle, pdu.handles[0]); return }
+        
+        var values = Data()
+        
+        for handle in pdu.handles {
+            
+            // validate handle
+            guard database.contains(handle: handle)
+                else { errorResponse(opcode, .invalidHandle, handle); return }
+            
+            // get attribute
+            let attribute = database[handle: handle]
+            
+            // validate application errors with read callback
+            if let error = callback.willRead?(attribute.uuid, handle, attribute.value, 0) {
+                errorResponse(opcode, error, handle)
+                return
+            }
+            
+            values += attribute.value
+        }
+        
+        let response = ATTReadMultipleResponse(values: values)
+        respond(response)
+    }
+    
+    private func prepareWriteRequest(_ pdu: ATTPrepareWriteRequest<Data>) {
+        
+        let opcode = ATTPrepareWriteRequest<Data>.attributeOpcode
+        
+        log?("Prepare Write Request (\(pdu.handle))")
+        
+        // no attributes, impossible to write
+        guard database.attributes.isEmpty == false
+            else { errorResponse(opcode, .invalidHandle, pdu.handle); return }
+        
+        // validate handle
+        guard database.contains(handle: pdu.handle)
+            else { errorResponse(opcode, .invalidHandle, pdu.handle); return }
+        
+        // validate that the prepared writes queue is not full
+        guard preparedWrites.count <= maximumPreparedWrites
+            else { errorResponse(opcode, .prepareQueueFull); return }
+        
+        // get attribute
+        let attribute = database[handle: pdu.handle]
+        
+        // validate permissions
+        if let error = checkPermissions([.write, .writeAuthentication, .writeEncrypt], attribute) {
+            errorResponse(opcode, error, pdu.handle)
+            return
+        }
+        
+        // The Attribute Value validation is done when an Execute Write Request is received.
+        // Hence, any Invalid Offset or Invalid Attribute Value Length errors are generated 
+        // when an Execute Write Request is received.
+        
+        // add queued write
+        let preparedWrite = PreparedWrite(handle: pdu.handle, value: pdu.partValue, offset: pdu.offset)
+        preparedWrites.append(preparedWrite)
+        let response = ATTPrepareWriteResponse(handle: pdu.handle, offset: pdu.offset, partValue: pdu.partValue)
+        respond(response)
+    }
+    
+    private func executeWriteRequest(_ pdu: ATTExecuteWriteRequest) {
+        let opcode = ATTExecuteWriteRequest.attributeOpcode
+        log?("Execute Write Request (\(pdu))")
+        let preparedWrites = self.preparedWrites
+        self.preparedWrites = []
+        var newValues = [UInt16: Data]()
+        switch pdu {
+        case .cancel:
+            break // queue always cleared
+        case .write:
+            // validate
+            for write in preparedWrites {
+                var newValue = newValues[write.handle] ?? Data()
+                newValue += write.value
+                // validate offset?
+                newValues[write.handle] = newValue
+            }
+            // validate new values
+            for (handle, newValue) in newValues {
+                let attribute = database[handle: handle]
+                // validate application errors with write callback
+                if let error = callback.willWrite?(attribute.uuid, handle, attribute.value, newValue) {
+                    errorResponse(opcode, error, handle)
+                    return
+                }
+            }
+            // write new values
+            for (handle, newValue) in newValues {
+                database.write(newValue, forAttribute: handle)
+            }
+        }
+        
+        respond(ATTExecuteWriteResponse())
+        for handle in newValues.keys {
+            didWriteAttribute(handle)
+        }
+    }
+}
+
+// MARK: - Supporting Types
+
+public extension GATTServer {
+    
+    struct Callback {
+                
+        public var willRead: ((_ uuid: BluetoothUUID, _ handle: UInt16, _ value: Data, _ offset: Int) -> ATTError?)?
+        
+        public var willWrite: ((_ uuid: BluetoothUUID, _ handle: UInt16, _ value: Data, _ newValue: Data) -> ATTError?)?
+        
+        public var didWrite: ((_ uuid: BluetoothUUID, _ handle: UInt16, _ value: Data) -> Void)?
+        
+        public init() { }
+    }
+}
+
+internal extension GATTServer {
+    
+    struct PreparedWrite {
+        
+        let handle: UInt16
+        
+        let value: Data
+        
+        let offset: UInt16
+    }
+}
+
+internal struct HandleRange {
+    
+    public let start: UInt16
+    
+    public let end: UInt16
+    
+    public init(start: UInt16, end: UInt16) {
+        assert(start <= end)
+        self.start = start
+        self.end = end
+    }
+}
+
+internal extension HandleRange {
+    
+    init<Data: DataContainer>(group: GATTDatabase<Data>.AttributeGroup) {
+        self.init(start: group.startHandle, end: group.endHandle)
+    }
+}
+
+internal extension HandleRange {
+    
+    func isSubset(_ other: HandleRange) -> Bool {
+        
+        return self.start >= other.start
+            && self.start <= other.end
+            && self.end >= other.start
+            && self.end <= other.end
+    }
+    
+    func contains(_ element: UInt16) -> Bool {
+        
+        return start <= element
+            && element <= end
+    }
+}
+
+internal extension GATTDatabase {
+    
+    /// Find the enclosing Service attribute group for the specified handle
+    func attributeGroup(for handle: UInt16) -> (group: AttributeGroup, attribute: Attribute) {
+        
+        for group in attributeGroups {
+            
+            for attribute in group.attributes {
+                
+                guard attribute.handle != handle
+                    else { return (group, attribute) }
+            }
+        }
+        
+        fatalError("Invalid handle")
+    }
+    
+    /// Used for Service discovery.
+    func readByGroupType(handle: (start: UInt16, end: UInt16), type: BluetoothUUID) -> [ATTReadByGroupTypeResponse<Data>.AttributeData] {
+        
+        typealias AttributeData = ATTReadByGroupTypeResponse<Data>.AttributeData
+        
+        var data = [AttributeData]()
+        data.reserveCapacity(attributeGroups.count)
+        
+        let handleRange = HandleRange(start: handle.start, end: handle.end)
+        
+        for group in attributeGroups {
+            
+            let groupRange = HandleRange(group: group)
+            
+            guard group.serviceAttribute.uuid == type,
+                groupRange.isSubset(handleRange)
+                else { continue }
+            
+            data.append(AttributeData(attributeHandle: group.startHandle,
+                                      endGroupHandle: group.endHandle,
+                                      value: group.serviceAttribute.value))
+        }
+        
+        return data
+    }
+    
+    func readByType(handle: (start: UInt16, end: UInt16), type: BluetoothUUID) -> [Attribute] {
+        
+        let range = HandleRange(start: handle.start, end: handle.end)
+        
+        return attributes.filter { range.contains($0.handle) && $0.uuid == type }
+    }
+    
+    func findInformation(handle: (start: UInt16, end: UInt16)) -> [Attribute] {
+        
+        let range = HandleRange(start: handle.start, end: handle.end)
+        
+        return attributes.filter { range.contains($0.handle) }
+    }
+    
+    func findByTypeValue(handle: (start: UInt16, end: UInt16), type: UInt16, value: Data) -> [ATTFindByTypeResponse.HandlesInformation] {
+        
+        typealias HandleInformation = ATTFindByTypeResponse.HandlesInformation
+        
+        let range = HandleRange(start: handle.start, end: handle.end)
+        
+        var results = [HandleInformation]()
+        
+        for group in attributeGroups {
+            
+            for attribute in group.attributes {
+                
+                let match = range.contains(attribute.handle)
+                    && attribute.uuid == .bit16(type)
+                    && attribute.value == value
+                
+                guard match else { continue }
+                
+                results.append(HandleInformation(foundAttribute: group.startHandle, groupEnd: group.endHandle))
+            }
+        }
+        
+        return results
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTUserDescription.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothGATT/GATTUserDescription.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: - Characteristic User Description
+
+/// GATT Characteristic User Description Descriptor
+///
+/// The Characteristic User Description descriptor provides a textual user description for a characteristic value.
+///
+/// If the Writable Auxiliary bit of the Characteristics Properties is set then this descriptor is written.
+/// Only one User Description descriptor exists in a characteristic definition.
+@frozen
+public struct GATTUserDescription: GATTDescriptor, RawRepresentable, Hashable, Sendable {
+    
+    public static var uuid: BluetoothUUID { .characteristicUserDescription }
+    
+    public var rawValue: String
+    
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+// MARK: - ExpressibleByStringLiteral
+
+extension GATTUserDescription: ExpressibleByStringLiteral {
+    
+    public init(stringLiteral value: String) {
+        self.init(rawValue: value)
+    }
+}
+
+// MARK: - DataConvertible
+
+extension GATTUserDescription: DataConvertible {
+    
+    public init?<Data: DataContainer>(data: Data) {
+        
+        guard let rawValue = String(utf8: data)
+            else { return nil }
+        
+        self.init(rawValue: rawValue)
+    }
+    
+    public func append<Data>(to data: inout Data) where Data : DataContainer {
+        data += rawValue.utf8
+    }
+    
+    public var dataLength: Int {
+        rawValue.utf8.count
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothHCI/ChannelIdentifier.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothHCI/ChannelIdentifier.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Bluetooth Channel Identifier
+@frozen
+public struct ChannelIdentifier: RawRepresentable, Equatable, Hashable {
+    
+    public var rawValue: UInt16
+    
+    public init(rawValue: UInt16) {
+        
+        self.rawValue = rawValue
+    }
+}
+
+public extension ChannelIdentifier {
+    
+    static var att: ChannelIdentifier { return 4 }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension ChannelIdentifier: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral value: UInt16) {
+        
+        self.init(rawValue: value)
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension ChannelIdentifier: CustomStringConvertible {
+    
+    public var description: String {
+        
+        return rawValue.description
+    }
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothHCI/HCIError.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothHCI/HCIError.swift
@@ -453,3 +453,83 @@ public enum HCIError: UInt8, Error {
     /// The MAC of the 802.11 AMP was requested to connect to a peer, but the connection failed.
     case macConnectionFailed                = 0x3F
 }
+
+// MARK: - CustomStringConvertible
+
+extension HCIError: CustomStringConvertible {
+    
+    public var description: String {
+        return name
+    }
+    
+    public var name: String {
+        return Self.names[Int(rawValue)]
+    }
+    
+    internal static let names = [
+        "Success",
+        "Unknown HCI Command",
+        "Unknown Connection Identifier",
+        "Hardware Failure",
+        "Page Timeout",
+        "Authentication Failure",
+        "PIN or Key Missing",
+        "Memory Capacity Exceeded",
+        "Connection Timeout",
+        "Connection Limit Exceeded",
+        "Synchronous Connection to a Device Exceeded",
+        "ACL Connection Already Exists",
+        "Command Disallowed",
+        "Connection Rejected due to Limited Resources",
+        "Connection Rejected due to Security Reasons",
+        "Connection Rejected due to Unacceptable BD_ADDR",
+        "Connection Accept Timeout Exceeded",
+        "Unsupported Feature or Parameter Value",
+        "Invalid HCI Command Parameters",
+        "Remote User Terminated Connection",
+        "Remote Device Terminated Connection due to Low Resources",
+        "Remote Device Terminated Connection due to Power Off",
+        "Connection Terminated by Local Host",
+        "Repeated Attempts",
+        "Pairing Not Allowed",
+        "Unknown LMP PDU",
+        "Unsupported Remote Feature / Unsupported LMP Feature",
+        "SCO Offset Rejected",
+        "SCO Interval Rejected",
+        "SCO Air Mode Rejected",
+        "Invalid LMP Parameters / Invalid LL Parameters",
+        "Unspecified Error",
+        "Unsupported LMP Parameter Value / Unsupported LL Parameter Value",
+        "Role Change Not Allowed",
+        "LMP Response Timeout",
+        "LMP Error Transaction Collision",
+        "LMP PDU Not Allowed",
+        "Encryption Mode Not Acceptable",
+        "Link Key Can Not be Changed",
+        "Requested QoS Not Supported",
+        "Instant Passed",
+        "Pairing with Unit Key Not Supported",
+        "Different Transaction Collision",
+        "Reserved",
+        "QoS Unacceptable Parameter",
+        "QoS Rejected",
+        "Channel Classification Not Supported",
+        "Insufficient Security",
+        "Parameter out of Mandatory Range",
+        "Reserved",
+        "Role Switch Pending",
+        "Reserved",
+        "Reserved Slot Violation",
+        "Role Switch Failed",
+        "Extended Inquiry Response Too Large",
+        "Simple Pairing Not Supported by Host",
+        "Host Busy - Pairing",
+        "Connection Rejected due to No Suitable Channel Found",
+        "Controller Busy",
+        "Unacceptable Connection Parameters",
+        "Directed Advertising Timeout",
+        "Connection Terminated Due to MIC Failure",
+        "Connection Failed to be Established",
+        "MAC Connection Failed"
+    ]
+}

--- a/pico-w-ble-peripheral-sdk/BluetoothHCI/HCIError.swift
+++ b/pico-w-ble-peripheral-sdk/BluetoothHCI/HCIError.swift
@@ -1,0 +1,455 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Bluetooth HCI Errors
+///
+/// If an HCI Command that should generate a Command Complete event generates an error 
+/// then this error shall be reported in the Command Complete event.
+///
+/// If an HCI Command that sent a Command Status with the error code ‘Success’
+/// to the Host before processing may find an error during execution then the error may 
+/// be reported in the normal completion command for the original command or in a Command Status event.
+///
+/// Some HCI Commands may generate errors that need to be reported to the Host, 
+/// but there is insufficient information to determine how the command would normally be processed.
+/// In this case, two events can be used to indicate this to the Host, the Command Complete event 
+/// and Command Status events. Which of the two events is used is implementation-dependent.
+@frozen
+public enum HCIError: UInt8, Error {
+    
+    /// Unknown HCI Command
+    /// 
+    /// The Unknown HCI Command error code indicates that the Controller 
+    /// does not understand the HCI Command Packet OpCode that the Host sent. 
+    /// The OpCode given might not correspond to any of the OpCodes specified 
+    /// in this document, or any vendor-specific OpCodes, or the command may not have been implemented.
+    case unknownCommand                     = 0x01
+    
+    /// Unknown Connection Identifier
+    /// 
+    /// The Unknown Connection Identifier error code indicates that
+    /// a command was sent from the Host that should identify a 
+    /// connection, but that connection does not exist.
+    case noConnection                       = 0x02
+    
+    /// Hardware Failure
+    /// 
+    /// The Hardware Failure error code indicates to the Host that 
+    /// something in the Controller has failed in a manner that cannot 
+    /// be described with any other error code. 
+    /// The meaning implied with this error code is implementation dependent.
+    case hardwareFailure                    = 0x03
+    
+    /// Page Timeout
+    /// 
+    /// The Page Timeout error code indicates that a page timed out because 
+    /// of the Page Timeout configuration parameter. 
+    ///
+    /// - Note: This error code may occur only with the `.remoteNameRequest` and `.createConnection` commands.
+    case pageTimeout                        = 0x04
+    
+    /// Authentication Failure
+    /// 
+    /// The Authentication Failure error code indicates that pairing 
+    /// or authentication failed due to incorrect results in the pairing 
+    /// or authentication procedure. 
+    /// This could be due to an incorrect PIN or Link Key.
+    case authenticationFailure              = 0x05
+    
+    /// PIN or Key Missing
+    /// 
+    /// The PIN or Key Missing error code is used when pairing failed 
+    /// because of a missing PIN, or authentication failed because of a missing Key.
+    case keyMissing                         = 0x06
+    
+    /// Memory Capacity Exceeded
+    /// 
+    /// The Memory Capacity Exceeded error code indicates to the Host that 
+    /// the Controller has run out of memory to store new parameters.
+    case memoryFull                         = 0x07
+    
+    /// Connection Timeout
+    /// 
+    /// The Connection Timeout error code indicates that the 
+    /// link supervision timeout has expired for a given connection.
+    case connectionTimeout                  = 0x08
+    
+    /// Connection Limit Exceeded
+    /// 
+    /// The Connection Limit Exceeded error code indicates that 
+    /// an attempt to create another connection failed because 
+    /// the Controller is already at its limit of the number of
+    /// connections it can support. 
+    ///
+    /// - Note: The number of connections a device can support is implementation dependent.
+    case maxConnections                     = 0x09
+    
+    /// Synchronous Connection Limit To A Device Exceeded
+    /// 
+    /// The Synchronous Connection Limit to a Device Exceeded error code 
+    /// indicates that the Controller has reached the limit to the number
+    /// of synchronous connections that can be achieved to a device. 
+    ///
+    /// - Note: The number of synchronous connections a device can support is implementation dependent.
+    case maxSCOConnections                  = 0x0A
+    
+    /// ACL Connection Already Exists
+    /// 
+    /// The ACL Connection Already Exists error code indicates that an 
+    /// attempt to create a new ACL Connection to a device when there 
+    /// is already a connection to this device.
+    case aclConnectionExists                = 0x0B
+    
+    /// Command Disallowed
+    /// 
+    /// The Command Disallowed error code indicates that the command requested 
+    /// cannot be executed because the Controller is in a state where it cannot 
+    /// process this command at this time. 
+    ///
+    /// - Note: This error shall not be used for command OpCodes where the error code Unknown HCI Command is valid.
+    case commandDisallowed                  = 0x0C
+    
+    /// Connection Rejected due to Limited Resources
+    /// 
+    /// The Connection Rejected Due To Limited Resources error code 
+    /// indicates that an incoming connection was rejected due to limited resources.
+    case rejectedLimitedResources           = 0x0D
+    
+    /// Connection Rejected Due To Security Reasons
+    /// 
+    /// The Connection Rejected Due To Security Reasons error code 
+    /// indicates that a connection was rejected due to security requirements 
+    /// not being fulfilled, like authentication or pairing.
+    case rejectedSecurity                   = 0x0E
+    
+    /// Connection Rejected due to Unacceptable `Bluetooth.Address`
+    /// 
+    /// The Connection Rejected due to Unacceptable Bluetooth Address
+    /// error code indicates that a connection was rejected because this
+    /// device does not accept the Bluetooth Address (`BD_ADDR`).
+    ///
+    /// This may be because the device will only accept connections from specific Bluetooth Addresses.
+    case rejectedAddress                    = 0x0F
+    
+    /// Connection Accept Timeout Exceeded
+    /// 
+    /// The Connection Accept Timeout Exceeded error code indicates that 
+    /// the Connection Accept Timeout has been exceeded for this connection attempt.
+    case hostTimeout                        = 0x10
+    
+    /// Unsupported Feature or Parameter Value
+    /// 
+    /// The Unsupported Feature Or Parameter Value error code indicates that 
+    /// a feature or parameter value in the HCI command is not supported. 
+    ///
+    /// - Note: This error code shall not be used in an LMP PDU.
+    case unsupportedFeature                 = 0x11
+    
+    /// Invalid HCI Command Parameters
+    /// 
+    /// The Invalid HCI Command Parameters error code indicates that at 
+    /// least one of the HCI command parameters is invalid.
+    ///
+    /// This shall be used when:
+    /// - the parameter total length is invalid.
+    /// - a command parameter is an invalid type.
+    /// - a connection identifier does not match the corresponding event.
+    /// - a parameter value shall be even.
+    /// - a parameter is outside of the specified range.
+    /// - two or more parameter values have inconsistent values.
+    /// 
+    /// Note: An invalid type can be, for example, when an SCO connection
+    /// handle is used where an ACL connection handle is required.
+    case invalidParameters                  = 0x012
+    
+    /// Remote User Terminated Connection
+    /// 
+    /// The Remote User Terminated Connection error code indicates that 
+    /// the user on the remote device terminated the connection.
+    case remoteUserEndedConnection          = 0x13
+    
+    /// Remote Device Terminated Connection due to Low Resources
+    /// 
+    /// The Remote Device Terminated Connection due to Low Resources 
+    /// error code indicates that the remote device terminated 
+    /// the connection because of low resources.
+    case remoteLowResources                 = 0x14
+    
+    /// Remote Device Terminated Connection due to Power Off
+    /// 
+    /// The Remote Device Terminated Connection due to Power Off 
+    /// error code indicates that the remote device terminated 
+    /// the connection because the device is about to power off.
+    case remotePowerOff                     = 0x15
+    
+    /// Connection Terminated By Local Host
+    /// 
+    /// The Connection Terminated By Local Host error code 
+    /// indicates that the local device terminated the connection.
+    case connectionTerminated               = 0x16
+    
+    /// Repeated Attempts
+    /// 
+    /// The Repeated Attempts error code indicates that the Controller 
+    /// is disallowing an authentication or pairing procedure because 
+    /// too little time has elapsed since the last authentication or pairing attempt failed.
+    case repeatedAttempts                   = 0x17
+    
+    /// Pairing Not Allowed
+    /// 
+    /// The Pairing Not Allowed error code indicates that the device does not allow pairing. 
+    /// For example, when a device only allows pairing during a certain time window after some user input allows pairing.
+    case pairingNotAllowed                  = 0x18
+    
+    /// Unknown LMP PDU
+    /// 
+    /// The Unknown LMP PDU error code indicates that the Controller has received an unknown LMP OpCode.
+    case unknownLMPPDU                      = 0x19
+    
+    /// Unsupported Remote Feature / Unsupported LMP Feature
+    /// 
+    /// The Unsupported Remote Feature error code indicates that the remote device 
+    /// does not support the feature associated with the issued command or LMP PDU.
+    case unsupportedRemoteFeature           = 0x1A
+    
+    /// SCO Offset Rejected
+    /// 
+    /// The SCO Offset Rejected error code indicates that the offset requested in 
+    /// the `LMP_SCO_link_req` PDU has been rejected.
+    case scoOffsetRejected                  = 0x1B
+    
+    /// SCO Interval Rejected
+    /// 
+    /// The SCO Interval Rejected error code indicates that the interval requested in
+    /// the `LMP_SCO_link_req` PDU has been rejected.
+    case scoIntervalRejected                = 0x1C
+    
+    /// SCO Air Mode Rejected
+    /// 
+    /// The SCO Air Mode Rejected error code indicates that the air mode requested in
+    /// the `LMP_SCO_link_req` PDU has been rejected.
+    case scoAirModeRejected                 = 0x1D
+    
+    /// Invalid LMP Parameters
+    /// 
+    /// The Invalid LMP Parameters error code indicates that some LMP PDU parameters were invalid.
+    /// This shall be used when:
+    /// - the PDU length is invalid.
+    /// - a parameter value shall be even.
+    /// - a parameter is outside of the specified range.
+    /// - two or more parameters have inconsistent values.
+    case invalidLMPParameters               = 0x1E
+    
+    /// Unspecified Error
+    /// 
+    /// The Unspecified Error error code indicates that 
+    /// no other error code specified is appropriate to use.
+    case unspecifiedError                   = 0x1F
+    
+    /// Unsupported LMP Parameter Value
+    /// 
+    /// The Unsupported LMP Parameter Value error code indicates 
+    /// that an LMP PDU contains at least one parameter value that 
+    /// is not supported by the Controller at this time. 
+    /// This is normally used after a long negotiation procedure,
+    /// for example during an `LMP_hold_req`, `LMP_sniff_req` 
+    /// and `LMP_encryption_key_size_req` PDU exchanges.
+    case unsupportedLMPParameterValue       = 0x20
+    
+    /// Role Change Not Allowed
+    /// 
+    /// The Role Change Not Allowed error code indicates that 
+    /// a Controller will not allow a role change at this time.
+    case roleChangeNotAllowed               = 0x21
+    
+    /// LMP Response Timeout / LL Response Timeout
+    /// 
+    /// The LMP Response Timeout / LL Response Timeout error code
+    /// indicates that an LMP transaction failed to respond within 
+    /// the LMP response timeout or an LL transaction failed to respond within the LL response timeout.
+    case lmpResponseTimeout                 = 0x22
+    
+    /// LMP Error Transaction Collision
+    /// 
+    /// The LMP Error Transaction Collision error code indicates 
+    /// that an LMP transaction has collided with the same transaction
+    /// that is already in progress.
+    case lmpErrorTransactionCollision       = 0x23
+    
+    /// LMP PDU Not Allowed
+    /// 
+    /// The LMP PDU Not Allowed error code indicates that a Controller 
+    /// sent an LMP PDU with an OpCode that was not allowed.
+    case lmpPDUNotAllowed                   = 0x24
+    
+    /// Encryption Mode Not Acceptable
+    /// 
+    /// The Encryption Mode Not Acceptable error code indicates 
+    /// that the requested encryption mode is not acceptable at this time.
+    case encryptionModeNotAcceptable        = 0x25
+    
+    /// Link Key cannot be Changed
+    /// 
+    /// The Link Key cannot be Changed error code indicates that 
+    /// a link key cannot be changed because a fixed unit key is being used.
+    case linkKeyCannotChange                = 0x26
+    
+    /// Requested QoS Not Supported
+    /// 
+    /// The Requested QoS Not Supported error code indicates that the requested Quality of Service is not supported.
+    case requestedQoSNotSupported           = 0x27
+    
+    /// Instant Passed
+    /// 
+    /// The Instant Passed error code indicates that an LMP PDU 
+    /// or LL PDU that includes an instant cannot be performed 
+    /// because the instant when this would have occurred has passed.
+    case instantPassed                      = 0x28
+    
+    /// Pairing With Unit Key Not Supported
+    /// 
+    /// The Pairing With Unit Key Not Supported error code indicates 
+    /// that it was not possible to pair as a unit key was requested 
+    /// and it is not supported.
+    case pairingWithUnitKeyNotSupported     = 0x29
+    
+    /// Different Transaction Collision
+    /// 
+    /// The Different Transaction Collision error code indicates that 
+    /// an LMP transaction was started that collides with an ongoing transaction.
+    case differentTransactionCollision      = 0x2A
+    
+    /// Reserved
+    case reserved2B                         = 0x2B
+    
+    /// QoS Unacceptable Parameter
+    /// 
+    /// The QoS Unacceptable Parameter error code indicates 
+    /// that the specified quality of service parameters could 
+    /// not be accepted at this time, but other parameters may be acceptable.
+    case qosUnacceptableParameter           = 0x2C
+    
+    /// QoS Rejected
+    /// 
+    /// The QoS Rejected error code indicates that the specified quality 
+    /// of service parameters cannot be accepted and QoS negotiation should be terminated.
+    case qosRejected                        = 0x2D
+    
+    /// Channel Classification Not Supported
+    /// 
+    /// The Channel Assessment Not Supported error code indicates that
+    /// the Controller cannot perform channel assessment because it is not supported.
+    case channelClassificationNotSupported  = 0x2E
+    
+    /// Insufficient Security
+    /// 
+    /// The Insufficient Security error code indicates that the 
+    /// HCI command or LMP PDU sent is only possible on an encrypted link.
+    case insufficientSecurity               = 0x2F
+    
+    /// Parameter Out Of Mandatory Range
+    /// 
+    /// The Parameter Out Of Mandatory Range error code indicates 
+    /// that a parameter value requested is outside the mandatory 
+    /// range of parameters for the given HCI command or LMP PDU.
+    case parameterOutOfMandatoryRange       = 0x30
+    
+    /// Reserved
+    case reserved31                         = 0x31
+    
+    /// Role Switch Pending
+    /// 
+    /// The Role Switch Pending error code indicates that a Role Switch is pending. 
+    /// This can be used when an HCI command or LMP PDU cannot be accepted because
+    /// of a pending role switch. This can also be used to notify a peer device 
+    /// about a pending role switch.
+    case roleSwitchPending                  = 0x32
+    
+    /// Reserved
+    case reserved33                         = 0x33
+    
+    /// Reserved Slot Violation
+    /// 
+    /// The Reserved Slot Violation error code indicates that the current 
+    /// Synchronous negotiation was terminated with the negotiation state set to Reserved Slot Violation.
+    case reservedSlotViolation              = 0x34
+    
+    /// Role Switch Failed
+    /// 
+    /// The Role Switch Failed error code indicates that a role switch 
+    /// was attempted but it failed and the original piconet structure is restored. 
+    /// The switch may have failed because the TDD switch or piconet switch failed.
+    case roleSwitchFailed                   = 0x35
+    
+    /// Extended Inquiry Response Too Large
+    /// 
+    /// The Extended Inquiry Response Too Large error code indicates 
+    /// that the extended inquiry response, with the requested requirements for FEC,
+    /// is too large to fit in any of the packet types supported by the Controller.
+    case extendedInquiryResponseTooLarge    = 0x36
+    
+    /// Secure Simple Pairing Not Supported By Host
+    /// 
+    /// The Secure Simple Pairing Not Supported by Host error code indicates that
+    /// the IO capabilities request or response was rejected because the sending 
+    /// Host does not support Secure Simple Pairing even though the receiving Link Manager does.
+    case secureSimplePairingNotSupported    = 0x37
+    
+    /// Host Busy - Pairing
+    /// 
+    /// The Host Busy - Pairing error code indicates that the Host is busy
+    /// with another pairing operation and unable to support the requested pairing. 
+    /// The receiving device should retry pairing again later.
+    case hostBusyPairing                    = 0x38
+    
+    /// Connection Rejected due to No Suitable Channel Found
+    /// 
+    /// The Connection Rejected due to No Suitable Channel Found error code 
+    /// indicates that the Controller could not calculate an appropriate 
+    /// value for the Channel selection operation.
+    case noSuitableChannelFound             = 0x39
+    
+    /// Controller Busy
+    /// 
+    /// The Controller Busy error code indicates that the operation 
+    /// was rejected because the Controller was busy and unable to process the request.
+    case controllerBusy                     = 0x3A
+    
+    /// Unacceptable Connection Interval
+    /// 
+    /// The Unacceptable Connection Interval error code indicates that 
+    /// the remote device terminated the connection because of an unacceptable connection interval.
+    case unacceptableConnectionInterval     = 0x3B
+    
+    /// Directed Advertising Timeout
+    /// 
+    /// The Directed Advertising Timeout error code indicates that 
+    /// directed advertising completed without a connection being created.
+    case directedAdvertisingTimeout         = 0x3C
+    
+    /// Connection Terminated due to MIC Failure
+    /// 
+    /// The Connection Terminated Due to MIC Failure error code indicates 
+    /// that the connection was terminated because the Message Integrity Check (MIC) 
+    /// failed on a received packet.
+    case micFailure                         = 0x3D
+    
+    /// Connection Failed to be Established
+    /// 
+    /// The Connection Failed to be Established error code indicates that the LL 
+    /// initiated a connection but the connection has failed to be established.
+    case connectionFailed                   = 0x3E
+    
+    /// MAC Connection Failed
+    /// 
+    /// The MAC of the 802.11 AMP was requested to connect to a peer, but the connection failed.
+    case macConnectionFailed                = 0x3F
+}

--- a/pico-w-ble-peripheral-sdk/BridgingHeader.h
+++ b/pico-w-ble-peripheral-sdk/BridgingHeader.h
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "pico/stdlib.h"
+#include "pico/cyw43_arch.h"
+#include "pico/btstack_cyw43.h"
+#include "btstack.h"
+#include "hci_transport.h"
+#include "hci_transport_usb.h"
+
+uint8_t l2cap_send_connectionless(hci_con_handle_t con_handle, uint16_t cid, uint8_t *data, uint16_t len);

--- a/pico-w-ble-peripheral-sdk/CMakeLists.txt
+++ b/pico-w-ble-peripheral-sdk/CMakeLists.txt
@@ -80,6 +80,9 @@ add_custom_command(
         $$\( echo '${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}'             | tr ' '  '\\n' | sed -e 's/\\\(.*\\\)/-Xcc -I\\1/g' \)
         -import-bridging-header ${CMAKE_CURRENT_LIST_DIR}/BridgingHeader.h
         ${CMAKE_CURRENT_LIST_DIR}/Main.swift
+        ${CMAKE_CURRENT_LIST_DIR}/PicoError.swift
+        ${CMAKE_CURRENT_LIST_DIR}/CYW43.swift
+        ${CMAKE_CURRENT_LIST_DIR}/GPIO.swift
         ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/Hexadecimal.swift
         ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/Integer.swift
         ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/String.swift
@@ -171,6 +174,9 @@ add_custom_command(
     DEPENDS
         ${CMAKE_CURRENT_LIST_DIR}/BridgingHeader.h
         ${CMAKE_CURRENT_LIST_DIR}/Main.swift
+        ${CMAKE_CURRENT_LIST_DIR}/PicoError.swift
+        ${CMAKE_CURRENT_LIST_DIR}/CYW43.swift
+        ${CMAKE_CURRENT_LIST_DIR}/GPIO.swift
         ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/Hexadecimal.swift
         ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/Integer.swift
         ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/String.swift

--- a/pico-w-ble-peripheral-sdk/CMakeLists.txt
+++ b/pico-w-ble-peripheral-sdk/CMakeLists.txt
@@ -1,0 +1,268 @@
+cmake_minimum_required(VERSION 3.13)
+include($ENV{PICO_SDK_PATH}/external/pico_sdk_import.cmake)
+
+project(swift-peripheral)
+pico_sdk_init()
+
+if(APPLE)
+execute_process(COMMAND xcrun -f swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+execute_process(COMMAND which swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+add_executable(swift-peripheral)
+target_link_libraries(swift-peripheral
+    pico_stdlib hardware_uart hardware_gpio pico_lwip_arch pico_cyw43_arch_none pico_btstack_ble pico_btstack_cyw43
+)
+
+target_include_directories(swift-peripheral PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/include # For btstack config
+)
+
+# Gather compile definitions from all dependencies
+set_property(GLOBAL PROPERTY visited_targets "")
+set_property(GLOBAL PROPERTY compilerdefs_list "")
+
+function(gather_compile_definitions_recursive target)
+    # Get the current value of visited_targets
+    get_property(visited_targets GLOBAL PROPERTY visited_targets)
+    
+    # make sure we don't visit the same target twice
+    # and that we don't visit the special generator expressions
+    if (${target} MATCHES "\\$<" OR ${target} MATCHES "::@" OR ${target} IN_LIST visited_targets)
+        return()
+    endif()
+
+    # Append the target to visited_targets
+    list(APPEND visited_targets ${target})
+    set_property(GLOBAL PROPERTY visited_targets "${visited_targets}")
+
+    # Get the current value of compilerdefs_list
+    get_property(compilerdefs_list GLOBAL PROPERTY compilerdefs_list)
+
+    get_target_property(target_definitions ${target} INTERFACE_COMPILE_DEFINITIONS)
+    if (target_definitions)
+        # Append the target definitions to compilerdefs_list
+        list(APPEND compilerdefs_list ${target_definitions})
+        set_property(GLOBAL PROPERTY compilerdefs_list "${compilerdefs_list}")
+    endif()
+
+    get_target_property(target_linked_libs ${target} INTERFACE_LINK_LIBRARIES)
+    if (target_linked_libs)
+        foreach(linked_target ${target_linked_libs})
+            # Recursively gather compile definitions from dependencies
+            gather_compile_definitions_recursive(${linked_target})
+        endforeach()
+    endif()
+endfunction()
+
+gather_compile_definitions_recursive(swift-peripheral)
+get_property(COMPILE_DEFINITIONS GLOBAL PROPERTY compilerdefs_list)
+
+# Parse compiler definitions into a format that swiftc can understand
+list(REMOVE_DUPLICATES COMPILE_DEFINITIONS)
+list(PREPEND COMPILE_DEFINITIONS "") # adds a semicolon at the beginning
+string(REPLACE "$<TARGET_PROPERTY:PICO_TARGET_BINARY_TYPE>" "$<TARGET_PROPERTY:swift-peripheral,PICO_TARGET_BINARY_TYPE>" COMPILE_DEFINITIONS "${COMPILE_DEFINITIONS}")
+string(REPLACE ";" ";-Xcc;-D" COMPILE_DEFINITIONS "${COMPILE_DEFINITIONS}")
+
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o
+    COMMAND
+        ${SWIFTC}
+        -target armv6m-none-none-eabi -Xcc -mfloat-abi=soft -Xcc -fshort-enums
+        ${COMPILE_DEFINITIONS}
+        -Xcc -DCYW43_LWIP
+        -Xcc -DPICO_CYW43_ARCH_THREADSAFE_BACKGROUND
+        -Xcc -I$ENV{PICO_SDK_PATH}/lib/lwip/src/include
+        -Xcc -I${CMAKE_CURRENT_LIST_DIR}/include
+        -Xfrontend -function-sections -enable-experimental-feature Embedded -wmo -parse-as-library
+        $$\( echo '$<TARGET_PROPERTY:swift-peripheral,INCLUDE_DIRECTORIES>' | tr '\;' '\\n' | sed -e 's/\\\(.*\\\)/-Xcc -I\\1/g' \)
+        $$\( echo '${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}'             | tr ' '  '\\n' | sed -e 's/\\\(.*\\\)/-Xcc -I\\1/g' \)
+        -import-bridging-header ${CMAKE_CURRENT_LIST_DIR}/BridgingHeader.h
+        ${CMAKE_CURRENT_LIST_DIR}/Main.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/Hexadecimal.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/Integer.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/String.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/System.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/UUID.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Generated/GeneratedCompanyIdentifiers.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Generated/GeneratedUnitIdentifiers.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Address.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/BluetoothUUID.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/ByteSwap.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/ByteValue.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/CompanyIdentifier.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Data.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/DefinedUUIDExtension.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/iBeacon.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/L2CAPSocket.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/LowEnergyAdvertisingData.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/SecurityLevel.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UInt24.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UInt40.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UInt48.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UInt128.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UInt256.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UInt512.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Unit.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UnitIdentifier.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/Decoder.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/Encoder.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/GAPCompleteLocalName.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/GAPData.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/GAPDataType.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/GAPFlags.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/GAPManufacturerSpecificData.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/GAPShortLocalName.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/iBeaconManufacturerData.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTAttributePermissions.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTConnection.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTError.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTErrorResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTExecuteWriteRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTExecuteWriteResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTFindByTypeRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTFindByTypeResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTFindInformationRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTFindInformationResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTHandleValueConfirmation.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTHandleValueIndication.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTHandleValueNotification.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTMaximumTransmissionUnit.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTMaximumTransmissionUnitRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTMaximumTransmissionUnitResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTOpcode.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTPrepareWriteRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTPrepareWriteResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTProtocolDataUnit.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadBlobRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadBlobResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadByGroupTypeRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadByGroupTypeResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadByTypeRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadByTypeResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadMultipleRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadMultipleResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTSignedWriteCommand.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTWriteCommand.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTWriteRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTWriteResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTAttributes.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTCharacteristicProperties.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTClientCharacteristicConfiguration.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTDatabase.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTDescriptor.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTServer.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTUserDescription.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothHCI/HCIError.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothHCI/ChannelIdentifier.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/Error.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/GAP.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/GATTPeripheral.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/GATTServerConnection.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/HostController.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/L2CAPServer.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/Transport.swift
+        ${CMAKE_CURRENT_LIST_DIR}/GATT/Peer.swift
+        ${CMAKE_CURRENT_LIST_DIR}/GATT/PeripheralProtocol.swift
+        -c -o ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o
+    DEPENDS
+        ${CMAKE_CURRENT_LIST_DIR}/BridgingHeader.h
+        ${CMAKE_CURRENT_LIST_DIR}/Main.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/Hexadecimal.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/Integer.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/String.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/System.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Extensions/UUID.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Generated/GeneratedCompanyIdentifiers.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Generated/GeneratedUnitIdentifiers.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Address.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/BluetoothUUID.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/ByteSwap.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/ByteValue.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/CompanyIdentifier.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Data.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/DefinedUUIDExtension.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/iBeacon.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/L2CAPSocket.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/LowEnergyAdvertisingData.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/SecurityLevel.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UInt24.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UInt40.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UInt48.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UInt128.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UInt256.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UInt512.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/Unit.swift
+        ${CMAKE_CURRENT_LIST_DIR}/Bluetooth/UnitIdentifier.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/Decoder.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/Encoder.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/GAPCompleteLocalName.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/GAPData.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/GAPDataType.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/GAPFlags.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/GAPManufacturerSpecificData.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/GAPShortLocalName.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGAP/iBeaconManufacturerData.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTAttributePermissions.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTConnection.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTError.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTErrorResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTExecuteWriteRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTExecuteWriteResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTFindByTypeRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTFindByTypeResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTFindInformationRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTFindInformationResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTHandleValueConfirmation.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTHandleValueIndication.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTHandleValueNotification.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTMaximumTransmissionUnit.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTMaximumTransmissionUnitRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTMaximumTransmissionUnitResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTOpcode.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTPrepareWriteRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTPrepareWriteResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTProtocolDataUnit.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadBlobRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadBlobResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadByGroupTypeRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadByGroupTypeResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadByTypeRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadByTypeResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadMultipleRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadMultipleResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTReadResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTSignedWriteCommand.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTWriteCommand.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTWriteRequest.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/ATTWriteResponse.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTAttributes.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTCharacteristicProperties.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTClientCharacteristicConfiguration.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTDatabase.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTDescriptor.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTServer.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothGATT/GATTUserDescription.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothHCI/HCIError.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BluetoothHCI/ChannelIdentifier.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/Error.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/GAP.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/GATTPeripheral.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/GATTServerConnection.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/HostController.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/L2CAPServer.swift
+        ${CMAKE_CURRENT_LIST_DIR}/BTStack/Transport.swift
+        ${CMAKE_CURRENT_LIST_DIR}/GATT/Peer.swift
+        ${CMAKE_CURRENT_LIST_DIR}/GATT/PeripheralProtocol.swift
+)
+add_custom_target(swift-peripheral-swiftcode DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o)
+
+target_link_libraries(swift-peripheral
+    ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o
+)
+add_dependencies(swift-peripheral swift-peripheral-swiftcode)
+pico_add_extra_outputs(swift-peripheral)

--- a/pico-w-ble-peripheral-sdk/CYW43.swift
+++ b/pico-w-ble-peripheral-sdk/CYW43.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+struct CYW43: ~Copyable {
+
+    /// Initialize the CYW43 architecture. 
+    /// 
+    /// [Documentation](https://www.raspberrypi.com/documentation/pico-sdk/networking.html#group_pico_cyw43_arch_1ga7a05bd21f02a0effadbba1e8266b8771)
+    init() throws(PicoError) {
+        let errorCode = cyw43_arch_init()
+        guard errorCode == 0 else {
+            throw PicoError(rawValue: errorCode) ?? .unknown
+        }
+    }
+
+    deinit {
+        cyw43_arch_deinit()
+    }
+}

--- a/pico-w-ble-peripheral-sdk/CYW43.swift
+++ b/pico-w-ble-peripheral-sdk/CYW43.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct CYW43: ~Copyable {
+final class CYW43 {
 
     /// Initialize the CYW43 architecture. 
     /// 

--- a/pico-w-ble-peripheral-sdk/GATT/Peer.swift
+++ b/pico-w-ble-peripheral-sdk/GATT/Peer.swift
@@ -11,13 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 /// Bluetooth LE Peer (Central, Peripheral)
-public protocol Peer: Hashable, CustomStringConvertible, Sendable where ID: Hashable {
+public protocol Peer: Hashable, Sendable where ID: Hashable {
     
     associatedtype ID: Hashable
     
     /// Unique identifier of the peer.
     var id: ID { get }
 }
+
+// MARK: Hashable
 
 public extension Peer {
     
@@ -28,9 +30,14 @@ public extension Peer {
     func hash(into hasher: inout Hasher) {
         id.hash(into: &hasher)
     }
+}
+
+// MARK: CustomStringConvertible
+
+extension Peer where Self: CustomStringConvertible, ID: CustomStringConvertible {
     
-    var description: String {
-        return "\(id)"
+    public var description: String {
+        return id.description
     }
 }
 
@@ -39,7 +46,7 @@ public extension Peer {
 /// Central Peer
 ///
 /// Represents a remote central device that has connected to an app implementing the peripheral role on a local device.
-public struct Central: Peer, Identifiable, Sendable {
+public struct Central: Peer, Identifiable, Sendable, CustomStringConvertible {
     
     public let id: BluetoothAddress
     
@@ -53,7 +60,7 @@ public struct Central: Peer, Identifiable, Sendable {
 /// Peripheral Peer
 ///
 /// Represents a remote peripheral device that has been discovered.
-public struct Peripheral: Peer, Identifiable, Sendable {
+public struct Peripheral: Peer, Identifiable, Sendable, CustomStringConvertible {
     
     public let id: BluetoothAddress
     

--- a/pico-w-ble-peripheral-sdk/GATT/Peer.swift
+++ b/pico-w-ble-peripheral-sdk/GATT/Peer.swift
@@ -1,0 +1,63 @@
+//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Bluetooth LE Peer (Central, Peripheral)
+public protocol Peer: Hashable, CustomStringConvertible, Sendable where ID: Hashable {
+    
+    associatedtype ID: Hashable
+    
+    /// Unique identifier of the peer.
+    var id: ID { get }
+}
+
+public extension Peer {
+    
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.id == rhs.id
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        id.hash(into: &hasher)
+    }
+    
+    var description: String {
+        return "\(id)"
+    }
+}
+
+// MARK: - Central
+
+/// Central Peer
+///
+/// Represents a remote central device that has connected to an app implementing the peripheral role on a local device.
+public struct Central: Peer, Identifiable, Sendable {
+    
+    public let id: BluetoothAddress
+    
+    public init(id: BluetoothAddress) {
+        self.id = id
+    }
+}
+
+// MARK: - Peripheral
+
+/// Peripheral Peer
+///
+/// Represents a remote peripheral device that has been discovered.
+public struct Peripheral: Peer, Identifiable, Sendable {
+    
+    public let id: BluetoothAddress
+    
+    public init(id: BluetoothAddress) {
+        self.id = id
+    }
+}

--- a/pico-w-ble-peripheral-sdk/GATT/PeripheralProtocol.swift
+++ b/pico-w-ble-peripheral-sdk/GATT/PeripheralProtocol.swift
@@ -1,0 +1,176 @@
+//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// GATT Peripheral Manager
+///
+/// Implementation varies by operating system.
+public protocol PeripheralManager {
+    
+    /// Central Peer
+    ///
+    /// Represents a remote central device that has connected to an app implementing the peripheral role on a local device.
+    associatedtype Central: Peer
+    
+    associatedtype Data: DataContainer
+    
+    associatedtype Error: Swift.Error
+    
+    var log: (@Sendable (String) -> ())? { get set }
+    
+    /// Start advertising the peripheral and listening for incoming connections.
+    func start() throws(Error)
+    
+    /// Stop the peripheral.
+    func stop()
+    
+    /// A Boolean value that indicates whether the peripheral is advertising data.
+    var isAdvertising: Bool { get }
+    
+    /// Attempts to add the specified service to the GATT database.
+    ///
+    /// - Returns: Handle for service declaration and handles for characteristic value handles.
+    func add(service: GATTAttribute<Data>.Service) throws(Error) -> (UInt16, [UInt16])
+    
+    /// Removes the service with the specified handle.
+    func remove(service: UInt16)
+    
+    /// Clears the local GATT database.
+    func removeAllServices()
+    
+    /// Callback to handle GATT read requests.
+    var willRead: ((GATTReadRequest<Central, Data>) -> ATTError?)? { get set }
+    
+    /// Callback to handle GATT write requests.
+    var willWrite: ((GATTWriteRequest<Central, Data>) -> ATTError?)? { get set }
+    
+    /// Callback to handle post-write actions for GATT write requests.
+    var didWrite: ((GATTWriteConfirmation<Central, Data>) -> ())? { get set }
+    
+    /// Modify the value of a characteristic, optionally emiting notifications if configured on active connections.
+    func write(_ newValue: Data, forCharacteristic handle: UInt16)
+    
+    /// Modify the value of a characteristic, optionally emiting notifications if configured on the specified connection.
+    ///
+    /// Throws error if central is unknown or disconnected.
+    func write(_ newValue: Data, forCharacteristic handle: UInt16, for central: Central) throws(Error)
+    
+    /// Read the value of the characteristic with specified handle.
+    subscript(characteristic handle: UInt16) -> Data { get }
+    
+    /// Read the value of the characteristic with specified handle for the specified connection.
+    func value(for characteristicHandle: UInt16, central: Central) throws(Error) -> Data
+}
+
+// MARK: - Supporting Types
+
+public protocol GATTRequest {
+    
+    associatedtype Central: Peer
+    
+    associatedtype Data: DataContainer
+    
+    var central: Central { get }
+    
+    var maximumUpdateValueLength: Int { get }
+    
+    var uuid: BluetoothUUID { get }
+    
+    var handle: UInt16 { get }
+    
+    var value: Data { get }
+}
+
+public struct GATTReadRequest <Central: Peer, Data: DataContainer> : GATTRequest, Equatable, Hashable, Sendable {
+    
+    public let central: Central
+    
+    public let maximumUpdateValueLength: Int
+    
+    public let uuid: BluetoothUUID
+    
+    public let handle: UInt16
+    
+    public let value: Data
+    
+    public let offset: Int
+    
+    public init(central: Central,
+                maximumUpdateValueLength: Int,
+                uuid: BluetoothUUID,
+                handle: UInt16,
+                value: Data,
+                offset: Int) {
+        
+        self.central = central
+        self.maximumUpdateValueLength = maximumUpdateValueLength
+        self.uuid = uuid
+        self.handle = handle
+        self.value = value
+        self.offset = offset
+    }
+}
+
+public struct GATTWriteRequest <Central: Peer, Data: DataContainer> : GATTRequest, Equatable, Hashable, Sendable {
+    
+    public let central: Central
+    
+    public let maximumUpdateValueLength: Int
+    
+    public let uuid: BluetoothUUID
+    
+    public let handle: UInt16
+    
+    public let value: Data
+    
+    public let newValue: Data
+    
+    public init(central: Central,
+                maximumUpdateValueLength: Int,
+                uuid: BluetoothUUID,
+                handle: UInt16,
+                value: Data,
+                newValue: Data) {
+        
+        self.central = central
+        self.maximumUpdateValueLength = maximumUpdateValueLength
+        self.uuid = uuid
+        self.handle = handle
+        self.value = value
+        self.newValue = newValue
+    }
+}
+
+public struct GATTWriteConfirmation <Central: Peer, Data: DataContainer> : GATTRequest, Equatable, Hashable, Sendable {
+    
+    public let central: Central
+    
+    public let maximumUpdateValueLength: Int
+    
+    public let uuid: BluetoothUUID
+    
+    public let handle: UInt16
+    
+    public let value: Data
+    
+    public init(central: Central,
+                maximumUpdateValueLength: Int,
+                uuid: BluetoothUUID,
+                handle: UInt16,
+                value: Data) {
+        
+        self.central = central
+        self.maximumUpdateValueLength = maximumUpdateValueLength
+        self.uuid = uuid
+        self.handle = handle
+        self.value = value
+    }
+}

--- a/pico-w-ble-peripheral-sdk/GPIO.swift
+++ b/pico-w-ble-peripheral-sdk/GPIO.swift
@@ -9,14 +9,23 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+extension CYW43 {
 
-#include "pico/stdlib.h"
-#include "pico/cyw43_arch.h"
-#include "pico/btstack_cyw43.h"
-#include "btstack.h"
-#include "hci_transport.h"
-#include "hci_transport_usb.h"
-#include "pico/btstack_hci_transport_cyw43.h"
+    enum GPIO: UInt32, CaseIterable, Copyable, Sendable {
 
-uint8_t l2cap_send_connectionless(hci_con_handle_t con_handle, uint16_t cid, uint8_t *data, uint16_t len);
+        case led = 0
+
+        case vsys = 1
+
+        case vbus = 2
+    }
+    
+    subscript (gpio: GPIO) -> Bool {
+        get {
+            cyw43_arch_gpio_get(gpio.rawValue)
+        }
+        nonmutating set {
+            cyw43_arch_gpio_put(gpio.rawValue, newValue)
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/GPIO.swift
+++ b/pico-w-ble-peripheral-sdk/GPIO.swift
@@ -24,7 +24,7 @@ extension CYW43 {
         get {
             cyw43_arch_gpio_get(gpio.rawValue)
         }
-        nonmutating set {
+        set {
             cyw43_arch_gpio_put(gpio.rawValue, newValue)
         }
     }

--- a/pico-w-ble-peripheral-sdk/Main.swift
+++ b/pico-w-ble-peripheral-sdk/Main.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@main
+struct Main {
+    static func main() {
+        let led = UInt32(CYW43_WL_GPIO_LED_PIN)
+        if cyw43_arch_init() != 0 {
+            print("Wi-Fi init failed")
+            return
+        }
+        let dot = {
+            cyw43_arch_gpio_put(led, true)
+            sleep_ms(250)
+            cyw43_arch_gpio_put(led, false)
+            sleep_ms(250)
+        }
+        let dash = {
+            cyw43_arch_gpio_put(led, true)
+            sleep_ms(500)
+            cyw43_arch_gpio_put(led, false)
+            sleep_ms(250)
+        }
+        while true {
+            dot()
+            dot()
+            dot()
+
+            dash()
+            dash()
+            dash()
+
+            dot()
+            dot()
+            dot()
+        }
+    }
+}

--- a/pico-w-ble-peripheral-sdk/Main.swift
+++ b/pico-w-ble-peripheral-sdk/Main.swift
@@ -11,36 +11,170 @@
 
 @main
 struct Main {
+
+    nonisolated(unsafe) static let hostController = HostController.default
+
+    static let peripheral = BTStackPeripheral(hostController: hostController)
+    
+    nonisolated(unsafe) static var lightState = false
+
     static func main() {
-        let led = UInt32(CYW43_WL_GPIO_LED_PIN)
-        if cyw43_arch_init() != 0 {
-            print("Wi-Fi init failed")
+        
+        stdio_init_all()
+
+        print("Hello World!")
+
+        let cyw43: CYW43
+        do {
+            cyw43 = try CYW43()
+        }
+        catch {
+            print("Wi-Fi init failed.")
             return
         }
-        let dot = {
-            cyw43_arch_gpio_put(led, true)
-            sleep_ms(250)
-            cyw43_arch_gpio_put(led, false)
-            sleep_ms(250)
-        }
-        let dash = {
-            cyw43_arch_gpio_put(led, true)
-            sleep_ms(500)
-            cyw43_arch_gpio_put(led, false)
-            sleep_ms(250)
-        }
-        while true {
-            dot()
-            dot()
-            dot()
+        
+        cyw43[.led] = false
 
-            dash()
-            dash()
-            dash()
+        hostController.log = { print("HCI: " + $0) }
+        peripheral.log = { print("Peripheral: " + $0) }
 
-            dot()
-            dot()
-            dot()
+        do {
+            try start()
         }
+        catch {
+            print("Bluetooth error")
+        }
+    }
+
+    static func start() throws(BTStackPeripheral.Error) {
+        
+        let hostController = HostController.default
+        do {
+            try hostController.setPower(.on)
+        }
+        catch {
+            throw .library(error)
+        }
+        
+        // wait for Bluetooth to turn on
+        while hostController.state != .on {
+             sleep_ms(500)
+        }
+                
+        hostController.setAdvertisementParameters()
+        
+        // Estimote iBeacon B9407F30-F5F8-466E-AFF9-25556B57FE6D
+        // Major 0x01 Minor 0x01
+        let uuid = UUID(uuidString: "B9407F30-F5F8-466E-AFF9-25556B57FE6D")!
+        let beacon = AppleBeacon(uuid: uuid, major: 0x01, minor: 0x01, rssi: -10)
+        let flags: GAPFlags = [.lowEnergyGeneralDiscoverableMode, .notSupportedBREDR]
+        let advertisement = LowEnergyAdvertisingData(
+            beacon: beacon,
+            flags: flags
+        )
+        
+        // scan response with name and bluetooth address
+        let address = hostController.address
+        let name = GAPCompleteLocalName(name: "Pico W " + address.description)
+        let scanResponse: LowEnergyAdvertisingData = GAPDataEncoder.encode(name)
+        
+        print("Advertisment Name: \(name.description)")
+        
+        // Add services
+        let (serviceHandle, _) = peripheral.add(service: GATTAttribute<BTStackPeripheral.Data>.Service(
+            uuid: .deviceInformation,
+            isPrimary: true,
+            characteristics: [
+                .init(
+                    uuid: .deviceName,
+                    value: Array("BTStack BLE Peripheral".utf8),
+                    permissions: .read,
+                    properties: [.read]
+                ),
+            ]
+        ))
+        
+        let lightStateUUID = BluetoothUUID(rawValue: "6170CEE6-9E3A-47B5-A621-B8BF7EC843D2")!
+        
+        let (lightService, _) = peripheral.add(service: GATTAttribute<BTStackPeripheral.Data>.Service(
+            uuid: BluetoothUUID(rawValue: "A5E9C26D-2B6A-4F22-9A47-21FF43393188")!,
+            isPrimary: true,
+            characteristics: [
+                .init(
+                    uuid: lightStateUUID,
+                    value: [0x00],
+                    permissions: [.read, .write],
+                    properties: [.read, .write],
+                    descriptors: [
+                        .init(GATTUserDescription(rawValue: "Light State"))
+                    ]
+                )
+            ]
+        ))
+        
+        peripheral.willWrite = { write in
+            switch write.uuid {
+            case lightStateUUID:
+                guard write.newValue.count == 1 else {
+                    return .writeNotPermitted
+                }
+                switch write.newValue[0] {
+                case 0, 1:
+                    return nil
+                default:
+                    return .writeNotPermitted
+                }
+            default:
+                return nil
+            }
+        }
+        
+        peripheral.didWrite = { write in
+            switch write.uuid {
+            case lightStateUUID:
+                let oldValue = lightState
+                let newState = write.value.first != 0
+                print("Light State: \(oldValue) -> \(newState)")
+                self.lightState = newState
+                
+            default:
+                break
+            }
+        }
+
+        // start advertisment
+        try peripheral.start(options: .init(
+            advertisingData: advertisement,
+            scanResponse: scanResponse)
+        )
+    }
+}
+
+/// Implement `posix_memalign(3)`, which is required by the Embedded Swift runtime but is
+/// not provided by the Pi Pico SDK.
+@_documentation(visibility: internal)
+@_cdecl("posix_memalign") public func posix_memalign(
+    _ memptr: UnsafeMutablePointer<UnsafeMutableRawPointer?>,
+    _ alignment: Int,
+    _ size: Int
+) -> CInt {
+    guard let allocation = aligned_alloc(alignment, size) else {
+        return 0
+    }
+    memptr.pointee = allocation
+    return 0
+}
+
+/// Implement `arc4random_buf` which is required by the Embedded Swift runtime for Hashable, Set, Dictionary,
+/// and random-number generating APIs but is not provided by the Pi Pico SDK.
+@_documentation(visibility: internal)
+@_cdecl("arc4random_buf") public func arc4random_buf(buf: UnsafeMutableRawPointer, nbytes: Int) {
+    for i in stride(from: 0, to: nbytes - 1, by: 2) {
+        let randomValue = UInt16(rand() & Int32(UInt16.max))
+        (buf + i).assumingMemoryBound(to: UInt16.self).pointee = randomValue
+    }
+    if nbytes % 2 == 1 {
+        let randomValue = UInt8(rand() & Int32(UInt8.max))
+        (buf + nbytes - 1).assumingMemoryBound(to: UInt8.self).pointee = randomValue
     }
 }

--- a/pico-w-ble-peripheral-sdk/PicoError.swift
+++ b/pico-w-ble-peripheral-sdk/PicoError.swift
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Raspberry Pi Pico Errors
+enum PicoError: Int32, Error, Sendable {
+    
+    /// An unspecified error occurred.
+    case unknown = -1
+    
+    /// The function failed due to timeout.
+    case timeout = -2
+    
+    /// Attempt to read from an empty buffer/FIFO.
+    case noData = -3
+    
+    /// Permission violation (e.g. write to read-only flash partition).
+    case notPermitted = -4
+    
+    /// Argument is outside the range of supported values.
+    case invalidArg = -5
+    
+    /// An I/O error occurred.
+    case io = -6
+    
+    /// The authorization failed due to bad credentials.
+    case badAuth = -7
+    
+    /// The connection failed.
+    case connectFailed = -8
+    
+    /// Dynamic allocation of resources failed.
+    case insufficientResources = -9
+    
+    /// Address argument was out-of-bounds or inaccessible.
+    case invalidAddress = -10
+    
+    /// Address was mis-aligned (usually not on a word boundary).
+    case badAlignment = -11
+    
+    /// Something failed in the past, preventing servicing the current request.
+    case invalidState = -12
+    
+    /// A user-allocated buffer was too small to hold the result.
+    case bufferTooSmall = -13
+    
+    /// The call failed because another function must be called first.
+    case preconditionNotMet = -14
+    
+    /// Cached data was determined to be inconsistent with the actual version.
+    case modifiedData = -15
+    
+    /// A data structure failed to validate.
+    case invalidData = -16
+    
+    /// Attempted to access something that does not exist; search failed.
+    case notFound = -17
+    
+    /// Write is impossible based on previous writes (e.g. attempted to clear an OTP bit).
+    case unsupportedModification = -18
+    
+    /// A required lock is not owned.
+    case lockRequired = -19
+    
+    /// A version mismatch occurred (e.g. running incompatible code).
+    case versionMismatch = -20
+    
+    /// The call could not proceed because required resources were unavailable.
+    case resourceInUse = -21
+}

--- a/pico-w-ble-peripheral-sdk/README.md
+++ b/pico-w-ble-peripheral-sdk/README.md
@@ -1,0 +1,43 @@
+# pico-w-ble-peripheral-sdk
+
+This example demonstrates how to integrate with the Pico SDK which is using CMake as its build system -- the simplest way to integrate with it is to also use CMake to build a Swift firmware application on top of the SDK and the libraries from it.
+
+<img src="https://github.com/apple/swift-embedded-examples/assets/26223064/a4949a2e-1887-4325-8f5f-a681963c93d7">
+
+## Requirements
+
+- A Raspberry Pi Pico W board. 
+- Follow the setup steps at https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf, in particular you'll need:
+  - A checkout of the [pico-sdk](https://github.com/raspberrypi/pico-sdk.git), with git submodules checked out.
+  - A checkout of the [pico-examples](https://github.com/raspberrypi/pico-examples.git).
+  - CMake.
+  - The [Arm Embedded Toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads).
+- Before trying to use Swift with the Pico SDK, make sure your environment works and can build the provided C/C++ sample projects, in particular:
+  - Try building and running the "blink" example from pico-examples written in C.
+
+
+## Building
+
+- Make sure you have a recent nightly Swift toolchain that has Embedded Swift support.
+- Build and copy the program in the UF2 format to the Mass Storage device to trigger flashing the program into memory (after which the device will reboot and run the firmware):
+``` console
+$ cd pico-w-ble-peripheral-sdk
+$ export TOOLCHAINS='<toolchain-identifier>'
+$ export PICO_BOARD=pico_w
+$ export PICO_SDK_PATH='<path-to-your-pico-sdk>'
+$ export PICO_TOOLCHAIN_PATH='<path-to-the-arm-toolchain>'
+$ cmake -B build -G Ninja .
+$ cmake --build build
+```
+
+## Running
+
+- Connect the Pico W board via a USB cable to your Mac, and make sure it's in the USB Mass Storage firmware upload mode (either hold the BOOTSEL button while plugging the board, or make sure your Flash memory doesn't contain any valid firmware).
+- Copy the UF2 firmware to the Mass Storage device:
+
+```console
+$ cp build/swift-peripheral.uf2 /Volumes/RP2040
+```
+
+- Use a Bluetooth LE client app like Nrf Connect or LightBlue to connect to the device.
+- Write 0x01 to the Light State characteristic to turn LED on.

--- a/pico-w-ble-peripheral-sdk/README.md
+++ b/pico-w-ble-peripheral-sdk/README.md
@@ -36,8 +36,8 @@ $ cmake --build build
 - Copy the UF2 firmware to the Mass Storage device:
 
 ```console
-$ cp build/swift-peripheral.uf2 /Volumes/RP2040
+$ cp build/swift-peripheral.uf2 /Volumes/RPI-RP2
 ```
 
-- Use a Bluetooth LE client app like Nrf Connect or LightBlue to connect to the device.
-- Write 0x01 to the Light State characteristic to turn LED on.
+- Use a Bluetooth LE client app like Nrf Connect or LightBlue and connect to your device, with name "Pico W XX:XX:XX:XX:XX:XX" where the suffix is the Bluetooth address of your Pico W.
+- Write 0x01 to the Light State characteristic 6170CEE6-9E3A-47B5-A621-B8BF7EC843D2 to turn LED on.

--- a/pico-w-ble-peripheral-sdk/include/btstack_config.h
+++ b/pico-w-ble-peripheral-sdk/include/btstack_config.h
@@ -1,0 +1,58 @@
+#ifndef _PICO_BTSTACK_BTSTACK_CONFIG_H
+#define _PICO_BTSTACK_BTSTACK_CONFIG_H
+
+#ifndef ENABLE_BLE
+#error Please link to pico_btstack_ble
+#endif
+
+// BTstack features that can be enabled
+#define ENABLE_LE_PERIPHERAL
+#define ENABLE_LOG_INFO
+#define ENABLE_LOG_ERROR
+#define ENABLE_PRINTF_HEXDUMP
+
+// for the client
+#if RUNNING_AS_CLIENT
+#define ENABLE_LE_CENTRAL
+#define MAX_NR_GATT_CLIENTS 1
+#else
+#define MAX_NR_GATT_CLIENTS 0
+#endif
+
+// BTstack configuration. buffers, sizes, ...
+#define HCI_OUTGOING_PRE_BUFFER_SIZE 4
+#define HCI_ACL_PAYLOAD_SIZE (255 + 4)
+#define HCI_ACL_CHUNK_SIZE_ALIGNMENT 4
+#define MAX_NR_HCI_CONNECTIONS 1
+#define MAX_NR_SM_LOOKUP_ENTRIES 3
+#define MAX_NR_WHITELIST_ENTRIES 16
+#define MAX_NR_LE_DEVICE_DB_ENTRIES 16
+
+// Limit number of ACL/SCO Buffer to use by stack to avoid cyw43 shared bus overrun
+#define MAX_NR_CONTROLLER_ACL_BUFFERS 3
+#define MAX_NR_CONTROLLER_SCO_PACKETS 3
+
+// Enable and configure HCI Controller to Host Flow Control to avoid cyw43 shared bus overrun
+#define ENABLE_HCI_CONTROLLER_TO_HOST_FLOW_CONTROL
+#define HCI_HOST_ACL_PACKET_LEN (255+4)
+#define HCI_HOST_ACL_PACKET_NUM 3
+#define HCI_HOST_SCO_PACKET_LEN 120
+#define HCI_HOST_SCO_PACKET_NUM 3
+
+// Link Key DB and LE Device DB using TLV on top of Flash Sector interface
+#define NVM_NUM_DEVICE_DB_ENTRIES 16
+#define NVM_NUM_LINK_KEYS 16
+
+// We don't give btstack a malloc, so use a fixed-size ATT DB.
+#define MAX_ATT_DB_SIZE 512
+
+// BTstack HAL configuration
+#define HAVE_EMBEDDED_TIME_MS
+// map btstack_assert onto Pico SDK assert()
+#define HAVE_ASSERT
+// Some USB dongles take longer to respond to HCI reset (e.g. BCM20702A).
+#define HCI_RESET_RESEND_TIMEOUT_MS 1000
+#define ENABLE_SOFTWARE_AES128
+#define ENABLE_MICRO_ECC_FOR_LE_SECURE_CONNECTIONS
+
+#endif // MICROPY_INCLUDED_EXTMOD_BTSTACK_BTSTACK_CONFIG_H

--- a/pico-w-ble-peripheral-sdk/include/lwipopts.h
+++ b/pico-w-ble-peripheral-sdk/include/lwipopts.h
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Generally you would define your own explicit list of lwIP options
+// (see https://www.nongnu.org/lwip/2_1_x/group__lwip__opts.html)
+
+#ifndef _LWIPOPTS_H
+#define _LWIPOPTS_H
+#endif


### PR DESCRIPTION
Adds a Pico W example to enable Bluetooth advertisements and GATT Peripheral functionality, advertising as an iBeacon in addition to its name and Bluetooth address. A custom GATT service and characteristic is exposed as read and write which toggles the GPIO LED state.

<img width="519" alt="Screenshot 2024-11-18 at 11 12 30 AM" src="https://github.com/user-attachments/assets/88054252-d2b7-405c-9f22-4279f834a5f4">
<img width="519" alt="Screenshot 2024-11-18 at 11 12 11 AM" src="https://github.com/user-attachments/assets/9c2c2227-2350-4b7c-b02e-3bde837dde2a">
