### PR TITLE
ESP32 enable minimal build

### DIFF
--- a/.github/workflows/build-esp.yml
+++ b/.github/workflows/build-esp.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build ${{ matrix.example }} (${{ matrix.target }})
     runs-on: ubuntu-24.04
     container: espressif/idf:latest
 
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         example: [esp32-led-blink-sdk, esp32-led-strip-sdk, esp32-uart-echo]
+        target: [esp32c3, esp32c6, esp32p4]
 
     steps:
       - name: Checkout repo
@@ -37,5 +38,5 @@ jobs:
           . ./export.sh
           cd -
           cd ${{ matrix.example }}
-          idf.py set-target esp32c6
+          idf.py set-target ${{ matrix.target }}
           idf.py build

--- a/esp32-led-blink-sdk/CMakeLists.txt
+++ b/esp32-led-blink-sdk/CMakeLists.txt
@@ -1,3 +1,4 @@
 cmake_minimum_required(VERSION 3.29)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+idf_build_set_property(MINIMAL_BUILD ON)
 project(main)

--- a/esp32-led-blink-sdk/README.md
+++ b/esp32-led-blink-sdk/README.md
@@ -7,8 +7,8 @@ This example demonstrates how to integrate with the ESP-IDF SDK via CMake and ho
 
 ## Requirements
 
-- Set up the [ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/) development environment. Follow the steps in the [ESP32-C6 "Get Started" guide](https://docs.espressif.com/projects/esp-idf/en/v5.2/esp32c6/get-started/index.html).
-  - Make sure you specifically set up development for the RISC-V ESP32-C6, and not the Xtensa based products.
+- Set up the [ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/) development environment. Follow the steps in the [ESP-IDF "Get Started" guide](https://docs.espressif.com/projects/esp-idf/en/v5.4/esp32c6/get-started/index.html).
+  - Make sure you specifically set up development for RISC-V based Espressif chips, and not the Xtensa based products.
   
 - Before trying to use Swift with the ESP-IDF SDK, make sure your environment works and can build the provided C/C++ sample projects, in particular:
   - Try building and running the "get-started/blink" example from ESP-IDF written in C.
@@ -17,11 +17,11 @@ This example demonstrates how to integrate with the ESP-IDF SDK via CMake and ho
 
 - Make sure you have a recent nightly Swift toolchain that has Embedded Swift support.
 - If needed, run export.sh to get access to the idf.py script from ESP-IDF.
-- Specify the target board type by using `idf.py set-target`.
+- Specify the target board type by using `idf.py set-target`. Any RISC-V based Espressif chip is supported.
 ``` console
 $ cd esp32-led-blink-sdk
 $ . <path-to-esp-idf>/export.sh
-$ idf.py set-target esp32c6
+$ idf.py set-target esp32c6  # or esp32c3, esp32p4, etc.
 $ idf.py build
 ```
 

--- a/esp32-led-strip-sdk/CMakeLists.txt
+++ b/esp32-led-strip-sdk/CMakeLists.txt
@@ -1,3 +1,4 @@
 cmake_minimum_required(VERSION 3.29)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+idf_build_set_property(MINIMAL_BUILD ON)
 project(main)

--- a/esp32-led-strip-sdk/README.md
+++ b/esp32-led-strip-sdk/README.md
@@ -6,8 +6,8 @@ This example demonstrates how to integrate with the ESP-IDF SDK via CMake and ho
 
 ## Requirements
 
-- Set up the [ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/) development environment. Follow the steps in the [ESP32-C6 "Get Started" guide](https://docs.espressif.com/projects/esp-idf/en/v5.2/esp32c6/get-started/index.html).
-  - Make sure you specifically set up development for the RISC-V ESP32-C6, and not the Xtensa based products.
+- Set up the [ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/) development environment. Follow the steps in the [ESP-IDF "Get Started" guide](https://docs.espressif.com/projects/esp-idf/en/v5.4/esp32c6/get-started/index.html).
+  - Make sure you specifically set up development for RISC-V based Espressif chips, and not the Xtensa based products.
   
 - Before trying to use Swift with the ESP-IDF SDK, make sure your environment works and can build the provided C/C++ sample projects, in particular:
   - Try building and running the "get-started/blink" example from ESP-IDF written in C.
@@ -16,11 +16,11 @@ This example demonstrates how to integrate with the ESP-IDF SDK via CMake and ho
 
 - Make sure you have a recent nightly Swift toolchain that has Embedded Swift support.
 - If needed, run export.sh to get access to the idf.py script from ESP-IDF.
-- Specify and the target board type by using `idf.py set-target`.
+- Specify the target board type by using `idf.py set-target`. Any RISC-V based Espressif chip is supported.
 ``` console
 $ cd esp32-led-strip-sdk
 $ . <path-to-esp-idf>/export.sh
-$ idf.py set-target esp32c6
+$ idf.py set-target esp32c6  # or esp32c3, esp32p4, etc.
 $ idf.py build
 ```
 

--- a/esp32-led-strip-sdk/main/Main.swift
+++ b/esp32-led-strip-sdk/main/Main.swift
@@ -13,8 +13,8 @@
 func main() {
   print("Hello from Swift on ESP32-C6!")
 
-  let n = 8
-  let ledStrip = LedStrip(gpioPin: 0, maxLeds: n)
+  let n = 1
+  let ledStrip = LedStrip(gpioPin: 8, maxLeds: n)
   ledStrip.clear()
 
   var colors: [LedStrip.Color] = .init(repeating: .off, count: n)


### PR DESCRIPTION
- Enable minimal build for ESP32 examples to reduce build time. https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/build-system.html#including-components-in-the-build
- Add CI target matrix to build all examples for esp32c3, esp32c6, and esp32p4