### PR TITLE
Upgrade to a more recent version of Zephyr.

### DIFF
--- a/.github/workflows/build-zephyr.yml
+++ b/.github/workflows/build-zephyr.yml
@@ -27,14 +27,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Setup Zephyr project
         uses: zephyrproject-rtos/action-zephyr-setup@v1
         with:
           app-path: ${{ matrix.example }}
           toolchains: arm-zephyr-eabi
-          sdk-version: 0.17.0
+          sdk-version: 0.17.4
 
       - name: Install Swift
         uses: ./.github/actions/install-swift

--- a/nrfx-blink-sdk/west.yml
+++ b/nrfx-blink-sdk/west.yml
@@ -9,5 +9,5 @@ manifest:
       revision: v4.2.2
       import:
         name-allowlist:
-          - cmsis  # required by the ARM port
+          - cmsis_6  # required by the ARM port for Cortex-M
           - hal_nordic  # required by the custom_plank board (Nordic based)

--- a/nrfx-blink-sdk/west.yml
+++ b/nrfx-blink-sdk/west.yml
@@ -6,7 +6,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v4.1.0
+      revision: v4.2.2
       import:
         name-allowlist:
           - cmsis  # required by the ARM port


### PR DESCRIPTION
This shows some new incompatibilities.

Specifically, https://github.com/zephyrproject-rtos/zephyr/commit/c4c1d92ceee1357820adc0786e595d06e3eea4d0#diff-d31e6c0e092586b6cc791077b8aaee7c14737ad84e51d4ef943000d062842ece changed the GPIO bit-fields to be function macros in `4.2`, breaking the bridging header.