### PR TITLE
Documentation updates for Swift 6.4

### DIFF
--- a/Sources/EmbeddedSwift/EmbeddedSwift.docc/CompilerDetails/Status.md
+++ b/Sources/EmbeddedSwift/EmbeddedSwift.docc/CompilerDetails/Status.md
@@ -4,70 +4,70 @@ Implementation status of compiler and language features in Embedded Swift, compa
 
 ## Embedded Swift Language Features
 
-| **Language Feature**                                  | **Currently Supported In Embedded Swift**                                          |
-|-------------------------------------------------------|------------------------------------------------------------------------------------|
-| *Anything not listed below*                           | Yes                                                                                |
-| Library Evolution (resilience)                        | No, intentionally unsupported long-term                                            |
-| Objective-C interoperability                          | No, intentionally unsupported long-term                                            |
-| Non-WMO builds                                        | No, intentionally unsupported long-term (WMO should be used)                       |
-| Existentials (values of protocol types)               | Only class-bound existentials (for protocols derived from AnyObject) are supported |
-| Any                                                   | No, currently disallowed                                                           |
-| AnyObject                                             | Yes                                                                                |
-| Metatypes                                             | No, currently only allowed as unused arguments (type hints)                        |
-| Untyped throwing                                      | No, intentionally unsupported long-term (typed throwing should be used instead)    |
-| Weak references, unowned references                   | No                                                                                 |
-| Non-final generic class methods                       | No, intentionally unsupported long-term, see <doc:NonFinalGenericMethods>|
-| Parameter packs (variadic generics)                   | No, not yet supported                                                              |
+| **Language Feature**                    | **Currently Supported In Embedded Swift**                    |
+| --------------------------------------- | ------------------------------------------------------------ |
+| *Anything not listed below*             | Yes                                                          |
+| Library Evolution (resilience)          | No, intentionally unsupported long-term                      |
+| Objective-C interoperability            | No, intentionally unsupported long-term                      |
+| Non-WMO builds                          | No, intentionally unsupported long-term (WMO should be used) |
+| Existentials (values of protocol types) | Yes, with some restrictions. See <doc:Existentials>          |
+| Any                                     | Yes                                                          |
+| AnyObject                               | Yes                                                          |
+| Metatypes                               | Yes                                                          |
+| Untyped throwing                        | Yes                                                          |
+| Weak references, unowned references     | No                                                           |
+| Non-final generic class methods         | No, intentionally unsupported long-term, see <doc:NonFinalGenericMethods> |
+| Parameter packs (variadic generics)     | No, not yet supported                                        |
 
 ## Embedded Standard Library Breakdown
 
 This status table describes which of the following standard library features can be used in Embedded Swift:
 
-| **Swift Standard Library Feature**                         | **Currently Supported In Embedded Swift?**          |
-|------------------------------------------------------------|-----------------------------------------------------|
-| Array (dynamic heap-allocated container)                   | Yes    |                                      
-| Array slices                                               | Yes    |                                      
-| assert, precondition, fatalError                           | Partial, only StaticStrings can be used as a failure message |
-| Bool, Integer types, Float types                           | Yes    |
-| Codable, Encodable, Decodable                              | No     |
-| Collection + related protocols                             | Yes    |
-| Collection algorithms (sort, reverse)                      | Yes    |
-| CustomStringConvertible, CustomDebugStringConvertible      | Yes, except those that require reflection (e.g. Array's .description)     |
-| Dictionary (dynamic heap-allocated container)              | Yes    |
-| Floating-point conversion to string                        | No     |
-| Floating-point parsing                                     | No     |
-| FixedWidthInteger + related protocols                      | Yes    |
-| Hashable, Equatable, Comparable protocols                  | Yes    |
-| InputStream, OutputStream                                  | No     |
-| Integer conversion to string                               | Yes    |
-| Integer parsing                                            | Yes    |
-| KeyPaths                                                   | Partial (only compile-time constant key paths to stored properties supported, only usable in MemoryLayout and UnsafePointer APIs)     |
-| Lazy collections                                           | Yes    |
-| ManagedBuffer                                              | Yes    |
-| Mirror (runtime reflection)                                | No, intentionally unsupported long-term |
-| Objective-C bridging                                       | No, intentionally unsupported long-term |
-| Optional                                                   | Yes    |
-| print / debugPrint                                         | Partial (only String, string interpolation, StaticStrings, integers, pointers and booleans, and custom types that are CustomStringConvertible) |
-| Range, ClosedRange, Stride                                 | Yes    |
-| Result                                                     | Yes    |
-| Set (dynamic heap-allocated container)                     | Yes    |                                      
-| SIMD types                                                 | Yes    |
-| StaticString                                               | Yes    |
-| String (dynamic)                                           | Yes    |
-| String interpolations                                      | Partial (only strings, integers, booleans, and custom types that are CustomStringConvertible can be interpolated)    |
-| Unicode                                                    | Yes    |
-| Unsafe\[Mutable\]\[Raw\]\[Buffer\]Pointer                  | Yes    |
-| VarArgs                                                    | No     |
+| **Swift Standard Library Feature**                    | **Currently Supported In Embedded Swift?**                   |
+| ----------------------------------------------------- | ------------------------------------------------------------ |
+| Array (dynamic heap-allocated container)              | Yes                                                          |
+| Array slices                                          | Yes                                                          |
+| assert, precondition, fatalError                      | Partial, only StaticStrings can be used as a failure message |
+| Bool, Integer types, Float types                      | Yes                                                          |
+| Codable, Encodable, Decodable                         | No                                                           |
+| Collection + related protocols                        | Yes                                                          |
+| Collection algorithms (sort, reverse)                 | Yes                                                          |
+| CustomStringConvertible, CustomDebugStringConvertible | Yes, except those that require reflection (e.g. Array's .description) |
+| Dictionary (dynamic heap-allocated container)         | Yes                                                          |
+| Floating-point conversion to string                   | Yes                                                          |
+| Floating-point parsing                                | Yes                                                          |
+| FixedWidthInteger + related protocols                 | Yes                                                          |
+| Hashable, Equatable, Comparable protocols             | Yes                                                          |
+| InputStream, OutputStream                             | No                                                           |
+| Integer conversion to string                          | Yes                                                          |
+| Integer parsing                                       | Yes                                                          |
+| KeyPaths                                              | Partial (only compile-time constant key paths to stored properties supported, only usable in MemoryLayout and UnsafePointer APIs) |
+| Lazy collections                                      | Yes                                                          |
+| ManagedBuffer                                         | Yes                                                          |
+| Mirror (runtime reflection)                           | No, intentionally unsupported long-term                      |
+| Objective-C bridging                                  | No, intentionally unsupported long-term                      |
+| Optional                                              | Yes                                                          |
+| print / debugPrint                                    | Partial (only String, string interpolation, StaticStrings, integers, pointers and booleans, and custom types that are CustomStringConvertible) |
+| Range, ClosedRange, Stride                            | Yes                                                          |
+| Result                                                | Yes                                                          |
+| Set (dynamic heap-allocated container)                | Yes                                                          |
+| SIMD types                                            | Yes                                                          |
+| StaticString                                          | Yes                                                          |
+| String (dynamic)                                      | Yes                                                          |
+| String interpolations                                 | Partial (only strings, integers, booleans, and custom types that are CustomStringConvertible can be interpolated) |
+| Unicode                                               | Yes                                                          |
+| Unsafe\[Mutable\]\[Raw\]\[Buffer\]Pointer             | Yes                                                          |
+| VarArgs                                               | No                                                           |
 
 ## Non-stdlib Features
 
 This status table describes which of the following Swift features can be used in Embedded Swift:
 
-| **Swift Feature**                                          | **Currently Supported In Embedded Swift?**          |
-|------------------------------------------------------------|-----------------------------------------------------|
-| Synchronization module                                     | Partial (only Atomic types, no Mutex)    |
-| Swift Concurrency                                          | Partial, experimental (basics of actors and tasks work in single-threaded concurrency mode) |
-| C interop                                                  | Yes    | 
-| C++ interop                                                | Yes    |
-| ObjC interop                                               | No, intentionally unsupported long-term |
-| Library Evolution                                          | No, intentionally unsupported long-term |
+| **Swift Feature**      | **Currently Supported In Embedded Swift?**                   |
+| ---------------------- | ------------------------------------------------------------ |
+| Synchronization module | Partial (only Atomic types, no Mutex)                        |
+| Swift Concurrency      | Partial, experimental (basics of actors and tasks work in single-threaded concurrency mode) |
+| C interop              | Yes                                                          |
+| C++ interop            | Partial, interoperability libraries are not built yet        |
+| ObjC interop           | No, intentionally unsupported long-term                      |
+| Library Evolution      | No, intentionally unsupported long-term                      |

--- a/Sources/EmbeddedSwift/EmbeddedSwift.docc/UsingEmbeddedSwift/Existentials.md
+++ b/Sources/EmbeddedSwift/EmbeddedSwift.docc/UsingEmbeddedSwift/Existentials.md
@@ -4,72 +4,81 @@ Restrictions on existentials ("any" types) that apply in Embedded Swift
 
 ## Background
 
-Existentials (also known as "any" types) in Swift are a way to express a type-erased value, where the actual type is not known statically, and at runtime it can be any type that conforms to the specified protocol. Because the possible types can vary in size, the representation of such a value is an "existential container" and the actual represented value is stored either inline (when it fits) or indirectly as a pointer to a heap allocation. There are also multiple concrete representations of the existential container that are optimized for different constraints (e.g. for class-bound existentials, the value does not make sense to ever store inline, so the size of the container is matched to hold exactly one pointer).
+Existentials (also known as "any" types) in Swift are a way to express a type-erased value, where the actual type is not known statically, and at runtime it can be any type that conforms to the specified protocol. Because the possible types can vary in size, the representation of such a value is an "existential container" and the actual represented value is stored either inline (when it fits) or indirectly as a pointer to a heap allocation. There are also multiple concrete representations of the existential container that are optimized for different constraints. For example, with class-bound existentials, the value does not make sense to ever store inline, so the size of the container is matched to hold exactly one pointer).
 
-Existentials are restricted in Embedded Swift in multiple ways, for multiple reasons:
+Existentials are somewhat restricted in Embedded Swift due to the requirement that all generics be fully specialized. Concretely, the following operations that are allowed in non-embedded Swift are prohibited in Embedded Swift:
 
-- Value existentials are not allowed. This prevents the optimization barriers and heap allocation indirections that come with those existentials in regular Swift.
-- Class-bound protocols can be used as an existential. This still circumvents the often undesired behavior of existentials where they allocate (and deallocate) storage on the heap for the inner value if it cannot fit in the inline buffer, because class references are always refcounted and references are shared.
-- Unbounded generic methods cannot be called through an existential.
+* A value cannot be dynamically cast to an existential type.
+* Generic operations cannot be called on an existential value.
+* Existential values cannot be "opened" into a generic value.
 
-## Class-bound existentials
+The restrictions are described in more detail below. Additionally, all compiler diagnostics related to Embedded Swift restrictions are documented as part of the [`EmbeddedRestrictions`](https://docs.swift.org/compiler/documentation/diagnostics/embedded-restrictions/) diagnostic group, which can also be enabled in non-embedded Swift code to help ensure that the code will continue to work with Embedded Swift.
 
-Embedded Swift allows and supports class-bound existentials:
+## Forming existentials
+
+Embedded Swift allows and supports forming existentials of any kind:
 
 ```swift
-protocol ClassBoundProtocol: AnyObject { // ✅, this means any type that wants to conform to ClassBoundProtocol must be a class type
-    func foo()
+protocol P { // ✅
+    func genericFoo<T>(_ value: T) { }
 }
 
-class Base: ClassBoundProtocol { ... }
-class Derived: Base { ... } // also conforms to ClassBoundProtocol
-class Other: ClassBoundProtocol { ... }
+extension Int: P { ... }
+class Base: P { ... }
+class Derived: Base { ... } // also conforms to P
 
-let existential: any ClassBoundProtocol = ... // ✅
+let existential: any P = ... // ✅, can be initialized with an Int, Base, Derived, etc.
 existential.foo() // ✅
 ```
 
-Note that protocols that are not class-bound cannot form existentials (in Embedded Swift):
+Existentials in Embedded Swift allow the "is" and "as!" / "as?" operators to check whether an existential holds a specific concrete type (or subclass thereof):
 
 ```swift
-let existential: any Equatable = ... // ❌
-
-class MyClass: Equatable { ... }
-let existential: any Equatable = MyClass // ❌, not enough that the actual type is a class, the protocol itself must be class-bound
-```
-
-Class-bound existentials in Embedded Swift allow the "is" and "as!" / "as?" operators:
-
-```swift
-let existential: any ClassBoundProtocol = ...
+let existential: any P = ...
 if existential is Base { ... } // ✅
 guard let concrete = existential as? Derived else { ... } // ✅
 let concrete = existential as! Derived // ✅, and will trap at runtime if a different type is inside the existential
 ```
 
-## Restrictions on class-bound existentials
+## Restrictions on casting to existential types
 
-Class-bound existentials in Embedded Swift do come with some restrictions compared to class-bound existentials in regular Swift:
+Existentials can be formed only from a concrete type. It is not possible to form an existential by casting to it from another type. For example:
 
-- You cannot use an existential to call a unbounded generic method from the protocol. This is described in depth in <doc:NonFinalGenericMethods>. For example:
 ```swift
-protocol ClassBoundProtocol: AnyObject {
-  func foo<T>(t: T)
-}
+let existential: Any = ...
 
-let ex: any ClassBoundProtocol = ... // ✅
-ex.foo(t: 42) // ❌
+if let p = existential as? any P { ... } // ❌, cannot cast to existential type "any P"
+let p = existential as! any P { ... } // ❌, cannot cast to existential type "any P"
 ```
 
-- You cannot use an existential composition of a class-bound protocol with a non-class-bound protocol. For example:
+The same restriction applies to casting to an existential metatype, e.g.,
+
 ```swift
-let ex: any ClassBoundProtocol & OtherClassBound = ... // ✅
-let ex: any ClassBoundProtocol & Equatable = ... // ❌
+let anyType: Any.Type
+if let metaP = anyType as? (any Error).Type { ... } // ❌, cannot cast to existential metatype
+let metaP = anyType as! (any Error).Type // ❌, cannot cast to existential metatype
+```
+
+## Restrictions on use of generics on existentials
+
+You cannot use an existential to call a unbounded generic method from a protocol or an extension of a protocol. This is described in depth in <doc:NonFinalGenericMethods>. For example:
+```swift
+protocol Q {
+  func genericFoo<T>(t: T)
+}
+
+extension Q {
+  func genericBar<T>(t: T) { }
+}
+
+let ex: any Q = ... // ✅
+ex.genericFoo(t: 42) // ❌, genericFoo is an unbounded generic
+ex.genericBar(t: 42) // ❌, genericBar is an unbounded generic
 ```
 
 ## Alternatives to existentials
 
-When existentials are not possible (e.g. because you need struct types in an existential), or not desirable (e.g. because the indirection on a class-bound existential causes an observation performance degradation), consider one of the following alternatives (which all have different tradeoffs and code structure implications):
+When existentials are not possible, or not desirable (e.g. because the indirection on an existential causes an observation performance or code-size degradation), consider one of the following alternatives (which all have different tradeoffs and code structure implications):
 
 **(1) Avoid using an existential, use generics instead**
 


### PR DESCRIPTION
Update the documentation to better reflect Embedded Swift as it stands in Swift 6.4:
* Existentials are supported (including non-class-bound), but have necessary limitations. Document them.
* Metatypes are available
* Floating point string conversions are available (in both directions)