### PR TITLE
Add Nintendo DS homebrew example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Note that the SDK integration examples (Pico SDK, Zephyr SDK, etc.) are not reco
 | [flappy-swift](https://github.com/sliemeobn/flappy-swift) | Web | A WebAssembly game written in Swift in ~100 KB. |
 | [swift-for-wasm-examples](https://github.com/swiftlang/swift-for-wasm-examples) | Web | A "Swift Audio Workstation" example built with Swift for WebAssembly running in the browser using Embedded Swift. |
 | [swift-embedded-pebble](https://github.com/MillerTechnologyPeru/swift-embedded-pebble) | Pebble | An example Pebble app for the Pebble Time 2, written in Embedded Swift. |
+| [swift-embedded-nds](https://github.com/MillerTechnologyPeru/swift-embedded-nds) | Nintendo DS | Nintendo DS homebrew written in Embedded Swift, ported from the official libnds examples. |
 
 Please note that the presence of community repositories and devices in this list does not constitute a recommendation or endorsement. If there's a project you'd like to see included here, please [submit an issue](https://github.com/swiftlang/swift-embedded-examples/issues/new) with the details.
 


### PR DESCRIPTION
Right now the `main-snapshot` toolchain only support armv4t, but I've opened a pull request to support armv5te to properly support the newer CPU on the DS. https://github.com/swiftlang/swift/pull/90023

<img width="506" height="756" alt="Screenshot 2026-06-17 at 11 56 40 AM" src="https://github.com/user-attachments/assets/6542bc86-fbb8-4aea-967f-82085a052ada" /> 
<img width="512" height="778" alt="Screenshot 2026-06-17 at 11 57 04 AM" src="https://github.com/user-attachments/assets/edd525e1-ace8-4577-84f0-50cf9319d704" />

