### PR TITLE
Update swift-mmio repository URL to new location

### DIFF
--- a/Sources/EmbeddedSwift/EmbeddedSwift.docc/GuidedExamples/STM32BaremetalGuide.md
+++ b/Sources/EmbeddedSwift/EmbeddedSwift.docc/GuidedExamples/STM32BaremetalGuide.md
@@ -4,7 +4,7 @@ Program a STM32 microcontroller directly with low-level Swift code
 
 This tutorial will guide you through setting up a baremetal STM32 project with Embedded Swift to create a simple LED blinking application with text output to UART, the "Hello World" of embedded systems. Concretely, we'll be using the STM32F746G-DISCO (discovery) development board, but the setup will work (with only small tweaks) on most other STM32 devices.
 
-We will be writing a full firmware from scratch including low-level bot code, direct hardware register configuration, a custom linker script and more. Besides educational purposes, this level of control is typically only needed in specialized setups because it involves more work and more complexity. If you want a simpler path to get started, you can integrate with an existing embedded SDK (like STCube or BSPs) instead, which offers higher-level APIs and hardware abstraction. Check out <doc:IntegratingWithPlatforms> for guidance on common integration patterns.
+We will be writing a full firmware from scratch including low-level boot code, direct hardware register configuration, a custom linker script and more. Besides educational purposes, this level of control is typically only needed in specialized setups because it involves more work and more complexity. If you want a simpler path to get started, you can integrate with an existing embedded SDK (like STCube or BSPs) instead, which offers higher-level APIs and hardware abstraction. Check out <doc:IntegratingWithPlatforms> for guidance on common integration patterns.
 
 ## Overall plan
 

--- a/Sources/EmbeddedSwift/EmbeddedSwift.docc/GuidedExamples/STM32BaremetalGuide.md
+++ b/Sources/EmbeddedSwift/EmbeddedSwift.docc/GuidedExamples/STM32BaremetalGuide.md
@@ -4,7 +4,7 @@ Program a STM32 microcontroller directly with low-level Swift code
 
 This tutorial will guide you through setting up a baremetal STM32 project with Embedded Swift to create a simple LED blinking application with text output to UART, the "Hello World" of embedded systems. Concretely, we'll be using the STM32F746G-DISCO (discovery) development board, but the setup will work (with only small tweaks) on most other STM32 devices.
 
-We will be writing a full firmware from scratch including low-level boot code, direct hardware register configuration, a custom linker script and more. Besides educational purposes, this level of control is typically only needed in specialized setups because it involves more work and more complexity. If you want a simpler path to get started, you can integrate with an existing embedded SDK (like STCube or BSPs) instead, which offers higher-level APIs and hardware abstraction. Check out <doc:IntegratingWithPlatforms> for guidance on common integration patterns.
+We will be writing a full firmware from scratch including low-level bot code, direct hardware register configuration, a custom linker script and more. Besides educational purposes, this level of control is typically only needed in specialized setups because it involves more work and more complexity. If you want a simpler path to get started, you can integrate with an existing embedded SDK (like STCube or BSPs) instead, which offers higher-level APIs and hardware abstraction. Check out <doc:IntegratingWithPlatforms> for guidance on common integration patterns.
 
 ## Overall plan
 
@@ -89,7 +89,7 @@ let package = Package(
     .executable(name: "STM32BlinkLED", targets: ["STM32BlinkLED"])
   ],
   dependencies: [
-    .package(url: "https://github.com/swiftlang/swift-mmio", branch: "main"),
+    .package(url: "https://github.com/apple/swift-mmio", branch: "main"),
   ],
   targets: [
     .executableTarget(


### PR DESCRIPTION
The swift-mmio repository has moved from github.com/swiftlang/swift-mmio to github.com/apple/swift-mmio. This updates the Package.swift dependency URL in the STM32 baremetal guide to point to the new location.

Fixes #210