### PR TITLE
Pin soundness workflow to 0.0.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
 
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.12
     with:
       api_breakage_check_enabled: false  # this repo doesn't vend any API
       license_header_check_enabled: false  # feature: https://github.com/swiftlang/github-workflows/issues/78


### PR DESCRIPTION
Tracking `@main` pulls in whatever lands upstream, which makes CI behavior nondeterministic and harder to debug. Pin to a released tag so soundness runs are reproducible.