### PR TITLE
Fix DocC catalog rendering and broken links

### DIFF
--- a/Sources/EmbeddedSwift/EmbeddedSwift.docc/EmbeddedSwift.md
+++ b/Sources/EmbeddedSwift/EmbeddedSwift.docc/EmbeddedSwift.md
@@ -1,10 +1,6 @@
-# Embedded Swift
+# ``EmbeddedSwift``
 
 Embedded Swift is a compilation and language mode that enables development of baremetal, embedded and standalone software in Swift
-
-@Metadata {
-  @TechnologyRoot
-}
 
 ## Topics
 
@@ -32,19 +28,20 @@ Embedded Swift is a compilation and language mode that enables development of ba
 - <doc:Existentials>
 - <doc:NonFinalGenericMethods>
 
-### Build System Support
+<!-- ### Build System Support
 
 - <doc:IntegrateWithBazel>
 - <doc:IntegrateWithCMake>
 - <doc:IntegrateWithMake>
 - <doc:IntegrateWithSwiftPM>
 - <doc:IntegrateWithXcode>
+-->
 
 ### SDK Support
 
 - <doc:IntegratingWithPlatforms>
 - <doc:Baremetal>
-- <doc:IntegrateWithESP>
+<!-- - <doc:IntegrateWithESP> -->
 - <doc:IntegrateWithPico>
 - <doc:IntegrateWithZephyr>
 


### PR DESCRIPTION
## Summary

Fixes the EmbeddedSwift DocC catalog so the landing page renders correctly and stops referencing pages that haven't been written yet.

- Use a symbol link (``EmbeddedSwift``) for the landing page title so the page is associated with the module.
- Remove `@TechnologyRoot` (the catalog documents a module, not a standalone technology root).
- Comment out topic links to unwritten pages that were producing broken DocC links.

## Test plan

- Build the DocC documentation and confirm the landing page renders with the correct title and no broken-link warnings.