### PR TITLE
Update the description of the embedded language subset

### DIFF
--- a/Sources/EmbeddedSwift/EmbeddedSwift.docc/GettingStarted/LanguageSubset.md
+++ b/Sources/EmbeddedSwift/EmbeddedSwift.docc/GettingStarted/LanguageSubset.md
@@ -11,10 +11,8 @@ Note that there are no behavior changes in Embedded Swift compared to full Swift
 ## Code-level features that are not available
 
 - **Not available**: Runtime reflection (`Mirror` APIs).
-- **Not available**: Values of protocol types ("existentials"), unless the protocol is restricted to be class-bound (derived from AnyObject). E.g. `let a: Hashable = ...` is not allowed. `Any` is also not allowed. See <doc:Existentials> for details and alternatives of existentials.
-- **Not available**: Throwing errors or `any Error` type (in contrast with "typed throws", which *is* supported in Embedded Swift).
-- **Not available**: Metatypes, e.g. `let t = SomeClass.Type` or `type(of: value)` are not allowed.
-- **Not available**: Standard library types that rely on the above, for example `Codable` and `KeyPath`, are not allowed.
+- **Not available**: Calling generic functions on values of protocol type ("existentials"). See <doc:Existentials> for details.
+- **Not available**: Standard library types that rely on the above, for example `Codable`, are not allowed.
 - **Not available**: Printing and stringification of arbitrary types (which is achieved via reflection in desktop Swift).
 - **Not available**: Using non-final generic class methods. See <doc:NonFinalGenericMethods> for details on this.
 - **Not available**: Weak and unowned references are not allowed (unsafe unowned references *are* available).


### PR DESCRIPTION
Untyped throws, metatypes, and existentials are supported now.