### PR TITLE
adding an explicit display name 

### DIFF
--- a/Sources/EmbeddedSwift/EmbeddedSwift.docc/EmbeddedSwift.md
+++ b/Sources/EmbeddedSwift/EmbeddedSwift.docc/EmbeddedSwift.md
@@ -2,6 +2,10 @@
 
 Embedded Swift is a compilation and language mode that enables development of baremetal, embedded and standalone software in Swift
 
+@Metadata {
+    @DisplayName("Embedded Swift")
+}
+
 ## Topics
 
 ### Getting Started


### PR DESCRIPTION
switches the display name from 'EmbeddedSwift' to 'Embedded Swift' in combined docs