### PR TITLE
Restore @TechnologyRoot to DocC landing page

### DIFF
--- a/Sources/EmbeddedSwift/EmbeddedSwift.docc/EmbeddedSwift.md
+++ b/Sources/EmbeddedSwift/EmbeddedSwift.docc/EmbeddedSwift.md
@@ -3,6 +3,7 @@
 Embedded Swift is a compilation and language mode that enables development of baremetal, embedded and standalone software in Swift
 
 @Metadata {
+    @TechnologyRoot
     @DisplayName("Embedded Swift")
 }
 


### PR DESCRIPTION
## Summary

- Commit 1a1abb49 removed `@TechnologyRoot` from the `@Metadata` block in `EmbeddedSwift.md`
- This restores it so the page is correctly designated as the root of the technology documentation in DocC

## Test plan

- [ ] Build the DocC catalog and verify the landing page renders correctly as the technology root