### PR TITLE
Status and dependency updates based on recent improvements

### DIFF
--- a/Sources/EmbeddedSwift/EmbeddedSwift.docc/CompilerDetails/Status.md
+++ b/Sources/EmbeddedSwift/EmbeddedSwift.docc/CompilerDetails/Status.md
@@ -15,7 +15,7 @@ Implementation status of compiler and language features in Embedded Swift, compa
 | AnyObject                               | Yes                                                          |
 | Metatypes                               | Yes                                                          |
 | Untyped throwing                        | Yes                                                          |
-| Weak references, unowned references     | No                                                           |
+| Weak references, unowned references     | No, not yet supported                                        |
 | Non-final generic class methods         | No, intentionally unsupported long-term, see <doc:NonFinalGenericMethods> |
 | Parameter packs (variadic generics)     | No, not yet supported                                        |
 
@@ -29,7 +29,7 @@ This status table describes which of the following standard library features can
 | Array slices                                          | Yes                                                          |
 | assert, precondition, fatalError                      | Partial, only StaticStrings can be used as a failure message |
 | Bool, Integer types, Float types                      | Yes                                                          |
-| Codable, Encodable, Decodable                         | No                                                           |
+| Codable, Encodable, Decodable                         | No, intentionally unsupported long term                      |
 | Collection + related protocols                        | Yes                                                          |
 | Collection algorithms (sort, reverse)                 | Yes                                                          |
 | CustomStringConvertible, CustomDebugStringConvertible | Yes, except those that require reflection (e.g. Array's .description) |
@@ -57,7 +57,7 @@ This status table describes which of the following standard library features can
 | String interpolations                                 | Partial (only strings, integers, booleans, and custom types that are CustomStringConvertible can be interpolated) |
 | Unicode                                               | Yes                                                          |
 | Unsafe\[Mutable\]\[Raw\]\[Buffer\]Pointer             | Yes                                                          |
-| VarArgs                                               | No                                                           |
+| VarArgs                                               | Yes                                                          |
 
 ## Non-stdlib Features
 
@@ -65,7 +65,7 @@ This status table describes which of the following Swift features can be used in
 
 | **Swift Feature**      | **Currently Supported In Embedded Swift?**                   |
 | ---------------------- | ------------------------------------------------------------ |
-| Synchronization module | Partial (only Atomic types, no Mutex)                        |
+| Synchronization module | Yes
 | Swift Concurrency      | Partial, experimental (basics of actors and tasks work in single-threaded concurrency mode) |
 | C interop              | Yes                                                          |
 | C++ interop            | Partial, interoperability libraries are not built yet        |

--- a/Sources/EmbeddedSwift/EmbeddedSwift.docc/UsingEmbeddedSwift/ExternalDependencies.md
+++ b/Sources/EmbeddedSwift/EmbeddedSwift.docc/UsingEmbeddedSwift/ExternalDependencies.md
@@ -13,6 +13,16 @@ For (1), external dependencies are only used based on actual usage of the progra
   - dependency: `int putchar(int);`
 - using Hashable, Set, Dictionary, or random-number generating APIs
   - dependency: `void arc4random_buf(void *, size_t);`
+- **dynamic exclusivity checking** (enabled with `-enforce-exclusivity=checked`)
+  - for single-threaded environments, link `swiftExclusivitySingleThreaded` library
+  - for multi-threaded environments that support C++11 thread-local storage, link `swiftExclusivityC11ThreadLocal`
+  - for environments where neither of the above will suffice
+    - dependency: `void * _swift_getExclusivityTLS()`
+    - dependency: void `_swift_setExclusivityTLS(void *newValue)`
+- using `Synchronization.Mutex`, one of:
+  - implement the `_swift_mutex_*` functions documented in the [platform abstraction header](https://github.com/swiftlang/swift/blob/main/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h), or
+  - for single-threaded, link swiftEmbeddedPlatformSingleThreaded
+  - for multi-threaded link swiftEmbeddedPlatformMultiThreadedPOSIX (POSIX libc) or swiftEmbeddedPlatformMultiThreadedDarwin (for Apple platforms)
 
 For (2), external dependencies are also triggered by specific code needing them, but they are somewhat lower-level patterns where it might not be obvious that such patterns should cause external dependencies:
 
@@ -33,12 +43,5 @@ For (2), external dependencies are also triggered by specific code needing them,
   - dependency (on Mach-O): `__divti3`
   - dependency (on Mach-O): `__modti3`
   - dependency (with EABI): `__aeabi_ldivmod`
-- **dynamic exclusivity checking** (enabled with `-enforce-exclusivity=checked`)
-  - for single-threaded environments, link `swiftExclusivitySingleThreaded` library
-  - for multi-threaded environments that support C++11 thread-local storage, link `swiftExclusivityC11ThreadLocal`
-  - for environments where neither of the above will suffice
-    - dependency: `void * _swift_getExclusivityTLS()`
-    - dependency: void `_swift_setExclusivityTLS(void *newValue)`
-
 
 The user and/or the platform (via basic libraries like libc or compiler builtins) is expected to provide these APIs.


### PR DESCRIPTION
* Weak/unowned are "not yet supported", since we'll be working on them
* Codable is not going to be supported
* VarArgs are supported now (yay!)
* Synchronization module is supported now (e.g., Mutex is available)

Mention the dependencies for supporting Mutex. There's a larger re-organization we'll want here once we switch to the abstraction layer.