### PR TITLE
Fix documentation links in README files for pi-pico-* and nrfx-blink-sdk

### DIFF
--- a/nrfx-blink-sdk/README.md
+++ b/nrfx-blink-sdk/README.md
@@ -1,3 +1,3 @@
 # nrfx-blink-sdk
 
-See [Blinking an LED on Nordic nRF with Zephyr](https://docs.swift.org/embedded/documentation/embedded/nrfxblinkguide) for documentation on this example.
+See [Blinking an LED on Nordic nRF with Zephyr](https://docs.swift.org/embedded/documentation/embedded/nrfblinkguide for documentation on this example.

--- a/rpi-pico-blink-sdk/README.md
+++ b/rpi-pico-blink-sdk/README.md
@@ -1,3 +1,3 @@
 # rpi-pico-blink-sdk
 
-See [Blinking an LED on the Raspberry Pi Pico with the Pico SDK](https://docs.swift.org/embedded/documentation/embedded/picoguide) for documentation on this example.
+See [Blinking an LED on the Raspberry Pi Pico with the Pico SDK](https://docs.swift.org/embedded/documentation/embedded/integratewithpico/) for documentation on this example.

--- a/rpi-pico-lldb/README.md
+++ b/rpi-pico-lldb/README.md
@@ -1,5 +1,5 @@
 # rpi-pico-lldb
-The sample code used in the [Trying out LLDB debugging on Raspberry Pi Pico](https://docs.swift.org/embedded/documentation/embedded/lldbguide) Guided Example.
+The sample code used in the [Trying out LLDB debugging on Raspberry Pi Pico](https://docs.swift.org/embedded/documentation/embedded/svd2lldbguide) Guided Example.
 
 ## Prerequisites
 - Install **Swift with Embedded support**, **LLDB**, and **SVD2LLDB**.

--- a/rpi-picow-blink-sdk/README.md
+++ b/rpi-picow-blink-sdk/README.md
@@ -1,3 +1,3 @@
 # rpi-picow-blink-sdk
 
-See [Blinking an LED in Morse code on the Raspberry Pi Pico W with the Pico SDK](https://docs.swift.org/embedded/documentation/embedded/picowblinkguide) for documentation on this example.
+See [Blinking an LED in Morse code on the Raspberry Pi Pico W with the Pico SDK](https://docs.swift.org/embedded/documentation/embedded/rpipicowblinkguide) for documentation on this example.


### PR DESCRIPTION
Solves some broken links in mostly Pico related Readmes.

re #234