### PR TITLE
Fix RP2350 Swift build by scoping '-fno-math-errno'

### DIFF
--- a/rpi-pico-blink-sdk/CMakeLists.txt
+++ b/rpi-pico-blink-sdk/CMakeLists.txt
@@ -39,6 +39,13 @@ target_link_libraries(swift-blinky
 set_target_properties(pico_standard_link PROPERTIES INTERFACE_COMPILE_OPTIONS "")
 target_compile_options(pico_standard_link INTERFACE "$<$<COMPILE_LANGUAGE:C>:SHELL: -ffunction-sections -fdata-sections>")
 
+# Same treatment for the RP2350-only VFP float library, which adds -fno-math-errno
+# unguarded. The target does not exist on RP2040, hence the if(TARGET) check.
+if(TARGET pico_float_pico_vfp)
+    set_target_properties(pico_float_pico_vfp PROPERTIES INTERFACE_COMPILE_OPTIONS "")
+    target_compile_options(pico_float_pico_vfp INTERFACE "$<$<COMPILE_LANGUAGE:C>:SHELL: -fno-math-errno>")
+endif()
+
 # Gather C compile definitions from all dependencies
 set_property(GLOBAL PROPERTY visited_targets "")
 set_property(GLOBAL PROPERTY compilerdefs_list "")


### PR DESCRIPTION
## Summary
- The Pico SDK's `pico_float_pico_vfp` target (linked in on RP2350 builds) adds `-fno-math-errno` via `target_compile_options` with no language guard, so it leaked into the Swift compile flags and broke building for the Pico2/RP2350 boards.
- Applies the same `INTERFACE_COMPILE_OPTIONS` reset already used for `pico_standard_link`, scoped to `rpi-pico-blink-sdk` only.

## Test plan
- [ ] Build `rpi-pico-blink-sdk` for RP2350 (set `PICO_BOARD` to `pico2`, `pico2_w` or `adafruit_fruit_jam` for example) and confirm the Swift compile step no longer sees the `-fno-math-errno` compiler directive
- [ ] Build `rpi-pico-blink-sdk` for RP2040 to confirm no regression; the `pico_float_pico_vfp` target doesn't exist there, so it is guarded by `if(TARGET ...)`

The fix for this issue was found by Claude Opus 5, and the PR text was generated by Claude Sonnet 5 and edited by me.

Original issue report on Swift Forums: https://forums.swift.org/t/pico-sdk-2-3-0-adds-fno-math-errno-to-rp2350-which-swiftc-doesnt-understand/88377/8
