### PR TITLE
Show "Platforms" eyebrow on landing page

### DIFF
--- a/Sources/EmbeddedSwift/EmbeddedSwift.docc/EmbeddedSwift.md
+++ b/Sources/EmbeddedSwift/EmbeddedSwift.docc/EmbeddedSwift.md
@@ -16,6 +16,7 @@ Boards with active community support include the Raspberry Pi Pico, various STM3
 
 @Metadata {
     @TechnologyRoot
+    @TitleHeading("Platforms")
 }
 
 ## Topics


### PR DESCRIPTION
## Summary
- This module belongs to the "Platforms" nav group on the combined Swift docs site, but the landing page didn't show that as an eyebrow above the title. Adds `@TitleHeading("Platforms")` alongside the existing `@TechnologyRoot` directive.

## Test plan
- [x] Confirmed a pre-existing, unrelated `MultipleRootPages` docc build error reproduces identically with and without this change (it's not a regression introduced here)
- [ ] Visually confirm the "Platforms" eyebrow renders above the title